### PR TITLE
fix(wave-5c): address Copilot review feedback on PR #235

### DIFF
--- a/backend/alembic/versions/c9a55365ed1f_fix_credential_tokens_purpose_check_.py
+++ b/backend/alembic/versions/c9a55365ed1f_fix_credential_tokens_purpose_check_.py
@@ -1,0 +1,43 @@
+"""fix credential_tokens purpose check constraint name
+
+Revision ID: c9a55365ed1f
+Revises: 32105e02cd4b
+Create Date: 2026-04-12 13:22:27.216048
+
+Copilot PR #235 review: the CredentialToken model uses
+``name="purpose"`` which the MetaData naming convention
+(``ck_%(table_name)s_%(constraint_name)s``) expands to
+``ck_credential_tokens_purpose``. The initial migration used the
+expanded name directly, which the convention then double-prefixed to
+``ck_credential_tokens_ck_credential_tokens_purpose`` in Postgres.
+
+This migration renames the live constraint to match what the model
+produces, so Alembic autogenerate no longer shows a spurious diff.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "c9a55365ed1f"
+down_revision: Union[str, Sequence[str], None] = "32105e02cd4b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Rename check constraint to match model + convention output."""
+    op.execute(
+        "ALTER TABLE credential_tokens "
+        "RENAME CONSTRAINT ck_credential_tokens_ck_credential_tokens_purpose "
+        "TO ck_credential_tokens_purpose"
+    )
+
+
+def downgrade() -> None:
+    """Restore the pre-fix constraint name."""
+    op.execute(
+        "ALTER TABLE credential_tokens "
+        "RENAME CONSTRAINT ck_credential_tokens_purpose "
+        "TO ck_credential_tokens_ck_credential_tokens_purpose"
+    )

--- a/backend/app/api/auth_endpoints.py
+++ b/backend/app/api/auth_endpoints.py
@@ -1,5 +1,8 @@
 """Authentication API endpoints."""
 
+import logging
+from urllib.parse import urlencode
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import delete as sa_delete
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -41,6 +44,40 @@ from app.schemas.auth import (
     UserUpdatePublic,
 )
 from app.utils.audit_logger import log_user_action
+
+logger = logging.getLogger(__name__)
+
+
+def _frontend_base_url() -> str:
+    """Return the first CORS origin, stripped, for email link construction.
+
+    Centralizes the helper so every identity-lifecycle email uses the
+    same base URL resolution (CORS_ORIGINS can contain spaces after
+    commas in env vars — split + strip is not automatic).
+    """
+    origins = settings.get_cors_origins_list()
+    return origins[0] if origins else ""
+
+
+async def _safe_send_email(
+    *, to: str, subject: str, body_html: str, context: str
+) -> None:
+    """Dispatch email via configured sender, swallowing + logging errors.
+
+    Email dispatch must never leak user-existence (anti-enumeration in
+    password reset flow) nor block an already-committed DB write (admin
+    create-user, invite). Callers always commit the token row BEFORE
+    calling this helper — a failed email never rolls back state.
+    """
+    try:
+        sender = get_email_sender()
+        await sender.send(to=to, subject=subject, body_html=body_html)
+    except Exception as exc:  # noqa: BLE001 — intentional catch-all
+        logger.error(
+            "Email dispatch failed",
+            extra={"context": context, "to": to, "error": str(exc)},
+        )
+
 
 router = APIRouter(prefix="/api/v2/auth", tags=["authentication"])
 
@@ -332,7 +369,9 @@ async def create_user(
         ),
     )
 
-    # Auto-dispatch email verification (Wave 5c Task 8)
+    # Auto-dispatch email verification (Wave 5c Task 8).
+    # Token is committed before email dispatch; email errors are logged
+    # but do not fail the create-user response (Copilot PR #235 review).
     token_svc = CredentialTokenService(db)
     raw_token, _ = await token_svc.create_token(
         purpose="verify",
@@ -340,12 +379,12 @@ async def create_user(
         user_id=user.id,
     )
 
-    sender = get_email_sender()
-    verify_url = f"{settings.CORS_ORIGINS.split(',')[0]}/verify-email/{raw_token}"
-    await sender.send(
+    verify_url = f"{_frontend_base_url()}/verify-email/{raw_token}"
+    await _safe_send_email(
         to=user.email,
         subject=f"Verify your email - {settings.email.from_name}",
         body_html=f"<p>Verify your email: {verify_url}</p>",
+        context="create_user.verify_email",
     )
 
     return UserResponse(
@@ -634,19 +673,20 @@ async def create_invite(
         metadata={"role": invite_data.role},
     )
 
-    # Dispatch invite email
-    sender = get_email_sender()
-    cors_origins = settings.CORS_ORIGINS.split(",")
+    # URL-encode email query param — addresses with '+' or reserved
+    # characters would otherwise produce broken links (Copilot PR #235).
     accept_url = (
-        f"{cors_origins[0].strip()}/accept-invite/{raw_token}?email={invite_data.email}"
+        f"{_frontend_base_url()}/accept-invite/{raw_token}"
+        f"?{urlencode({'email': invite_data.email})}"
     )
-    await sender.send(
+    await _safe_send_email(
         to=invite_data.email,
         subject=f"You've been invited to {settings.email.from_name}",
         body_html=(
             f"<p>You've been invited as a {invite_data.role}. "
             f'Click here to accept: <a href="{accept_url}">{accept_url}</a></p>'
         ),
+        context="invite.dispatch",
     )
 
     await log_user_action(
@@ -782,12 +822,14 @@ async def request_password_reset(
             user_id=user.id,
         )
 
-        sender = get_email_sender()
-        reset_url = f"{settings.CORS_ORIGINS.split(',')[0]}/reset-password/{raw_token}"
-        await sender.send(
+        # Email errors MUST NOT leak user existence (OWASP anti-enum).
+        # Swallow + log via _safe_send_email (Copilot PR #235 review).
+        reset_url = f"{_frontend_base_url()}/reset-password/{raw_token}"
+        await _safe_send_email(
             to=reset_data.email,
             subject=f"Password Reset - {settings.email.from_name}",
             body_html=f"<p>Reset your password: {reset_url}</p>",
+            context="password_reset.request",
         )
 
     response = MessageResponse(
@@ -873,12 +915,12 @@ async def resend_verification(
         user_id=current_user.id,
     )
 
-    sender = get_email_sender()
-    verify_url = f"{settings.CORS_ORIGINS.split(',')[0]}/verify-email/{raw_token}"
-    await sender.send(
+    verify_url = f"{_frontend_base_url()}/verify-email/{raw_token}"
+    await _safe_send_email(
         to=current_user.email,
         subject=f"Verify your email - {settings.email.from_name}",
         body_html=f"<p>Verify your email: {verify_url}</p>",
+        context="verify_email.resend",
     )
 
     response = MessageResponse(message="Verification email sent.")

--- a/backend/app/auth/credential_tokens.py
+++ b/backend/app/auth/credential_tokens.py
@@ -9,7 +9,7 @@ import hmac
 import secrets
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import CursorResult, select, update
+from sqlalchemy import CursorResult, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.credential_token import CredentialToken
@@ -65,37 +65,38 @@ class CredentialTokenService:
     async def verify_and_consume(
         self, raw_token: str, *, purpose: str
     ) -> CredentialToken | None:
-        """Verify a token and mark it as consumed.
+        """Verify a token and mark it as consumed atomically.
+
+        Uses a single conditional UPDATE ... RETURNING to guarantee
+        single-use semantics under concurrent requests (no SELECT-then-
+        UPDATE race). Only succeeds when the row matches token+purpose
+        AND is_unused AND not_expired.
 
         Returns the consumed token row, or None if invalid/expired/used.
-        Uses hmac.compare_digest for defense in depth (spec R1).
         """
         token_hash = _hash_token(raw_token)
         now = datetime.now(timezone.utc)
 
         result = await self.db.execute(
-            select(CredentialToken).where(
+            update(CredentialToken)
+            .where(
                 CredentialToken.token_sha256 == token_hash,
                 CredentialToken.purpose == purpose,
+                CredentialToken.used_at.is_(None),
+                CredentialToken.expires_at > now,
             )
+            .values(used_at=now)
+            .returning(CredentialToken)
         )
         db_token = result.scalar_one_or_none()
+        await self.db.commit()
 
         if db_token is None:
             return None
 
+        # Constant-time hash comparison for defense in depth (spec R1).
         if not hmac.compare_digest(db_token.token_sha256, token_hash):
             return None
-
-        if db_token.used_at is not None:
-            return None
-
-        if db_token.expires_at <= now:
-            return None
-
-        db_token.used_at = now
-        await self.db.commit()
-        await self.db.refresh(db_token)
 
         return db_token
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -421,12 +421,14 @@ class Settings(BaseSettings):
                         "SMTP_PASSWORD is empty. Set them in .env or set "
                         "email.use_credentials: false in config.yaml."
                     )
-        if email_cfg.tls_mode == "none":
-            logger.critical(
-                "EMAIL TLS IS DISABLED (email.tls_mode: 'none'). "
-                "Emails will be sent unencrypted. This is only safe "
-                "for trusted internal relays."
-            )
+            # Gate TLS warning behind smtp backend — it is irrelevant (and
+            # noisy) when backend is console (Copilot PR #235 review).
+            if email_cfg.tls_mode == "none":
+                logger.critical(
+                    "EMAIL TLS IS DISABLED (email.tls_mode: 'none'). "
+                    "Emails will be sent unencrypted. This is only safe "
+                    "for trusted internal relays."
+                )
         return self
 
     @property


### PR DESCRIPTION
Follow-up to #235 addressing all Copilot review comments and Codecov findings.

## Fixes

### 🔒 Atomic token consumption (HIGH — race condition)
`CredentialTokenService.verify_and_consume` was SELECT-then-UPDATE, allowing two concurrent requests to both pass the \`used_at IS NULL\` check before either committed. Replaced with a single conditional \`UPDATE ... RETURNING\` so the DB guarantees single-use semantics under concurrent load.

### 📧 Email dispatch safety (HIGH — information disclosure + UX)
Three endpoints (\`request_password_reset\`, \`create_user\`, \`resend_verification\`) now wrap email dispatch in \`_safe_send_email\` which logs + swallows errors. Previously:
- \`request_password_reset\` leaked user existence: SMTP failures only bubbled up when the user existed
- \`create_user\` would return 500 with a user already created in the DB if SMTP failed
- \`resend_verification\` same as create_user — commit then fail

### 🔗 URL construction (MEDIUM)
- Centralized \`_frontend_base_url()\` uses \`settings.get_cors_origins_list()[0]\` — handles whitespace after commas in env vars consistently
- Invite \`accept_url\` URL-encodes the email query param via \`urllib.parse.urlencode\` — email addresses with \`+\` or reserved characters now produce valid links

### ⚙️ Config noise (LOW)
TLS 'none' warning now only fires when \`email.backend == 'smtp'\` — was producing noisy critical logs at startup for dev/console deployments.

### 🗄️ Schema naming (MEDIUM)
Added migration \`c9a55365ed1f\` to rename \`ck_credential_tokens_ck_credential_tokens_purpose\` → \`ck_credential_tokens_purpose\`. The original migration double-prefixed via the MetaData naming convention; this aligns DB with model output so autogenerate doesn't show spurious diffs.

## Verification

- [x] Backend lint: \`ruff check\` clean
- [x] Backend typecheck: \`mypy\` clean
- [x] 31 affected tests pass (credential_tokens + auth_invite + auth_password_reset + auth_email_verify + email_sender)
- [x] Migration round-trip tested (upgrade → downgrade → upgrade)

## Not addressed

- PR description for #235 mentioning JWT-on-invite-accept — the merged PR description can't be amended; the code returns \`UserResponse\` (no tokens, frontend redirects to login) which is the correct behavior per the design spec §5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)