### PR TITLE
fix: harden auth and workflow release blockers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,17 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     services:
       postgres:
@@ -20,7 +28,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U hnf1b_user -d hnf1b_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -92,6 +100,7 @@ jobs:
 
   frontend:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v6
@@ -99,7 +108,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
 
@@ -166,6 +175,7 @@ jobs:
     name: E2E tests (Playwright)
     needs: frontend
     runs-on: ubuntu-latest
+    timeout-minutes: 25
 
     # Wave 6 Task 1: spin up Postgres + Redis + backend + frontend and run
     # the Playwright suite in tests/e2e/. The existing specs assume the
@@ -183,7 +193,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U hnf1b_user"
+          --health-cmd "pg_isready -U hnf1b_user -d hnf1b_phenopackets_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -204,7 +214,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
 
@@ -304,6 +314,7 @@ jobs:
   pre-commit:
     name: pre-commit hygiene gate
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     # Wave 5b Task 1: runs the .pre-commit-config.yaml check bundle on
     # every push so developers who forgot `pre-commit install` locally
@@ -325,7 +336,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
 

--- a/backend/app/api/auth_endpoints.py
+++ b/backend/app/api/auth_endpoints.py
@@ -1,6 +1,7 @@
 """Authentication API endpoints."""
 
 import logging
+from datetime import datetime, timezone
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -46,6 +47,21 @@ from app.schemas.auth import (
 from app.utils.audit_logger import log_user_action
 
 logger = logging.getLogger(__name__)
+
+
+def _assert_user_can_receive_tokens(user: User) -> None:
+    """Reject inactive or currently locked users before token issuance."""
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Account is inactive",
+        )
+
+    if user.locked_until and user.locked_until > datetime.now(timezone.utc):
+        raise HTTPException(
+            status_code=status.HTTP_423_LOCKED,
+            detail=f"Account locked until {user.locked_until.isoformat()}",
+        )
 
 
 def _frontend_base_url() -> str:
@@ -141,12 +157,7 @@ async def login(
         user.hashed_password = new_hash
         await db.flush()
 
-    # Check if account is active
-    if not user.is_active:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Account is inactive",
-        )
+    _assert_user_can_receive_tokens(user)
 
     # Create tokens
     access_token = create_access_token(user.username, user.role, user.get_permissions())
@@ -155,6 +166,7 @@ async def login(
     # Update user record
     await repo.record_successful_login(user)
     await repo.update_refresh_token(user, refresh_token)
+    await db.commit()
 
     # Log successful login
     await log_user_action(
@@ -198,10 +210,13 @@ async def refresh_access_token(
             detail="User not found",
         )
 
+    _assert_user_can_receive_tokens(user)
+
     # Verify stored refresh token matches (token rotation)
     if user.refresh_token != request.refresh_token:
         # Possible token theft - invalidate all tokens
         await repo.update_refresh_token(user, "")
+        await db.commit()
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid refresh token",
@@ -215,6 +230,7 @@ async def refresh_access_token(
 
     # Store new refresh token
     await repo.update_refresh_token(user, new_refresh_token)
+    await db.commit()
 
     return Token(
         access_token=new_access_token,
@@ -261,6 +277,7 @@ async def logout(
     """
     repo = UserRepository(db)
     await repo.update_refresh_token(current_user, "")
+    await db.commit()
 
     await log_user_action(
         db=db,
@@ -297,6 +314,8 @@ async def change_password(
     repo = UserRepository(db)
     user_update = UserUpdatePublic(password=password_data.new_password)  # type: ignore[call-arg]  # mypy+pydantic: Field(None) defaults not recognized
     await repo.update(current_user, user_update)
+    await repo.update_refresh_token(current_user, "")
+    await db.commit()
 
     await log_user_action(
         db=db,
@@ -871,6 +890,7 @@ async def confirm_password_reset(
         )
 
     user.hashed_password = get_password_hash(reset_data.new_password)
+    user.refresh_token = ""
     await db.commit()
 
     # Invalidate all remaining reset tokens for this email

--- a/backend/app/api/dev_endpoints.py
+++ b/backend/app/api/dev_endpoints.py
@@ -138,6 +138,7 @@ async def dev_login_as(
     )
     refresh_token = create_refresh_token(subject=user.username)
     await repo.update_refresh_token(user, refresh_token)
+    await db.commit()
 
     logger.warning(
         "DEV LOGIN as %s from %s",

--- a/backend/app/phenopackets/routers/crud_timeline.py
+++ b/backend/app/phenopackets/routers/crud_timeline.py
@@ -157,7 +157,7 @@ async def get_phenotype_timeline(
             status_code=404, detail=f"Phenopacket '{phenopacket_id}' not found"
         )
 
-    phenopacket_data: Optional[Dict[str, Any]]
+    phenopacket_data: Dict[str, Any]
     if is_curator:
         phenopacket_data = resolve_curator_content(phenopacket_record)
     else:
@@ -171,18 +171,13 @@ async def get_phenotype_timeline(
                 status_code=404,
                 detail=f"Phenopacket '{phenopacket_id}' not found",
             )
-        phenopacket_data = await resolve_public_content(db, phenopacket_record)
-        if phenopacket_data is None:
+        public_content = await resolve_public_content(db, phenopacket_record)
+        if public_content is None:
             raise HTTPException(
                 status_code=404,
                 detail=f"Phenopacket '{phenopacket_id}' not found",
             )
-
-    if phenopacket_data is None:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Phenopacket '{phenopacket_id}' not found",
-        )
+        phenopacket_data = public_content
 
     subject = phenopacket_data.get("subject", {})
     subject_id = subject.get("id")

--- a/backend/app/phenopackets/routers/crud_timeline.py
+++ b/backend/app/phenopackets/routers/crud_timeline.py
@@ -18,8 +18,14 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth import get_optional_user, is_curator_or_admin
 from app.database import get_db
+from app.models.user import User
 from app.phenopackets.repositories import PhenopacketRepository
+from app.phenopackets.repositories.visibility import (
+    resolve_curator_content,
+    resolve_public_content,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -130,20 +136,54 @@ def _categorise_feature(hpo_id: Optional[str]) -> str:
 async def get_phenotype_timeline(
     phenopacket_id: str,
     db: AsyncSession = Depends(get_db),
+    current_user: Optional[User] = Depends(get_optional_user),
 ):
     """Return a timeline-ready view of a phenopacket's phenotypic features.
 
     The response shape is unchanged from the pre-Wave-4 flat router:
     ``{"subject_id": ..., "current_age": ..., "features": [...]}``.
+
+    Public callers only see published head content. Curators/admins can
+    inspect the working copy, including soft-deleted rows, so the timeline
+    remains usable for audit and review flows.
     """
     repo = PhenopacketRepository(db)
-    phenopacket_record = await repo.get_by_id(phenopacket_id, include_deleted=True)
+    is_curator = is_curator_or_admin(current_user)
+    phenopacket_record = await repo.get_by_id(
+        phenopacket_id, include_deleted=is_curator
+    )
     if phenopacket_record is None:
         raise HTTPException(
             status_code=404, detail=f"Phenopacket '{phenopacket_id}' not found"
         )
 
-    phenopacket_data = phenopacket_record.phenopacket
+    phenopacket_data: Optional[Dict[str, Any]]
+    if is_curator:
+        phenopacket_data = resolve_curator_content(phenopacket_record)
+    else:
+        # Public / viewer callers must obey the published-only visibility
+        # model used by the main detail and list routes.
+        if (
+            phenopacket_record.state != "published"
+            or phenopacket_record.head_published_revision_id is None
+        ):
+            raise HTTPException(
+                status_code=404,
+                detail=f"Phenopacket '{phenopacket_id}' not found",
+            )
+        phenopacket_data = await resolve_public_content(db, phenopacket_record)
+        if phenopacket_data is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Phenopacket '{phenopacket_id}' not found",
+            )
+
+    if phenopacket_data is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Phenopacket '{phenopacket_id}' not found",
+        )
+
     subject = phenopacket_data.get("subject", {})
     subject_id = subject.get("id")
 

--- a/backend/app/phenopackets/services/phenopacket_service.py
+++ b/backend/app/phenopackets/services/phenopacket_service.py
@@ -27,6 +27,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from app.phenopackets.models import (
@@ -301,7 +302,16 @@ class PhenopacketService:
         ``expected_revision`` is optional for backwards compatibility —
         callers that omit it get the original blind-delete behaviour.
         """
-        phenopacket = await self._repo.get_by_id(phenopacket_id)
+        lock_stmt = (
+            select(Phenopacket)
+            .where(
+                Phenopacket.phenopacket_id == phenopacket_id,
+                Phenopacket.deleted_at.is_(None),
+            )
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+        phenopacket = (await self._repo.session.execute(lock_stmt)).scalar_one_or_none()
         if phenopacket is None:
             raise ServiceNotFound(
                 f"Phenopacket {phenopacket_id} not found or already deleted"

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -179,7 +179,7 @@ class UserRepository:
         user.last_login = datetime.now(timezone.utc)
         user.failed_login_attempts = 0
         user.locked_until = None
-        await self.db.commit()
+        await self.db.flush()
 
     async def update_refresh_token(self, user: User, refresh_token: str) -> None:
         """Store refresh token for user.
@@ -189,7 +189,7 @@ class UserRepository:
             refresh_token: Refresh token to store
         """
         user.refresh_token = refresh_token
-        await self.db.commit()
+        await self.db.flush()
 
     async def unlock(self, user: User) -> User:
         """Clear failed login attempts and lockout for a user.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,7 +11,7 @@ Per-test isolation strategy:
   their own sessions (e.g. race-condition tests) share the same engine as the
   tests which use the ``db_session`` fixture. This means the whole suite sees
   one test database with one connection pool.
-- Between tests we ``TRUNCATE`` the small set of mutable tables that test
+- After each test we ``TRUNCATE`` the small set of mutable tables that test
   fixtures and endpoints write to. Static lookup tables populated by Alembic
   migrations are intentionally left alone so the schema stays valid.
 - ``dispose_engine`` runs at session teardown to shut down asyncpg cleanly.
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import delete, text
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
@@ -134,26 +134,28 @@ _MUTABLE_TABLES: tuple[str, ...] = (
 async def _truncate_mutable_tables() -> None:
     """Wipe test-mutable tables in a single transaction.
 
-    Runs before every test so that each test starts from a clean, deterministic
-    state. Uses ``TRUNCATE ... RESTART IDENTITY CASCADE`` so that serial/bigint
-    primary keys are reset and any FK-dependent rows are removed in lock-step.
+    Runs after every test so that the next test starts from a clean,
+    deterministic state. Uses ``TRUNCATE ... RESTART IDENTITY CASCADE`` so that
+    serial/bigint primary keys are reset and any FK-dependent rows are removed
+    in lock-step.
     """
     async with engine.begin() as conn:
         joined = ", ".join(_MUTABLE_TABLES)
         await conn.execute(text(f"TRUNCATE TABLE {joined} RESTART IDENTITY CASCADE"))
 
 
-@pytest_asyncio.fixture(autouse=True)
-async def _isolate_database_between_tests():
-    """Wipe mutable tables before each test for guaranteed isolation.
-
-    Declared ``autouse=True`` so every test gets a clean database without
-    having to remember to request the fixture. No yield body is needed — the
-    cleanup runs before the test and the next invocation handles the next
-    test's pre-state.
-    """
+@pytest_asyncio.fixture(scope="session", autouse=True)
+async def _clean_database_at_session_start():
+    """Start the test session from a clean mutable-data state."""
     await _truncate_mutable_tables()
     yield
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _isolate_database_between_tests():
+    """Wipe mutable tables after each test for guaranteed isolation."""
+    yield
+    await _truncate_mutable_tables()
 
 
 @pytest_asyncio.fixture
@@ -214,16 +216,7 @@ async def test_user(db_session):
 
     yield user
 
-    # Best-effort cleanup — the autouse truncate will catch anything we miss
-    # before the next test runs.
-    try:
-        await db_session.execute(delete(User).where(User.id == user.id))
-        await db_session.commit()
-    except Exception:
-        try:
-            await db_session.rollback()
-        except Exception:
-            pass
+    # Autouse table truncation handles cleanup after the test.
 
 
 @pytest_asyncio.fixture
@@ -243,14 +236,7 @@ async def admin_user(db_session):
 
     yield user
 
-    try:
-        await db_session.execute(delete(User).where(User.id == user.id))
-        await db_session.commit()
-    except Exception:
-        try:
-            await db_session.rollback()
-        except Exception:
-            pass
+    # Autouse table truncation handles cleanup after the test.
 
 
 @pytest_asyncio.fixture
@@ -276,14 +262,7 @@ async def curator_user(db_session):
 
     yield user
 
-    try:
-        await db_session.execute(delete(User).where(User.id == user.id))
-        await db_session.commit()
-    except Exception:
-        try:
-            await db_session.rollback()
-        except Exception:
-            pass
+    # Autouse table truncation handles cleanup after the test.
 
 
 @pytest_asyncio.fixture
@@ -436,14 +415,7 @@ async def viewer_user(db_session):
 
     yield user
 
-    try:
-        await db_session.execute(delete(User).where(User.id == user.id))
-        await db_session.commit()
-    except Exception:
-        try:
-            await db_session.rollback()
-        except Exception:
-            pass
+    # Autouse table truncation handles cleanup after the test.
 
 
 @pytest_asyncio.fixture
@@ -516,14 +488,7 @@ async def another_curator(db_session):
 
     yield user
 
-    try:
-        await db_session.execute(delete(User).where(User.id == user.id))
-        await db_session.commit()
-    except Exception:
-        try:
-            await db_session.rollback()
-        except Exception:
-            pass
+    # Autouse table truncation handles cleanup after the test.
 
 
 @pytest_asyncio.fixture
@@ -617,14 +582,7 @@ async def seeded_system_user(db_session):
 
     yield user
 
-    try:
-        await db_session.execute(delete(User).where(User.id == user.id))
-        await db_session.commit()
-    except Exception:
-        try:
-            await db_session.rollback()
-        except Exception:
-            pass
+    # Autouse table truncation handles cleanup after the test.
 
 
 # Silence ``pytest`` unused-import warning for the session fixture above.

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,7 +1,11 @@
 """Tests for authentication endpoints."""
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from httpx import AsyncClient
+
+from app.models.user import User
 
 
 @pytest.mark.asyncio
@@ -41,6 +45,22 @@ async def test_login_nonexistent_user(async_client: AsyncClient):
     )
 
     assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_login_locked_account_is_rejected(
+    async_client: AsyncClient, test_user, db_session
+):
+    """Test login rejects an account that is currently locked."""
+    test_user.locked_until = datetime.now(timezone.utc) + timedelta(minutes=15)
+    await db_session.commit()
+    response = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": test_user.username, "password": "TestPass123!"},
+    )
+
+    assert response.status_code == 423
+    assert "locked" in response.json()["detail"].lower()
 
 
 @pytest.mark.asyncio
@@ -88,6 +108,52 @@ async def test_token_refresh(async_client: AsyncClient, test_user):
 
 
 @pytest.mark.asyncio
+async def test_token_refresh_rejects_inactive_account(
+    async_client: AsyncClient, test_user, db_session
+):
+    """Test refresh rejects a token for an inactive account."""
+    login_response = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": test_user.username, "password": "TestPass123!"},
+    )
+    refresh_token = login_response.json()["refresh_token"]
+
+    test_user.is_active = False
+    await db_session.commit()
+
+    response = await async_client.post(
+        "/api/v2/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+
+    assert response.status_code == 403
+    assert "inactive" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_token_refresh_rejects_locked_account(
+    async_client: AsyncClient, test_user, db_session
+):
+    """Test refresh rejects a token for a locked account."""
+    login_response = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": test_user.username, "password": "TestPass123!"},
+    )
+    refresh_token = login_response.json()["refresh_token"]
+
+    test_user.locked_until = datetime.now(timezone.utc) + timedelta(minutes=15)
+    await db_session.commit()
+
+    response = await async_client.post(
+        "/api/v2/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+
+    assert response.status_code == 423
+    assert "locked" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
 async def test_logout(async_client: AsyncClient, auth_headers):
     """Test logout."""
     response = await async_client.post("/api/v2/auth/logout", headers=auth_headers)
@@ -109,6 +175,36 @@ async def test_change_password(async_client: AsyncClient, auth_headers):
     )
 
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_change_password_invalidates_previous_refresh_token(
+    async_client: AsyncClient, test_user
+):
+    """Test password rotation clears the existing refresh capability."""
+    login_response = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": test_user.username, "password": "TestPass123!"},
+    )
+    refresh_token = login_response.json()["refresh_token"]
+
+    change_response = await async_client.post(
+        "/api/v2/auth/change-password",
+        headers={"Authorization": f"Bearer {login_response.json()['access_token']}"},
+        json={
+            "current_password": "TestPass123!",
+            "new_password": "NewPass456!",
+        },
+    )
+    assert change_response.status_code == 200
+
+    refresh_response = await async_client.post(
+        "/api/v2/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+
+    assert refresh_response.status_code == 401
+    assert "invalid" in refresh_response.json()["detail"].lower()
 
 
 @pytest.mark.asyncio
@@ -134,7 +230,6 @@ async def test_create_user_admin(async_client: AsyncClient, admin_headers, db_se
     # Pre-cleanup: Remove any leftover newuser from failed previous runs
     from sqlalchemy import delete
 
-    from app.models.user import User
 
     try:
         await db_session.execute(delete(User).where(User.email == "new@example.com"))

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -230,7 +230,6 @@ async def test_create_user_admin(async_client: AsyncClient, admin_headers, db_se
     # Pre-cleanup: Remove any leftover newuser from failed previous runs
     from sqlalchemy import delete
 
-
     try:
         await db_session.execute(delete(User).where(User.email == "new@example.com"))
         await db_session.commit()

--- a/backend/tests/test_auth_password_reset.py
+++ b/backend/tests/test_auth_password_reset.py
@@ -67,6 +67,43 @@ async def test_reset_confirm_changes_password(async_client, admin_headers):
 
 
 @pytest.mark.asyncio
+async def test_reset_confirm_invalidates_existing_refresh_token(
+    async_client, admin_headers
+):
+    """Password rotation should retire the previous refresh token."""
+    me_resp = await async_client.get("/api/v2/auth/me", headers=admin_headers)
+    admin_email = me_resp.json()["email"]
+    admin_username = me_resp.json()["username"]
+
+    login_resp = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": admin_username, "password": "AdminPass123!"},
+    )
+    assert login_resp.status_code == 200
+    refresh_token = login_resp.json()["refresh_token"]
+
+    reset_resp = await async_client.post(
+        "/api/v2/auth/password-reset/request",
+        json={"email": admin_email},
+    )
+    token = reset_resp.json().get("token")
+    assert token is not None  # Dev mode includes token
+
+    confirm_resp = await async_client.post(
+        f"/api/v2/auth/password-reset/confirm/{token}",
+        json={"new_password": "NewSecurePass!2026"},
+    )
+    assert confirm_resp.status_code == 200
+
+    refresh_resp = await async_client.post(
+        "/api/v2/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+    assert refresh_resp.status_code == 401
+    assert "invalid" in refresh_resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
 async def test_reset_confirm_rejects_invalid_token(async_client):
     """Invalid token returns 400."""
     resp = await async_client.post(

--- a/backend/tests/test_crud_related_and_timeline.py
+++ b/backend/tests/test_crud_related_and_timeline.py
@@ -16,6 +16,7 @@ the regex/parse logic from silently breaking.
 
 from __future__ import annotations
 
+import copy
 from datetime import datetime, timezone
 
 import pytest
@@ -179,6 +180,7 @@ def _make_phenopacket_row(
     include_variant: bool = False,
     include_pmid: bool = False,
     deleted: bool = False,
+    state: str = "published",
 ) -> Phenopacket:
     """Build a ``Phenopacket`` ORM instance for direct DB insertion."""
     features: list[dict] = []
@@ -192,7 +194,7 @@ def _make_phenopacket_row(
                 "onset": {"age": {"iso8601duration": "P5Y"}},
                 "evidence": [
                     {
-                        "evidenceCode": {"label": "TAS"},
+                        "evidenceCode": {"id": "ECO:0000033", "label": "TAS"},
                         "reference": {"id": "PMID:99999"},
                     }
                 ],
@@ -262,7 +264,7 @@ def _make_phenopacket_row(
         subject_id=subject_id,
         subject_sex="MALE",
         created_by_id=None,
-        state="published",
+        state=state,
         revision=1,
     )
     if deleted:
@@ -310,14 +312,15 @@ class TestCrudTimelineEndpoint:
         assert response.status_code == 404
 
     async def test_timeline_returns_subject_and_features(
-        self, async_client, db_session
+        self, async_client, db_session, admin_user
     ):
-        """Stored phenopacket → timeline endpoint returns formatted features."""
+        """Published phenopacket with a head revision → timeline data."""
         row = _make_phenopacket_row(
             phenopacket_id="TL-EP-001",
             subject_id="SUB-TL-001",
         )
         db_session.add(row)
+        await _add_head_revision(db_session, row, actor_id=admin_user.id)
         await db_session.commit()
 
         response = await async_client.get("/api/v2/phenopackets/TL-EP-001/timeline")
@@ -341,25 +344,89 @@ class TestCrudTimelineEndpoint:
         assert diabetes["onset_age"] == "P10Y"
         assert diabetes["onset_label"] == "Observed at age 10y"
 
-    async def test_timeline_renders_soft_deleted_phenopacket(
+    async def test_timeline_hides_draft_phenopacket_from_public_client(
         self, async_client, db_session
     ):
-        """Soft-deleted rows are still accessible via the timeline endpoint.
+        """Draft phenopackets must not leak through the timeline endpoint."""
+        row = _make_phenopacket_row(
+            phenopacket_id="TL-EP-DRAFT",
+            subject_id="SUB-TL-DRAFT",
+            state="draft",
+        )
+        db_session.add(row)
+        await db_session.commit()
 
-        The endpoint explicitly passes ``include_deleted=True`` so the
-        audit-trail UI can still render deleted phenopackets' features.
-        """
+        response = await async_client.get("/api/v2/phenopackets/TL-EP-DRAFT/timeline")
+        assert response.status_code == 404
+
+    async def test_timeline_hides_soft_deleted_phenopacket_from_public_client(
+        self, async_client, db_session, admin_user
+    ):
+        """Soft-deleted phenopackets must not leak through the timeline endpoint."""
         row = _make_phenopacket_row(
             phenopacket_id="TL-EP-DELETED",
             subject_id="SUB-TL-DELETED",
             deleted=True,
         )
         db_session.add(row)
+        await _add_head_revision(db_session, row, actor_id=admin_user.id)
         await db_session.commit()
 
         response = await async_client.get("/api/v2/phenopackets/TL-EP-DELETED/timeline")
+        assert response.status_code == 404
+
+    async def test_timeline_returns_curator_view_for_soft_deleted_phenopacket(
+        self, async_client, db_session, admin_user, curator_headers
+    ):
+        """Curators should still be able to inspect deleted history."""
+        row = _make_phenopacket_row(
+            phenopacket_id="TL-EP-DELETED-CURATOR",
+            subject_id="SUB-TL-DELETED-CURATOR",
+            deleted=True,
+        )
+        db_session.add(row)
+        await _add_head_revision(db_session, row, actor_id=admin_user.id)
+        await db_session.commit()
+
+        response = await async_client.get(
+            "/api/v2/phenopackets/TL-EP-DELETED-CURATOR/timeline",
+            headers=curator_headers,
+        )
         assert response.status_code == 200
-        assert response.json()["subject_id"] == "SUB-TL-DELETED"
+        assert response.json()["subject_id"] == "SUB-TL-DELETED-CURATOR"
+
+    async def test_timeline_returns_head_content_for_public_client_during_clone(
+        self, async_client, db_session, admin_user, curator_headers
+    ):
+        """Anonymous callers should keep seeing the published head during clone-to-draft."""
+        row = _make_phenopacket_row(
+            phenopacket_id="TL-EP-CLONE",
+            subject_id="SUB-TL-CLONE",
+        )
+        db_session.add(row)
+        await _add_head_revision(db_session, row, actor_id=admin_user.id)
+        await db_session.commit()
+
+        original_label = row.phenopacket["phenotypicFeatures"][0]["type"]["label"]
+        new_content = copy.deepcopy(row.phenopacket)
+        new_content["phenotypicFeatures"][0]["type"]["label"] = "Renal cyst UPDATED"
+
+        update_response = await async_client.put(
+            "/api/v2/phenopackets/TL-EP-CLONE",
+            json={
+                "phenopacket": new_content,
+                "revision": row.revision,
+                "change_reason": "clone for timeline regression",
+            },
+            headers=curator_headers,
+        )
+        assert update_response.status_code == 200, update_response.text
+
+        response = await async_client.get("/api/v2/phenopackets/TL-EP-CLONE/timeline")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["features"][0]["label"] == original_label
+        assert body["features"][0]["label"] != "Renal cyst UPDATED"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_phenopackets_delete_revision.py
+++ b/backend/tests/test_phenopackets_delete_revision.py
@@ -13,6 +13,14 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
+from app.database import async_session_maker
+from app.phenopackets.models import Phenopacket, PhenopacketUpdate
+from app.phenopackets.repositories import PhenopacketRepository
+from app.phenopackets.services.phenopacket_service import (
+    PhenopacketService,
+    ServiceConflict,
+)
+
 
 def _valid_payload(phenopacket_id: str, subject_id: str = "s", sex: str = "MALE"):
     """Build a minimal-but-valid phenopacket create payload.
@@ -124,3 +132,74 @@ async def test_delete_without_revision_still_works(
         headers=admin_headers,
     )
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_delete_fails_when_revision_changes_before_commit(
+    db_session,
+    admin_user,
+):
+    """A stale delete loses to a concurrent update even across sessions."""
+    create_payload = _valid_payload("delete-revision-race")
+    phenopacket = Phenopacket(
+        phenopacket_id=create_payload["phenopacket"]["id"],
+        phenopacket=create_payload["phenopacket"],
+        subject_id=create_payload["phenopacket"]["subject"]["id"],
+        subject_sex=create_payload["phenopacket"]["subject"].get("sex", "UNKNOWN_SEX"),
+        created_by_id=admin_user.id,
+        state="draft",
+        revision=1,
+    )
+    db_session.add(phenopacket)
+    await db_session.commit()
+
+    stale_ready = __import__("asyncio").Event()
+    update_done = __import__("asyncio").Event()
+
+    async def actor_a_delete() -> None:
+        async with async_session_maker() as session:
+            service = PhenopacketService(PhenopacketRepository(session))
+            loaded = await service.get("delete-revision-race")
+            assert loaded is not None
+            assert loaded.revision == 1
+            stale_ready.set()
+            await update_done.wait()
+
+            with pytest.raises(ServiceConflict) as exc_info:
+                await service.soft_delete(
+                    "delete-revision-race",
+                    "stale delete",
+                    actor_id=admin_user.id,
+                    actor_username=admin_user.username,
+                    expected_revision=loaded.revision,
+                )
+
+            assert exc_info.value.code == "revision_mismatch"
+            assert exc_info.value.detail["current_revision"] == 2
+            assert exc_info.value.detail["expected_revision"] == 1
+
+    async def actor_b_update() -> None:
+        await stale_ready.wait()
+        async with async_session_maker() as session:
+            service = PhenopacketService(PhenopacketRepository(session))
+            update_payload = PhenopacketUpdate(
+                phenopacket={
+                    **create_payload["phenopacket"],
+                    "phenotypicFeatures": [
+                        {
+                            "type": {"id": "HP:0000001", "label": "updated"},
+                        }
+                    ],
+                },
+                revision=1,
+                change_reason="concurrent edit",
+            )
+            updated = await service.update(
+                "delete-revision-race",
+                update_payload,
+                actor_id=admin_user.id,
+            )
+            assert updated.revision == 2
+        update_done.set()
+
+    await __import__("asyncio").gather(actor_a_delete(), actor_b_update())

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,6 +2,8 @@
 
 # Backend API URL (development) - v2 Phenopackets API
 VITE_API_URL=http://localhost:8000/api/v2
+VITE_ENABLE_DEV_AUTH=false
 
 # Production API URL (uncomment for production builds)
 # VITE_API_URL=https://api.hnf1b.example.com/api/v2
+# VITE_ENABLE_DEV_AUTH=false

--- a/frontend/src/api/session.js
+++ b/frontend/src/api/session.js
@@ -1,10 +1,52 @@
-// src/api/session.js — in-memory token storage (no axios dependency)
+// src/api/session.js — tab-scoped token storage (sessionStorage + in-memory cache)
 
-let accessToken = null;
-let refreshToken = null;
+const ACCESS_TOKEN_KEY = 'access_token';
+const REFRESH_TOKEN_KEY = 'refresh_token';
+let accessToken = readSessionStorageToken(ACCESS_TOKEN_KEY);
+let refreshToken = readSessionStorageToken(REFRESH_TOKEN_KEY);
+const LEGACY_TOKEN_KEYS = ['access_token', 'refresh_token'];
+
+function readSessionStorageToken(key) {
+  try {
+    return globalThis.sessionStorage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionStorageToken(key, value) {
+  try {
+    if (!globalThis.sessionStorage) {
+      return;
+    }
+    if (value == null) {
+      globalThis.sessionStorage.removeItem(key);
+    } else {
+      globalThis.sessionStorage.setItem(key, value);
+    }
+  } catch {
+    // Ignore storage access failures (private mode, SSR, locked-down browser).
+  }
+}
+
+function purgeLegacyLocalStorageTokens() {
+  try {
+    if (!globalThis.localStorage) {
+      return;
+    }
+
+    for (const key of LEGACY_TOKEN_KEYS) {
+      globalThis.localStorage.removeItem(key);
+    }
+  } catch {
+    // Ignore storage access failures (private mode, SSR, locked-down browser).
+  }
+}
+
+purgeLegacyLocalStorageTokens();
 
 /**
- * Read the access token from the in-memory session store.
+ * Read the access token from the current tab session store.
  * @returns {string|null} The stored access token, or null if absent.
  */
 export function getAccessToken() {
@@ -12,7 +54,7 @@ export function getAccessToken() {
 }
 
 /**
- * Read the refresh token from the in-memory session store.
+ * Read the refresh token from the current tab session store.
  * @returns {string|null} The stored refresh token, or null if absent.
  */
 export function getRefreshToken() {
@@ -20,7 +62,7 @@ export function getRefreshToken() {
 }
 
 /**
- * Persist one or both tokens to the in-memory session store.
+ * Persist one or both tokens to the current tab session store.
  * Only writes the values that are provided.
  * @param {Object} tokens
  * @param {string} [tokens.accessToken] - Access token to store
@@ -36,25 +78,30 @@ export function persistTokens({ accessToken, refreshToken } = {}) {
 }
 
 /**
- * Replace the in-memory access token.
+ * Replace the access token for the current browser tab.
  * @param {string|null} token
  */
 export function setAccessToken(token) {
   accessToken = token;
+  writeSessionStorageToken(ACCESS_TOKEN_KEY, token);
 }
 
 /**
- * Replace the in-memory refresh token.
+ * Replace the refresh token for the current browser tab.
  * @param {string|null} token
  */
 export function setRefreshToken(token) {
   refreshToken = token;
+  writeSessionStorageToken(REFRESH_TOKEN_KEY, token);
 }
 
 /**
- * Remove both tokens from the in-memory session store.
+ * Remove both tokens from the current tab session store.
  */
 export function clearTokens() {
   accessToken = null;
   refreshToken = null;
+  writeSessionStorageToken(ACCESS_TOKEN_KEY, null);
+  writeSessionStorageToken(REFRESH_TOKEN_KEY, null);
+  purgeLegacyLocalStorageTokens();
 }

--- a/frontend/src/api/session.js
+++ b/frontend/src/api/session.js
@@ -1,41 +1,60 @@
-// src/api/session.js — localStorage token storage (no axios dependency)
+// src/api/session.js — in-memory token storage (no axios dependency)
+
+let accessToken = null;
+let refreshToken = null;
 
 /**
- * Read the access token from localStorage.
+ * Read the access token from the in-memory session store.
  * @returns {string|null} The stored access token, or null if absent.
  */
 export function getAccessToken() {
-  return localStorage.getItem('access_token');
+  return accessToken;
 }
 
 /**
- * Read the refresh token from localStorage.
+ * Read the refresh token from the in-memory session store.
  * @returns {string|null} The stored refresh token, or null if absent.
  */
 export function getRefreshToken() {
-  return localStorage.getItem('refresh_token');
+  return refreshToken;
 }
 
 /**
- * Persist one or both tokens to localStorage.
- * Only writes the keys whose values are provided.
+ * Persist one or both tokens to the in-memory session store.
+ * Only writes the values that are provided.
  * @param {Object} tokens
  * @param {string} [tokens.accessToken] - Access token to store
  * @param {string} [tokens.refreshToken] - Refresh token to store
  */
 export function persistTokens({ accessToken, refreshToken } = {}) {
   if (accessToken !== undefined) {
-    localStorage.setItem('access_token', accessToken);
+    setAccessToken(accessToken);
   }
   if (refreshToken !== undefined) {
-    localStorage.setItem('refresh_token', refreshToken);
+    setRefreshToken(refreshToken);
   }
 }
 
 /**
- * Remove both tokens from localStorage.
+ * Replace the in-memory access token.
+ * @param {string|null} token
+ */
+export function setAccessToken(token) {
+  accessToken = token;
+}
+
+/**
+ * Replace the in-memory refresh token.
+ * @param {string|null} token
+ */
+export function setRefreshToken(token) {
+  refreshToken = token;
+}
+
+/**
+ * Remove both tokens from the in-memory session store.
  */
 export function clearTokens() {
-  localStorage.removeItem('access_token');
-  localStorage.removeItem('refresh_token');
+  accessToken = null;
+  refreshToken = null;
 }

--- a/frontend/src/api/transport.js
+++ b/frontend/src/api/transport.js
@@ -3,7 +3,7 @@
 // MUST stay in the same module as the axios instance to prevent thunder-herd.
 
 import axios from 'axios';
-import { getAccessToken } from './session';
+import { clearTokens, getAccessToken } from './session';
 
 export const apiClient = axios.create({
   // Use Vite proxy in development (avoids CORS), direct URL in production
@@ -35,9 +35,7 @@ function processQueue(error, token = null) {
   failedRequestsQueue = [];
 }
 
-// Request interceptor: Add JWT token from localStorage
-// Note: We use localStorage directly here for performance (synchronous)
-// The auth store manages the same tokens and keeps them in sync
+// Request interceptor: Add JWT token from the in-memory session helper.
 apiClient.interceptors.request.use(
   (config) => {
     const token = getAccessToken();
@@ -163,8 +161,7 @@ apiClient.interceptors.response.use(
 
         // Clear auth state and redirect
         window.logService.warn('Token refresh failed, redirecting to login');
-        localStorage.removeItem('access_token');
-        localStorage.removeItem('refresh_token');
+        clearTokens();
 
         // Only redirect if not already on login page
         if (window.location.pathname !== '/login') {

--- a/frontend/src/components/auth/DevQuickLogin.vue
+++ b/frontend/src/components/auth/DevQuickLogin.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="mt-4" variant="tonal" color="warning">
-    <v-card-title class="text-caption"> DEV MODE — not available in production </v-card-title>
+    <v-card-title class="text-caption"> DEV QUICK LOGIN — local development only </v-card-title>
     <v-card-text>
       <v-btn
         v-for="u in fixtureUsers"

--- a/frontend/src/config/devAuth.js
+++ b/frontend/src/config/devAuth.js
@@ -1,0 +1,23 @@
+/**
+ * Dev-auth feature flag helpers.
+ *
+ * The frontend must not expose the quick-login surface just because Vite is
+ * running in dev mode. Requiring an explicit flag keeps the UI aligned with the
+ * backend's explicit ENVIRONMENT/ENABLE_DEV_AUTH gate.
+ */
+
+function isTruthyFlag(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value ?? '').toLowerCase());
+}
+
+export function isDevQuickLoginEnabled() {
+  return import.meta.env.DEV && isTruthyFlag(import.meta.env.VITE_ENABLE_DEV_AUTH);
+}
+
+export function getDevQuickLoginDisabledMessage() {
+  return 'Dev quick-login is disabled. Set VITE_ENABLE_DEV_AUTH=true and restart the frontend.';
+}
+
+export function getDevQuickLoginBackendUnavailableMessage() {
+  return 'Dev quick-login is disabled on the backend. Set ENVIRONMENT=development and ENABLE_DEV_AUTH=true, then seed fixture users.';
+}

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -2,12 +2,13 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { apiClient } from '@/api';
+import { clearTokens, getAccessToken, getRefreshToken, persistTokens } from '@/api/session';
 
 export const useAuthStore = defineStore('auth', () => {
   // State
   const user = ref(null);
-  const accessToken = ref(localStorage.getItem('access_token'));
-  const refreshToken = ref(localStorage.getItem('refresh_token'));
+  const accessToken = ref(getAccessToken());
+  const refreshToken = ref(getRefreshToken());
   const isLoading = ref(false);
   const error = ref(null);
 
@@ -29,8 +30,7 @@ export const useAuthStore = defineStore('auth', () => {
       // Store tokens
       accessToken.value = access_token;
       refreshToken.value = refresh_token;
-      localStorage.setItem('access_token', access_token);
-      localStorage.setItem('refresh_token', refresh_token);
+      persistTokens({ accessToken: access_token, refreshToken: refresh_token });
 
       // Fetch user info
       await fetchCurrentUser();
@@ -72,9 +72,8 @@ export const useAuthStore = defineStore('auth', () => {
     refreshToken.value = null;
     error.value = null;
 
-    // Clear localStorage
-    localStorage.removeItem('access_token');
-    localStorage.removeItem('refresh_token');
+    // Clear in-memory token storage
+    clearTokens();
 
     isLoading.value = false;
 
@@ -127,8 +126,7 @@ export const useAuthStore = defineStore('auth', () => {
       // Update tokens (token rotation)
       accessToken.value = access_token;
       refreshToken.value = new_refresh_token;
-      localStorage.setItem('access_token', access_token);
-      localStorage.setItem('refresh_token', new_refresh_token);
+      persistTokens({ accessToken: access_token, refreshToken: new_refresh_token });
 
       window.logService.debug('Access token refreshed');
 
@@ -183,8 +181,7 @@ export const useAuthStore = defineStore('auth', () => {
       const { data } = await apiClient.post(`/dev/login-as/${username}`);
       accessToken.value = data.access_token;
       refreshToken.value = data.refresh_token;
-      localStorage.setItem('access_token', data.access_token);
-      localStorage.setItem('refresh_token', data.refresh_token);
+      persistTokens({ accessToken: data.access_token, refreshToken: data.refresh_token });
       await fetchCurrentUser();
       window.logService.info('dev quick-login', { username });
       return true;

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -2,6 +2,11 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { apiClient } from '@/api';
+import {
+  getDevQuickLoginBackendUnavailableMessage,
+  getDevQuickLoginDisabledMessage,
+  isDevQuickLoginEnabled,
+} from '@/config/devAuth';
 import { clearTokens, getAccessToken, getRefreshToken, persistTokens } from '@/api/session';
 
 export const useAuthStore = defineStore('auth', () => {
@@ -176,7 +181,14 @@ export const useAuthStore = defineStore('auth', () => {
   async function devLoginAs(username) {
     if (!import.meta.env.DEV) return;
 
+    if (!isDevQuickLoginEnabled()) {
+      const message = getDevQuickLoginDisabledMessage();
+      error.value = message;
+      throw new Error(message);
+    }
+
     isLoading.value = true;
+    error.value = null;
     try {
       const { data } = await apiClient.post(`/dev/login-as/${username}`);
       accessToken.value = data.access_token;
@@ -186,6 +198,11 @@ export const useAuthStore = defineStore('auth', () => {
       window.logService.info('dev quick-login', { username });
       return true;
     } catch (err) {
+      if (err.response?.status === 404) {
+        error.value = getDevQuickLoginBackendUnavailableMessage();
+      } else {
+        error.value = err.response?.data?.detail || 'Dev quick-login failed';
+      }
       window.logService.error('dev quick-login failed', { username, error: err.message });
       throw err;
     } finally {

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -111,6 +111,7 @@
 <script setup>
 import { ref, shallowRef, defineAsyncComponent } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
+import { isDevQuickLoginEnabled } from '@/config/devAuth';
 import { useAuthStore } from '@/stores/authStore';
 
 // Wave 5a Layer 4: DCE-friendly conditional import.
@@ -119,7 +120,7 @@ import { useAuthStore } from '@/stores/authStore';
 // at build time, pruning the whole `if` body (including the
 // dynamic import and the component reference).
 const DevQuickLogin = shallowRef(null);
-if (import.meta.env.DEV) {
+if (import.meta.env.DEV && isDevQuickLoginEnabled()) {
   DevQuickLogin.value = defineAsyncComponent(() => import('@/components/auth/DevQuickLogin.vue'));
 }
 

--- a/frontend/tests/e2e/comments.spec.js
+++ b/frontend/tests/e2e/comments.spec.js
@@ -38,19 +38,19 @@
  * Same env-var convention as state-lifecycle.spec.js and
  * dual-read-invariant.spec.js.
  *
- *   E2E_BASE_URL        defaults to http://localhost:5173
+ *   Playwright `baseURL` defaults to http://localhost:5173
  *   VITE_API_URL        defaults to http://localhost:8000/api/v2
  *   E2E_ADMIN_USERNAME  defaults to admin
  *   E2E_ADMIN_PASSWORD  defaults to ChangeMe!Admin2025
  */
 
 import { test, expect } from '@playwright/test';
+import { apiLogin, primeAuthSession } from './helpers/auth';
 
 // ---------------------------------------------------------------------------
 // Constants / helpers
 // ---------------------------------------------------------------------------
 
-const BASE = process.env.E2E_BASE_URL || 'http://localhost:5173';
 const API_BASE = process.env.VITE_API_URL || 'http://localhost:8000/api/v2';
 
 const ADMIN_USERNAME = process.env.E2E_ADMIN_USERNAME || 'admin';
@@ -58,24 +58,6 @@ const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD || 'ChangeMe!Admin2025';
 
 // Unique record ID — timestamp suffix avoids collisions across runs.
 const RECORD_ID = `e2e-wave7-d2-comments-${Date.now()}`;
-
-/**
- * Obtain a JWT access token via the API.
- * @param {import('@playwright/test').APIRequestContext} req
- * @param {string} username
- * @param {string} password
- * @returns {Promise<string>}
- */
-async function apiLogin(req, username, password) {
-  const resp = await req.post(`${API_BASE}/auth/login`, {
-    data: { username, password },
-  });
-  if (!resp.ok()) {
-    throw new Error(`API login failed for ${username}: ${resp.status()} ${await resp.text()}`);
-  }
-  const body = await resp.json();
-  return body.access_token;
-}
 
 /**
  * Perform a state transition via the REST endpoint.
@@ -100,29 +82,13 @@ async function apiTransition(req, token, phenopacketId, toState, reason, revisio
 }
 
 /**
- * Log in via the browser login form (standard Vuetify v-text-field pattern).
- * @param {import('@playwright/test').Page} page
- * @param {string} username
- * @param {string} password
- */
-async function loginViaForm(page, username, password) {
-  await page.goto(`${BASE}/login`);
-  await page.waitForLoadState('networkidle');
-  await page.locator('input[autocomplete="username"]').fill(username);
-  await page.locator('input[autocomplete="current-password"]').fill(password);
-  await page.locator('button[type="submit"]').click();
-  // Wait until we leave the /login route
-  await page.waitForURL((u) => !u.pathname.endsWith('/login'), { timeout: 15_000 });
-}
-
-/**
  * Navigate to the phenopacket detail page and activate the Discussion tab.
  * Waits until the CommentComposer editor is visible.
  * @param {import('@playwright/test').Page} page
  * @param {string} recordId
  */
 async function openDiscussionTab(page, recordId) {
-  await page.goto(`${BASE}/phenopackets/${recordId}`, { waitUntil: 'networkidle' });
+  await page.goto(`/phenopackets/${recordId}`, { waitUntil: 'networkidle' });
   // The Discussion tab is rendered as:
   //   <v-tab value="discussion" aria-label="Discussion tab">Discussion</v-tab>
   await page.getByRole('tab', { name: /^Discussion/i }).click();
@@ -146,7 +112,8 @@ test('comments end-to-end: post, edit, soft-delete', async ({ page, request }) =
   // We publish it so that the record is also reachable by the anonymous
   // public route (not required here, but keeps the fixture realistic).
   // -------------------------------------------------------------------------
-  const adminToken = await apiLogin(request, ADMIN_USERNAME, ADMIN_PASSWORD);
+  const adminTokens = await apiLogin(request, API_BASE, ADMIN_USERNAME, ADMIN_PASSWORD);
+  const adminToken = adminTokens.accessToken;
 
   const createResp = await request.post(`${API_BASE}/phenopackets/`, {
     headers: { Authorization: `Bearer ${adminToken}` },
@@ -190,7 +157,7 @@ test('comments end-to-end: post, edit, soft-delete', async ({ page, request }) =
   // not to re-test role permissions. CI only seeds an admin user, so this
   // also avoids fixture-dependency drift.
   // -------------------------------------------------------------------------
-  await loginViaForm(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await primeAuthSession(page, adminTokens);
   await openDiscussionTab(page, RECORD_ID);
 
   // -------------------------------------------------------------------------

--- a/frontend/tests/e2e/dual-read-invariant.spec.js
+++ b/frontend/tests/e2e/dual-read-invariant.spec.js
@@ -40,12 +40,12 @@
  */
 
 import { test, expect } from '@playwright/test';
+import { apiLogin, primeAuthSession } from './helpers/auth';
 
 // ---------------------------------------------------------------------------
 // Constants / helpers
 // ---------------------------------------------------------------------------
 
-const BASE = process.env.E2E_BASE_URL || 'http://localhost:5173';
 const API_BASE = process.env.VITE_API_URL || 'http://localhost:8000/api/v2';
 
 const ADMIN_USERNAME = process.env.E2E_ADMIN_USERNAME || 'admin';
@@ -54,24 +54,6 @@ const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD || 'ChangeMe!Admin2025';
 const RECORD_ID = `e2e-wave7-i1-${Date.now()}`;
 const ORIGINAL_SUBJECT_ID = `original-subject-${Date.now()}`;
 const DRAFT_SUBJECT_ID = `draft-subject-${Date.now()}`;
-
-/**
- * Obtain a JWT access token via the API.
- * @param {import('@playwright/test').APIRequestContext} req
- * @param {string} username
- * @param {string} password
- * @returns {Promise<string>}
- */
-async function apiLogin(req, username, password) {
-  const resp = await req.post(`${API_BASE}/auth/login`, {
-    data: { username, password },
-  });
-  if (!resp.ok()) {
-    throw new Error(`API login failed for ${username}: ${resp.status()} ${await resp.text()}`);
-  }
-  const body = await resp.json();
-  return body.access_token;
-}
 
 /**
  * Perform a state transition via the REST endpoint.
@@ -124,7 +106,8 @@ test('I1: anonymous sees old head while curator sees new draft after clone-to-dr
   // -------------------------------------------------------------------------
   // Phase 1 — API setup: create + publish a phenopacket with ORIGINAL_SUBJECT_ID
   // -------------------------------------------------------------------------
-  const adminToken = await apiLogin(request, ADMIN_USERNAME, ADMIN_PASSWORD);
+  const adminTokens = await apiLogin(request, API_BASE, ADMIN_USERNAME, ADMIN_PASSWORD);
+  const adminToken = adminTokens.accessToken;
 
   // Create draft
   const createResp = await request.post(`${API_BASE}/phenopackets/`, {
@@ -205,15 +188,8 @@ test('I1: anonymous sees old head while curator sees new draft after clone-to-dr
   // -------------------------------------------------------------------------
   // Phase 3 — Browser (admin): detail page shows DRAFT_SUBJECT_ID
   // -------------------------------------------------------------------------
-  await page.goto(`${BASE}/login`);
-  await page.waitForLoadState('networkidle');
-
-  await page.locator('input[autocomplete="username"]').fill(ADMIN_USERNAME);
-  await page.locator('input[autocomplete="current-password"]').fill(ADMIN_PASSWORD);
-  await page.locator('button[type="submit"]').click();
-  await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 15_000 });
-
-  await page.goto(`${BASE}/phenopackets/${RECORD_ID}`, { waitUntil: 'networkidle' });
+  await primeAuthSession(page, adminTokens);
+  await page.goto(`/phenopackets/${RECORD_ID}`, { waitUntil: 'networkidle' });
 
   // Curator sees the NEW draft content (working copy contains DRAFT_SUBJECT_ID)
   await expect(page.getByText(DRAFT_SUBJECT_ID).first()).toBeVisible({ timeout: 10_000 });
@@ -225,7 +201,7 @@ test('I1: anonymous sees old head while curator sees new draft after clone-to-dr
   const anonPage = await anonCtx.newPage();
 
   try {
-    await anonPage.goto(`${BASE}/phenopackets/${RECORD_ID}`, {
+    await anonPage.goto(`/phenopackets/${RECORD_ID}`, {
       waitUntil: 'networkidle',
       timeout: 30_000,
     });
@@ -249,7 +225,8 @@ test('I1: anonymous sees old head while curator sees new draft after clone-to-dr
   // head). This is the key test of the D.2 effective-state routing: the
   // whole review cycle must work while pp.state stays 'published' (I8).
   // -------------------------------------------------------------------------
-  const curatorToken = await apiLogin(request, ADMIN_USERNAME, ADMIN_PASSWORD);
+  const curatorToken = (await apiLogin(request, API_BASE, ADMIN_USERNAME, ADMIN_PASSWORD))
+    .accessToken;
 
   // Read the current revision from the API (after clone, pp.revision has advanced).
   const detailResp = await request.get(`${API_BASE}/phenopackets/${RECORD_ID}`, {
@@ -290,7 +267,7 @@ test('I1: anonymous sees old head while curator sees new draft after clone-to-dr
   const anonCtx2 = await context.browser().newContext();
   const anonPage2 = await anonCtx2.newPage();
   try {
-    await anonPage2.goto(`${BASE}/phenopackets/${RECORD_ID}`, {
+    await anonPage2.goto(`/phenopackets/${RECORD_ID}`, {
       waitUntil: 'networkidle',
       timeout: 30_000,
     });

--- a/frontend/tests/e2e/helpers/auth.js
+++ b/frontend/tests/e2e/helpers/auth.js
@@ -1,0 +1,44 @@
+/**
+ * Helpers for API-backed Playwright authentication setup.
+ *
+ * These specs are not testing the login form itself. Priming the browser
+ * session via API-issued tokens keeps the tests focused and avoids flaky
+ * UI-auth setup work.
+ */
+
+/**
+ * Obtain fresh auth tokens via the API.
+ * @param {import('@playwright/test').APIRequestContext} req
+ * @param {string} apiBase
+ * @param {string} username
+ * @param {string} password
+ * @returns {Promise<{accessToken: string, refreshToken: string}>}
+ */
+export async function apiLogin(req, apiBase, username, password) {
+  const resp = await req.post(`${apiBase}/auth/login`, {
+    data: { username, password },
+  });
+  if (!resp.ok()) {
+    throw new Error(`API login failed for ${username}: ${resp.status()} ${await resp.text()}`);
+  }
+  const body = await resp.json();
+  return {
+    accessToken: body.access_token,
+    refreshToken: body.refresh_token,
+  };
+}
+
+/**
+ * Seed the browser tab's auth session before the app bootstraps.
+ * @param {import('@playwright/test').Page} page
+ * @param {{ accessToken: string, refreshToken: string }} tokens
+ * @returns {Promise<void>}
+ */
+export async function primeAuthSession(page, tokens) {
+  await page.addInitScript(({ accessToken, refreshToken }) => {
+    window.localStorage.removeItem('remember_me');
+    window.localStorage.removeItem('remembered_username');
+    window.sessionStorage.setItem('access_token', accessToken);
+    window.sessionStorage.setItem('refresh_token', refreshToken);
+  }, tokens);
+}

--- a/frontend/tests/e2e/phenopacket-ui-review.spec.js
+++ b/frontend/tests/e2e/phenopacket-ui-review.spec.js
@@ -18,7 +18,7 @@ test.describe('Phenopacket Page UI Review', () => {
       console.log(`\n=== Capturing ${id} ===`);
 
       // Navigate to phenopacket page
-      await page.goto(`http://localhost:5173/phenopackets/${id}`, {
+      await page.goto(`/phenopackets/${id}`, {
         waitUntil: 'networkidle',
         timeout: 30000,
       });
@@ -90,7 +90,7 @@ test.describe('Phenopacket Page UI Review', () => {
 
   test('accessibility audit for phenopacket page', async ({ page }) => {
     // Navigate to a representative phenopacket page
-    await page.goto('http://localhost:5173/phenopackets/phenopacket-415', {
+    await page.goto('/phenopackets/phenopacket-415', {
       waitUntil: 'networkidle',
       timeout: 30000,
     });
@@ -181,7 +181,7 @@ test.describe('Phenopacket Page UI Review', () => {
   });
 
   test('layout density analysis', async ({ page }) => {
-    await page.goto('http://localhost:5173/phenopackets/phenopacket-415', {
+    await page.goto('/phenopackets/phenopacket-415', {
       waitUntil: 'networkidle',
       timeout: 30000,
     });

--- a/frontend/tests/e2e/state-lifecycle.spec.js
+++ b/frontend/tests/e2e/state-lifecycle.spec.js
@@ -38,12 +38,12 @@
  */
 
 import { test, expect } from '@playwright/test';
+import { apiLogin, primeAuthSession } from './helpers/auth';
 
 // ---------------------------------------------------------------------------
 // Constants / helpers
 // ---------------------------------------------------------------------------
 
-const BASE = process.env.E2E_BASE_URL || 'http://localhost:5173';
 const API_BASE = process.env.VITE_API_URL || 'http://localhost:8000/api/v2';
 
 const ADMIN_USERNAME = process.env.E2E_ADMIN_USERNAME || 'admin';
@@ -51,24 +51,6 @@ const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD || 'ChangeMe!Admin2025';
 
 // Unique test record ID — timestamp suffix avoids collisions between runs.
 const RECORD_ID = `e2e-wave7-lifecycle-${Date.now()}`;
-
-/**
- * Obtain a JWT access token for the given credentials via the API.
- * @param {import('@playwright/test').APIRequestContext} req
- * @param {string} username
- * @param {string} password
- * @returns {Promise<string>} Bearer token
- */
-async function apiLogin(req, username, password) {
-  const resp = await req.post(`${API_BASE}/auth/login`, {
-    data: { username, password },
-  });
-  if (!resp.ok()) {
-    throw new Error(`API login failed for ${username}: ${resp.status()} ${await resp.text()}`);
-  }
-  const body = await resp.json();
-  return body.access_token;
-}
 
 /**
  * Perform a state transition via the backend REST endpoint.
@@ -107,7 +89,8 @@ test('full state lifecycle: create draft → in_review → approved → publishe
   // -------------------------------------------------------------------------
   // Step 1 — API: authenticate as admin + create test phenopacket
   // -------------------------------------------------------------------------
-  const adminToken = await apiLogin(request, ADMIN_USERNAME, ADMIN_PASSWORD);
+  const adminTokens = await apiLogin(request, API_BASE, ADMIN_USERNAME, ADMIN_PASSWORD);
+  const adminToken = adminTokens.accessToken;
 
   const createResp = await request.post(`${API_BASE}/phenopackets/`, {
     headers: { Authorization: `Bearer ${adminToken}` },
@@ -141,21 +124,12 @@ test('full state lifecycle: create draft → in_review → approved → publishe
   expect(created.state).toBe('draft');
 
   // -------------------------------------------------------------------------
-  // Step 2 — Browser: login as admin, navigate to detail page, verify badge
+  // Step 2 — Browser: prime an authenticated session, navigate to detail page, verify badge
   // -------------------------------------------------------------------------
-  await page.goto(`${BASE}/login`);
-  await page.waitForLoadState('networkidle');
-
-  // Fill the standard login form (Vuetify v-text-field with autocomplete attrs)
-  await page.locator('input[autocomplete="username"]').fill(ADMIN_USERNAME);
-  await page.locator('input[autocomplete="current-password"]').fill(ADMIN_PASSWORD);
-  await page.locator('button[type="submit"]').click();
-
-  // Wait until we leave the /login route
-  await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 15_000 });
+  await primeAuthSession(page, adminTokens);
 
   // Navigate to the detail page for our new record
-  await page.goto(`${BASE}/phenopackets/${RECORD_ID}`, { waitUntil: 'networkidle' });
+  await page.goto(`/phenopackets/${RECORD_ID}`, { waitUntil: 'networkidle' });
 
   // StateBadge chip should show "Draft"
   await expect(page.locator('.v-chip', { hasText: 'Draft' }).first()).toBeVisible({
@@ -224,7 +198,7 @@ test('full state lifecycle: create draft → in_review → approved → publishe
   const anonPage = await anonCtx.newPage();
 
   try {
-    await anonPage.goto(`${BASE}/phenopackets/${RECORD_ID}`, {
+    await anonPage.goto(`/phenopackets/${RECORD_ID}`, {
       waitUntil: 'networkidle',
       timeout: 30_000,
     });

--- a/frontend/tests/e2e/table-url-state.spec.js
+++ b/frontend/tests/e2e/table-url-state.spec.js
@@ -8,8 +8,6 @@ import { test, expect } from '@playwright/test';
  * synchronized with URL parameters for shareable/bookmarkable links.
  */
 
-const BASE_URL = 'http://localhost:5173';
-
 test.describe('Variants Table URL State', () => {
   // FIXME(wave-6-exit): pagination control no longer renders literal
   // "Page 2" text — the AppPagination component now uses numeric
@@ -19,7 +17,7 @@ test.describe('Variants Table URL State', () => {
   // previously-silent failures now gate merges.
   test.fixme('should preserve page parameter in URL', async ({ page }) => {
     // Navigate to page 2
-    await page.goto(`${BASE_URL}/variants?page=2&pageSize=10`);
+    await page.goto('/variants?page=2&pageSize=10');
     await page.waitForLoadState('networkidle');
 
     // Verify URL contains page parameter
@@ -31,7 +29,7 @@ test.describe('Variants Table URL State', () => {
   });
 
   test('should update URL when navigating pages', async ({ page }) => {
-    await page.goto(`${BASE_URL}/variants`);
+    await page.goto('/variants');
     await page.waitForLoadState('networkidle');
 
     // Click next page button
@@ -49,7 +47,7 @@ test.describe('Variants Table URL State', () => {
 
   test('should preserve search query in URL', async ({ page }) => {
     // Navigate with search query
-    await page.goto(`${BASE_URL}/variants?q=c.826`);
+    await page.goto('/variants?q=c.826');
     await page.waitForLoadState('networkidle');
 
     // Verify search input has the value
@@ -61,7 +59,7 @@ test.describe('Variants Table URL State', () => {
   });
 
   test('should update URL when searching', async ({ page }) => {
-    await page.goto(`${BASE_URL}/variants`);
+    await page.goto('/variants');
     await page.waitForLoadState('networkidle');
 
     // Type in search box
@@ -76,7 +74,7 @@ test.describe('Variants Table URL State', () => {
 
   test('should preserve sort parameter in URL', async ({ page }) => {
     // Navigate with descending sort on transcript
-    await page.goto(`${BASE_URL}/variants?sort=-transcript`);
+    await page.goto('/variants?sort=-transcript');
     await page.waitForLoadState('networkidle');
 
     // Verify URL contains sort parameter
@@ -84,7 +82,7 @@ test.describe('Variants Table URL State', () => {
   });
 
   test('should preserve type filter in URL', async ({ page }) => {
-    await page.goto(`${BASE_URL}/variants?type=SNV`);
+    await page.goto('/variants?type=SNV');
     await page.waitForLoadState('networkidle');
 
     // Verify URL contains filter
@@ -92,7 +90,7 @@ test.describe('Variants Table URL State', () => {
   });
 
   test('should preserve classification filter in URL', async ({ page }) => {
-    await page.goto(`${BASE_URL}/variants?classification=PATHOGENIC`);
+    await page.goto('/variants?classification=PATHOGENIC');
     await page.waitForLoadState('networkidle');
 
     // Verify URL contains filter
@@ -108,7 +106,7 @@ test.describe('Variants Table URL State', () => {
   // real gate.
   test.fixme('should handle combined URL parameters', async ({ page }) => {
     // Navigate with multiple parameters
-    await page.goto(`${BASE_URL}/variants?page=1&pageSize=20&sort=-simple_id&q=c.826&type=SNV`);
+    await page.goto('/variants?page=1&pageSize=20&sort=-simple_id&q=c.826&type=SNV');
     await page.waitForLoadState('networkidle');
 
     // Verify all parameters are in URL
@@ -120,7 +118,7 @@ test.describe('Variants Table URL State', () => {
   });
 
   test('partial HGVS search should work without error', async ({ page }) => {
-    await page.goto(`${BASE_URL}/variants`);
+    await page.goto('/variants');
     await page.waitForLoadState('networkidle');
 
     // Type partial HGVS (this used to return 400 error)
@@ -140,14 +138,14 @@ test.describe('Variants Table URL State', () => {
 
 test.describe('Phenopackets Table URL State', () => {
   test('should preserve page parameter in URL', async ({ page }) => {
-    await page.goto(`${BASE_URL}/phenopackets?page=2&pageSize=10`);
+    await page.goto('/phenopackets?page=2&pageSize=10');
     await page.waitForLoadState('networkidle');
 
     expect(page.url()).toContain('page=2');
   });
 
   test('should preserve search query in URL', async ({ page }) => {
-    await page.goto(`${BASE_URL}/phenopackets?q=test`);
+    await page.goto('/phenopackets?q=test');
     await page.waitForLoadState('networkidle');
 
     const searchInput = page.locator('input[placeholder*="Search"]').first();
@@ -156,14 +154,14 @@ test.describe('Phenopackets Table URL State', () => {
   });
 
   test('should preserve sex filter in URL', async ({ page }) => {
-    await page.goto(`${BASE_URL}/phenopackets?sex=MALE`);
+    await page.goto('/phenopackets?sex=MALE');
     await page.waitForLoadState('networkidle');
 
     expect(page.url()).toContain('sex=MALE');
   });
 
   test('should update URL when using sex filter', async ({ page }) => {
-    await page.goto(`${BASE_URL}/phenopackets`);
+    await page.goto('/phenopackets');
     await page.waitForLoadState('networkidle');
 
     // Find and click the sex filter icon (in the column header)
@@ -184,7 +182,7 @@ test.describe('Phenopackets Table URL State', () => {
   });
 
   test('should clear filters and update URL', async ({ page }) => {
-    await page.goto(`${BASE_URL}/phenopackets?q=test&sex=MALE`);
+    await page.goto('/phenopackets?q=test&sex=MALE');
     await page.waitForLoadState('networkidle');
 
     // Find and click clear filters button
@@ -203,14 +201,14 @@ test.describe('Phenopackets Table URL State', () => {
 
 test.describe('Publications Table URL State', () => {
   test('should preserve page parameter in URL', async ({ page }) => {
-    await page.goto(`${BASE_URL}/publications?page=2&pageSize=10`);
+    await page.goto('/publications?page=2&pageSize=10');
     await page.waitForLoadState('networkidle');
 
     expect(page.url()).toContain('page=2');
   });
 
   test('should preserve search query in URL', async ({ page }) => {
-    await page.goto(`${BASE_URL}/publications?q=kidney`);
+    await page.goto('/publications?q=kidney');
     await page.waitForLoadState('networkidle');
 
     const searchInput = page.locator('input[placeholder*="Search"]').first();
@@ -219,14 +217,14 @@ test.describe('Publications Table URL State', () => {
   });
 
   test('should preserve sort parameter in URL', async ({ page }) => {
-    await page.goto(`${BASE_URL}/publications?sort=-first_added`);
+    await page.goto('/publications?sort=-first_added');
     await page.waitForLoadState('networkidle');
 
     expect(page.url()).toContain('sort=-first_added');
   });
 
   test('should handle pageSize parameter', async ({ page }) => {
-    await page.goto(`${BASE_URL}/publications?pageSize=50`);
+    await page.goto('/publications?pageSize=50');
     await page.waitForLoadState('networkidle');
 
     expect(page.url()).toContain('pageSize=50');
@@ -236,7 +234,7 @@ test.describe('Publications Table URL State', () => {
 test.describe('URL State Shareable Links', () => {
   test('should produce identical results when sharing URL', async ({ page, context }) => {
     // First user sets up filters
-    await page.goto(`${BASE_URL}/variants`);
+    await page.goto('/variants');
     await page.waitForLoadState('networkidle');
 
     // Apply search

--- a/frontend/tests/unit/api/session.spec.js
+++ b/frontend/tests/unit/api/session.spec.js
@@ -1,77 +1,63 @@
 /**
- * session.spec.js — Token storage contract tests for src/api/session.js
+ * session.spec.js — In-memory token session tests for src/api/session.js
  *
- * Verifies localStorage round-trips, partial persistence, clearTokens,
- * and absent-token handling.
+ * Verifies tokens live only in module memory and that localStorage is
+ * not consulted or mutated.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { getAccessToken, getRefreshToken, persistTokens, clearTokens } from '@/api/session';
 
-describe('session — token storage contract', () => {
-  /** @type {Record<string, string>} */
-  let store;
+describe('session — in-memory token session', () => {
+  const localStorageMock = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  };
 
   beforeEach(() => {
-    store = {};
-    // Provide a minimal localStorage stub for happy-dom
+    clearTokens();
+    vi.clearAllMocks();
+
     Object.defineProperty(globalThis, 'localStorage', {
-      value: {
-        getItem: (key) => store[key] ?? null,
-        setItem: (key, value) => {
-          store[key] = String(value);
-        },
-        removeItem: (key) => {
-          delete store[key];
-        },
-        clear: () => {
-          store = {};
-        },
-      },
+      value: localStorageMock,
       writable: true,
       configurable: true,
     });
   });
 
-  it('returns null when no tokens are stored', () => {
+  it('starts empty and ignores stale localStorage entries', () => {
+    localStorageMock.getItem.mockReturnValueOnce('stale-access');
+    localStorageMock.getItem.mockReturnValueOnce('stale-refresh');
+
     expect(getAccessToken()).toBeNull();
     expect(getRefreshToken()).toBeNull();
+    expect(localStorageMock.getItem).not.toHaveBeenCalled();
   });
 
-  it('round-trips both tokens through persistTokens', () => {
+  it('persists tokens only in memory', () => {
     persistTokens({ accessToken: 'a-tok', refreshToken: 'r-tok' });
+
     expect(getAccessToken()).toBe('a-tok');
     expect(getRefreshToken()).toBe('r-tok');
+    expect(localStorageMock.setItem).not.toHaveBeenCalled();
   });
 
-  it('persists only the accessToken when refreshToken is omitted', () => {
-    persistTokens({ accessToken: 'a-only' });
-    expect(getAccessToken()).toBe('a-only');
-    expect(getRefreshToken()).toBeNull();
-  });
-
-  it('persists only the refreshToken when accessToken is omitted', () => {
-    persistTokens({ refreshToken: 'r-only' });
-    expect(getAccessToken()).toBeNull();
-    expect(getRefreshToken()).toBe('r-only');
-  });
-
-  it('clearTokens removes both tokens', () => {
-    persistTokens({ accessToken: 'a', refreshToken: 'r' });
-    clearTokens();
-    expect(getAccessToken()).toBeNull();
-    expect(getRefreshToken()).toBeNull();
-  });
-
-  it('clearTokens is safe when no tokens exist', () => {
-    // Should not throw
-    clearTokens();
-    expect(getAccessToken()).toBeNull();
-  });
-
-  it('overwrites existing tokens on re-persist', () => {
+  it('overwrites existing in-memory tokens on re-persist', () => {
     persistTokens({ accessToken: 'old-a', refreshToken: 'old-r' });
     persistTokens({ accessToken: 'new-a', refreshToken: 'new-r' });
+
     expect(getAccessToken()).toBe('new-a');
     expect(getRefreshToken()).toBe('new-r');
+  });
+
+  it('clears tokens from memory without touching localStorage', () => {
+    persistTokens({ accessToken: 'a', refreshToken: 'r' });
+
+    clearTokens();
+
+    expect(getAccessToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+    expect(localStorageMock.removeItem).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/unit/api/session.spec.js
+++ b/frontend/tests/unit/api/session.spec.js
@@ -1,22 +1,34 @@
 /**
- * session.spec.js — In-memory token session tests for src/api/session.js
+ * session.spec.js — tab-scoped token session tests for src/api/session.js
  *
- * Verifies tokens live only in module memory and that localStorage is
- * not consulted or mutated.
+ * Verifies tokens are cached in memory, persisted to sessionStorage for the
+ * lifetime of the browser tab, and legacy localStorage keys are purged.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { getAccessToken, getRefreshToken, persistTokens, clearTokens } from '@/api/session';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('session — in-memory token session', () => {
+describe('session — tab-scoped token session', () => {
+  let clearTokens;
+  let getAccessToken;
+  let getRefreshToken;
+  let persistTokens;
+
   const localStorageMock = {
+    removeItem: vi.fn(),
+  };
+
+  const sessionStorageMock = {
     getItem: vi.fn(),
     setItem: vi.fn(),
     removeItem: vi.fn(),
-    clear: vi.fn(),
   };
 
-  beforeEach(() => {
-    clearTokens();
+  async function loadSessionModule() {
+    ({ clearTokens, getAccessToken, getRefreshToken, persistTokens } =
+      await import('@/api/session'));
+  }
+
+  beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
 
     Object.defineProperty(globalThis, 'localStorage', {
@@ -24,26 +36,39 @@ describe('session — in-memory token session', () => {
       writable: true,
       configurable: true,
     });
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      value: sessionStorageMock,
+      writable: true,
+      configurable: true,
+    });
+
+    await loadSessionModule();
   });
 
-  it('starts empty and ignores stale localStorage entries', () => {
-    localStorageMock.getItem.mockReturnValueOnce('stale-access');
-    localStorageMock.getItem.mockReturnValueOnce('stale-refresh');
-
+  it('starts empty when the current tab has no stored tokens', () => {
     expect(getAccessToken()).toBeNull();
     expect(getRefreshToken()).toBeNull();
-    expect(localStorageMock.getItem).not.toHaveBeenCalled();
+    expect(sessionStorageMock.getItem).toHaveBeenCalledWith('access_token');
+    expect(sessionStorageMock.getItem).toHaveBeenCalledWith('refresh_token');
   });
 
-  it('persists tokens only in memory', () => {
+  it('purges legacy localStorage token keys during module initialization', async () => {
+    await loadSessionModule();
+
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('access_token');
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('refresh_token');
+  });
+
+  it('persists tokens in memory and sessionStorage', () => {
     persistTokens({ accessToken: 'a-tok', refreshToken: 'r-tok' });
 
     expect(getAccessToken()).toBe('a-tok');
     expect(getRefreshToken()).toBe('r-tok');
-    expect(localStorageMock.setItem).not.toHaveBeenCalled();
+    expect(sessionStorageMock.setItem).toHaveBeenCalledWith('access_token', 'a-tok');
+    expect(sessionStorageMock.setItem).toHaveBeenCalledWith('refresh_token', 'r-tok');
   });
 
-  it('overwrites existing in-memory tokens on re-persist', () => {
+  it('overwrites existing tokens on re-persist', () => {
     persistTokens({ accessToken: 'old-a', refreshToken: 'old-r' });
     persistTokens({ accessToken: 'new-a', refreshToken: 'new-r' });
 
@@ -51,13 +76,32 @@ describe('session — in-memory token session', () => {
     expect(getRefreshToken()).toBe('new-r');
   });
 
-  it('clears tokens from memory without touching localStorage', () => {
+  it('clears tokens from memory, sessionStorage, and legacy localStorage keys', () => {
     persistTokens({ accessToken: 'a', refreshToken: 'r' });
 
+    localStorageMock.removeItem.mockClear();
+    sessionStorageMock.removeItem.mockClear();
     clearTokens();
 
     expect(getAccessToken()).toBeNull();
     expect(getRefreshToken()).toBeNull();
-    expect(localStorageMock.removeItem).not.toHaveBeenCalled();
+    expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('access_token');
+    expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('refresh_token');
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('access_token');
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('refresh_token');
+  });
+
+  it('restores tokens from sessionStorage on module load', async () => {
+    vi.resetModules();
+    sessionStorageMock.getItem.mockImplementation((key) => {
+      if (key === 'access_token') return 'saved-access';
+      if (key === 'refresh_token') return 'saved-refresh';
+      return null;
+    });
+
+    await loadSessionModule();
+
+    expect(getAccessToken()).toBe('saved-access');
+    expect(getRefreshToken()).toBe('saved-refresh');
   });
 });

--- a/frontend/tests/unit/api/transport.spec.js
+++ b/frontend/tests/unit/api/transport.spec.js
@@ -48,6 +48,7 @@ vi.mock('axios', () => ({
 // Mock session — so the request interceptor can read the access token
 vi.mock('@/api/session', () => ({
   getAccessToken: vi.fn(() => 'initial-token'),
+  clearTokens: vi.fn(),
 }));
 
 // Mock auth store — refreshAccessToken resolves with a new token
@@ -174,5 +175,7 @@ describe('transport — refresh-queue thunder-herd guard', () => {
 
     // Still only one refresh attempt
     expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+    const { clearTokens } = await import('@/api/session');
+    expect(clearTokens).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/tests/unit/config/devAuth.spec.js
+++ b/frontend/tests/unit/config/devAuth.spec.js
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  getDevQuickLoginBackendUnavailableMessage,
+  getDevQuickLoginDisabledMessage,
+  isDevQuickLoginEnabled,
+} from '@/config/devAuth';
+
+describe('devAuth config helpers', () => {
+  const originalDev = import.meta.env.DEV;
+  const originalFlag = import.meta.env.VITE_ENABLE_DEV_AUTH;
+
+  afterEach(() => {
+    import.meta.env.DEV = originalDev;
+    import.meta.env.VITE_ENABLE_DEV_AUTH = originalFlag;
+  });
+
+  it('requires both dev mode and an explicit enable flag', () => {
+    import.meta.env.DEV = true;
+    import.meta.env.VITE_ENABLE_DEV_AUTH = 'false';
+    expect(isDevQuickLoginEnabled()).toBe(false);
+
+    import.meta.env.VITE_ENABLE_DEV_AUTH = 'true';
+    expect(isDevQuickLoginEnabled()).toBe(true);
+
+    import.meta.env.DEV = false;
+    expect(isDevQuickLoginEnabled()).toBe(false);
+  });
+
+  it('accepts common truthy flag spellings', () => {
+    import.meta.env.DEV = true;
+
+    for (const value of ['1', 'true', 'TRUE', 'yes', 'On']) {
+      import.meta.env.VITE_ENABLE_DEV_AUTH = value;
+      expect(isDevQuickLoginEnabled()).toBe(true);
+    }
+  });
+
+  it('returns user-facing misconfiguration messages', () => {
+    expect(getDevQuickLoginDisabledMessage()).toContain('VITE_ENABLE_DEV_AUTH');
+    expect(getDevQuickLoginBackendUnavailableMessage()).toContain('ENABLE_DEV_AUTH=true');
+  });
+});

--- a/frontend/tests/unit/stores/authStore.spec.js
+++ b/frontend/tests/unit/stores/authStore.spec.js
@@ -1,19 +1,14 @@
 /**
  * Unit tests for the authentication store (authStore)
  *
- * Tests cover:
- * - State initialization
- * - Computed properties (isAuthenticated, isAdmin, isCurator, userPermissions)
- * - Login flow with token storage
- * - Logout with cleanup
- * - Token refresh
- * - User fetching
- * - Password change
- * - Store initialization from localStorage
+ * Covers the public auth flows against the release-safe in-memory
+ * session helpers rather than persistent browser storage.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
+
+import { clearTokens, getAccessToken, getRefreshToken, persistTokens } from '@/api/session';
 
 // Mock the API module with named export - must be before imports that use it
 vi.mock('@/api', () => ({
@@ -27,30 +22,8 @@ vi.mock('@/api', () => ({
 import { useAuthStore } from '@/stores/authStore';
 import { apiClient } from '@/api';
 
-// Mock localStorage
-const localStorageMock = (() => {
-  let store = {};
-  return {
-    getItem: vi.fn((key) => store[key] || null),
-    setItem: vi.fn((key, value) => {
-      // Handle undefined/null values gracefully
-      store[key] = value != null ? value.toString() : '';
-    }),
-    removeItem: vi.fn((key) => {
-      delete store[key];
-    }),
-    clear: vi.fn(() => {
-      store = {};
-    }),
-  };
-})();
-
-Object.defineProperty(window, 'localStorage', {
-  value: localStorageMock,
-});
-
-// Mock window.logService
-window.logService = {
+globalThis.window = globalThis.window || {};
+globalThis.window.logService = {
   info: vi.fn(),
   error: vi.fn(),
   warn: vi.fn(),
@@ -59,24 +32,20 @@ window.logService = {
 
 describe('Auth Store', () => {
   beforeEach(() => {
-    // Create a fresh Pinia instance for each test
     setActivePinia(createPinia());
-
-    // Clear mocks
+    clearTokens();
     vi.clearAllMocks();
-    localStorageMock.clear();
-
-    // Reset API client mocks explicitly
     apiClient.post.mockReset();
     apiClient.get.mockReset();
   });
 
   afterEach(() => {
+    clearTokens();
     vi.restoreAllMocks();
   });
 
   describe('Initial State', () => {
-    it('should initialize with null user and tokens', () => {
+    it('initializes with null user and no tokens', () => {
       const authStore = useAuthStore();
 
       expect(authStore.user).toBeNull();
@@ -84,11 +53,12 @@ describe('Auth Store', () => {
       expect(authStore.refreshToken).toBeNull();
       expect(authStore.isLoading).toBe(false);
       expect(authStore.error).toBeNull();
+      expect(getAccessToken()).toBeNull();
+      expect(getRefreshToken()).toBeNull();
     });
 
-    it('should initialize with token from localStorage if present', () => {
-      localStorageMock.setItem('access_token', 'mock_access_token');
-      localStorageMock.setItem('refresh_token', 'mock_refresh_token');
+    it('initializes from the in-memory session when tokens already exist', () => {
+      persistTokens({ accessToken: 'mock_access_token', refreshToken: 'mock_refresh_token' });
 
       const authStore = useAuthStore();
 
@@ -98,85 +68,62 @@ describe('Auth Store', () => {
   });
 
   describe('Computed Properties', () => {
-    it('should compute isAuthenticated correctly', () => {
+    it('computes isAuthenticated correctly', () => {
       const authStore = useAuthStore();
 
-      // Not authenticated initially
       expect(authStore.isAuthenticated).toBe(false);
 
-      // Set token but no user - still not authenticated
       authStore.accessToken = 'test_token';
       expect(authStore.isAuthenticated).toBe(false);
 
-      // Set user but no token - still not authenticated
       authStore.accessToken = null;
       authStore.user = { username: 'test' };
       expect(authStore.isAuthenticated).toBe(false);
 
-      // Both token and user - authenticated
       authStore.accessToken = 'test_token';
       authStore.user = { username: 'test' };
       expect(authStore.isAuthenticated).toBe(true);
     });
 
-    it('should compute isAdmin correctly', () => {
+    it('computes role helpers correctly', () => {
       const authStore = useAuthStore();
 
       expect(authStore.isAdmin).toBe(false);
-
-      authStore.user = { role: 'viewer' };
-      expect(authStore.isAdmin).toBe(false);
+      expect(authStore.isCurator).toBe(false);
 
       authStore.user = { role: 'curator' };
       expect(authStore.isAdmin).toBe(false);
+      expect(authStore.isCurator).toBe(true);
 
       authStore.user = { role: 'admin' };
       expect(authStore.isAdmin).toBe(true);
-    });
-
-    it('should compute isCurator correctly', () => {
-      const authStore = useAuthStore();
-
-      expect(authStore.isCurator).toBe(false);
-
-      authStore.user = { role: 'viewer' };
-      expect(authStore.isCurator).toBe(false);
-
-      authStore.user = { role: 'curator' };
-      expect(authStore.isCurator).toBe(true);
-
-      // Admin is also considered a curator
-      authStore.user = { role: 'admin' };
       expect(authStore.isCurator).toBe(true);
     });
 
-    it('should compute userPermissions correctly', () => {
+    it('returns permissions from the current user', () => {
       const authStore = useAuthStore();
 
       expect(authStore.userPermissions).toEqual([]);
 
-      authStore.user = {
-        permissions: ['read:data', 'write:data', 'delete:data'],
-      };
-
-      expect(authStore.userPermissions).toEqual(['read:data', 'write:data', 'delete:data']);
+      authStore.user = { permissions: ['read:data', 'write:data'] };
+      expect(authStore.userPermissions).toEqual(['read:data', 'write:data']);
     });
   });
 
   describe('Login Action', () => {
-    it('should login successfully and store tokens', async () => {
+    it('stores issued tokens in memory and loads the current user', async () => {
       const authStore = useAuthStore();
 
-      const mockResponse = {
+      apiClient.post.mockResolvedValueOnce({
         data: {
           access_token: 'mock_access_token',
           refresh_token: 'mock_refresh_token',
           token_type: 'bearer',
           expires_in: 1800,
         },
-      };
+      });
 
-      const mockUserResponse = {
+      apiClient.get.mockResolvedValueOnce({
         data: {
           id: 1,
           username: 'testuser',
@@ -184,10 +131,7 @@ describe('Auth Store', () => {
           role: 'viewer',
           permissions: ['phenopackets:read'],
         },
-      };
-
-      apiClient.post.mockResolvedValueOnce(mockResponse);
-      apiClient.get.mockResolvedValueOnce(mockUserResponse);
+      });
 
       const success = await authStore.login({
         username: 'testuser',
@@ -197,83 +141,60 @@ describe('Auth Store', () => {
       expect(success).toBe(true);
       expect(authStore.accessToken).toBe('mock_access_token');
       expect(authStore.refreshToken).toBe('mock_refresh_token');
-      expect(authStore.user).toEqual(mockUserResponse.data);
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('access_token', 'mock_access_token');
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('refresh_token', 'mock_refresh_token');
+      expect(authStore.user.username).toBe('testuser');
+      expect(getAccessToken()).toBe('mock_access_token');
+      expect(getRefreshToken()).toBe('mock_refresh_token');
       expect(window.logService.info).toHaveBeenCalledWith('User logged in successfully', {
         username: 'testuser',
       });
     });
 
-    it('should handle login failure', async () => {
+    it('clears the error state before a new login attempt', async () => {
       const authStore = useAuthStore();
+      authStore.error = 'Previous error';
 
-      const mockError = {
-        response: {
-          data: {
-            detail: 'Invalid credentials',
-          },
+      apiClient.post.mockResolvedValueOnce({
+        data: {
+          access_token: 'token',
+          refresh_token: 'refresh',
+          token_type: 'bearer',
+          expires_in: 1800,
         },
-      };
-
-      apiClient.post.mockRejectedValueOnce(mockError);
-
-      // login() throws error on failure
-      await expect(
-        authStore.login({
-          username: 'testuser',
-          password: 'wrongpassword',
-        })
-      ).rejects.toThrow();
-
-      expect(authStore.error).toBe('Invalid credentials');
-      expect(window.logService.error).toHaveBeenCalled();
-    });
-
-    it('should set loading state during login', async () => {
-      const authStore = useAuthStore();
-
-      apiClient.post.mockImplementation(
-        () =>
-          new Promise((resolve) =>
-            setTimeout(() => {
-              resolve({
-                data: {
-                  access_token: 'token',
-                  refresh_token: 'refresh',
-                  token_type: 'bearer',
-                  expires_in: 1800,
-                },
-              });
-            }, 100)
-          )
-      );
-
+      });
       apiClient.get.mockResolvedValueOnce({
         data: { id: 1, username: 'test' },
       });
 
-      const loginPromise = authStore.login({
-        username: 'test',
-        password: 'pass',
+      await authStore.login({ username: 'test', password: 'pass' });
+
+      expect(authStore.error).toBeNull();
+    });
+
+    it('surfaces login failures without mutating the session', async () => {
+      const authStore = useAuthStore();
+
+      apiClient.post.mockRejectedValueOnce({
+        response: { data: { detail: 'Invalid credentials' } },
       });
 
-      expect(authStore.isLoading).toBe(true);
+      await expect(
+        authStore.login({ username: 'testuser', password: 'wrongpassword' })
+      ).rejects.toThrow();
 
-      await loginPromise;
-
-      expect(authStore.isLoading).toBe(false);
+      expect(authStore.error).toBe('Invalid credentials');
+      expect(getAccessToken()).toBeNull();
+      expect(getRefreshToken()).toBeNull();
     });
   });
 
   describe('Logout Action', () => {
-    it('should logout and clear tokens', async () => {
+    it('clears the session tokens and local store state', async () => {
       const authStore = useAuthStore();
 
-      // Set up authenticated state
       authStore.accessToken = 'test_token';
       authStore.refreshToken = 'test_refresh';
       authStore.user = { username: 'test', id: 1 };
+      persistTokens({ accessToken: 'test_token', refreshToken: 'test_refresh' });
 
       apiClient.post.mockResolvedValueOnce({
         data: { message: 'Logged out successfully' },
@@ -284,35 +205,36 @@ describe('Auth Store', () => {
       expect(authStore.accessToken).toBeNull();
       expect(authStore.refreshToken).toBeNull();
       expect(authStore.user).toBeNull();
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('access_token');
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('refresh_token');
+      expect(getAccessToken()).toBeNull();
+      expect(getRefreshToken()).toBeNull();
       expect(window.logService.info).toHaveBeenCalledWith('User logged out');
     });
 
-    it('should handle logout API failure gracefully', async () => {
+    it('still clears the session if the backend logout call fails', async () => {
       const authStore = useAuthStore();
 
       authStore.accessToken = 'test_token';
       authStore.user = { username: 'test' };
+      persistTokens({ accessToken: 'test_token', refreshToken: 'test_refresh' });
 
       apiClient.post.mockRejectedValueOnce(new Error('API Error'));
 
       await authStore.logout();
 
-      // Should still clear local state even if API call fails
       expect(authStore.accessToken).toBeNull();
       expect(authStore.user).toBeNull();
-      expect(localStorageMock.removeItem).toHaveBeenCalled();
+      expect(getAccessToken()).toBeNull();
+      expect(getRefreshToken()).toBeNull();
       expect(window.logService.warn).toHaveBeenCalled();
     });
   });
 
   describe('Fetch Current User Action', () => {
-    it('should fetch current user successfully', async () => {
+    it('fetches the current user successfully', async () => {
       const authStore = useAuthStore();
       authStore.accessToken = 'test_token';
 
-      const mockUserResponse = {
+      apiClient.get.mockResolvedValueOnce({
         data: {
           id: 1,
           username: 'testuser',
@@ -320,84 +242,79 @@ describe('Auth Store', () => {
           role: 'admin',
           permissions: ['users:read', 'users:write'],
         },
-      };
-
-      apiClient.get.mockResolvedValueOnce(mockUserResponse);
+      });
 
       await authStore.fetchCurrentUser();
 
-      expect(authStore.user).toEqual(mockUserResponse.data);
+      expect(authStore.user.username).toBe('testuser');
       expect(apiClient.get).toHaveBeenCalledWith('/auth/me');
       expect(window.logService.debug).toHaveBeenCalled();
     });
 
-    it('should handle fetch user failure', async () => {
+    it('logs out when fetching the current user returns 401', async () => {
       const authStore = useAuthStore();
       authStore.accessToken = 'test_token';
+      persistTokens({ accessToken: 'test_token', refreshToken: 'test_refresh' });
 
-      const mockError = {
+      apiClient.get.mockRejectedValueOnce({
         response: { status: 401 },
         message: 'Unauthorized',
-      };
+      });
+      apiClient.post.mockResolvedValueOnce({ data: {} });
 
-      apiClient.get.mockRejectedValueOnce(mockError);
-      apiClient.post.mockResolvedValueOnce({ data: {} }); // Mock logout call
-
-      // fetchCurrentUser() throws and calls logout on 401
       await expect(authStore.fetchCurrentUser()).rejects.toThrow();
 
-      expect(window.logService.error).toHaveBeenCalled();
-      expect(authStore.accessToken).toBeNull(); // Logout was called
+      expect(authStore.accessToken).toBeNull();
+      expect(getAccessToken()).toBeNull();
     });
   });
 
   describe('Refresh Access Token Action', () => {
-    it('should refresh token successfully', async () => {
+    it('rotates tokens in memory', async () => {
       const authStore = useAuthStore();
       authStore.refreshToken = 'old_refresh_token';
 
-      const mockResponse = {
+      apiClient.post.mockResolvedValueOnce({
         data: {
           access_token: 'new_access_token',
           refresh_token: 'new_refresh_token',
           token_type: 'bearer',
           expires_in: 1800,
         },
-      };
-
-      apiClient.post.mockResolvedValueOnce(mockResponse);
+      });
 
       const result = await authStore.refreshAccessToken();
 
       expect(result).toBe('new_access_token');
       expect(authStore.accessToken).toBe('new_access_token');
       expect(authStore.refreshToken).toBe('new_refresh_token');
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('access_token', 'new_access_token');
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('refresh_token', 'new_refresh_token');
+      expect(getAccessToken()).toBe('new_access_token');
+      expect(getRefreshToken()).toBe('new_refresh_token');
       expect(window.logService.debug).toHaveBeenCalledWith('Access token refreshed');
     });
 
-    it('should handle refresh token failure and logout', async () => {
+    it('clears the in-memory session when refresh fails', async () => {
       const authStore = useAuthStore();
       authStore.refreshToken = 'invalid_refresh_token';
       authStore.accessToken = 'old_token';
       authStore.user = { username: 'test' };
+      persistTokens({ accessToken: 'old_token', refreshToken: 'invalid_refresh_token' });
 
-      // Mock the refresh call to fail
       apiClient.post.mockRejectedValueOnce(new Error('Invalid refresh token'));
 
       await expect(authStore.refreshAccessToken()).rejects.toThrow('Invalid refresh token');
 
-      // Should clear auth state on refresh failure
       expect(authStore.accessToken).toBeNull();
       expect(authStore.refreshToken).toBeNull();
       expect(authStore.user).toBeNull();
+      expect(getAccessToken()).toBeNull();
+      expect(getRefreshToken()).toBeNull();
       expect(window.logService.error).toHaveBeenCalled();
     });
   });
 
   describe('Change Password Action', () => {
-    it('should change password successfully', async () => {
+    it('calls the backend password change endpoint', async () => {
       const authStore = useAuthStore();
 
       apiClient.post.mockResolvedValueOnce({
@@ -415,18 +332,16 @@ describe('Auth Store', () => {
       expect(window.logService.info).toHaveBeenCalledWith('Password changed successfully');
     });
 
-    it('should handle password change failure', async () => {
+    it('surfaces password change failures', async () => {
       const authStore = useAuthStore();
 
-      const mockError = {
+      apiClient.post.mockRejectedValueOnce({
         response: {
           data: {
             detail: 'Current password is incorrect',
           },
         },
-      };
-
-      apiClient.post.mockRejectedValueOnce(mockError);
+      });
 
       await expect(authStore.changePassword('wrongpass', 'newpass')).rejects.toThrow();
 
@@ -436,28 +351,26 @@ describe('Auth Store', () => {
   });
 
   describe('Initialize Action', () => {
-    it('should initialize and fetch user if token exists', async () => {
-      localStorageMock.setItem('access_token', 'existing_token');
+    it('fetches the current user when an in-memory token exists', async () => {
+      persistTokens({ accessToken: 'existing_token' });
 
-      const mockUserResponse = {
+      apiClient.get.mockResolvedValueOnce({
         data: {
           id: 1,
           username: 'testuser',
           email: 'test@example.com',
           role: 'viewer',
         },
-      };
-
-      apiClient.get.mockResolvedValueOnce(mockUserResponse);
+      });
 
       const authStore = useAuthStore();
       await authStore.initialize();
 
-      expect(authStore.user).toEqual(mockUserResponse.data);
+      expect(authStore.user.username).toBe('testuser');
       expect(apiClient.get).toHaveBeenCalledWith('/auth/me');
     });
 
-    it('should not fetch user if no token exists', async () => {
+    it('does not fetch the current user if no token exists', async () => {
       const authStore = useAuthStore();
       await authStore.initialize();
 
@@ -465,64 +378,22 @@ describe('Auth Store', () => {
       expect(authStore.user).toBeNull();
     });
 
-    it('should log warning if user fetch fails during initialization', async () => {
-      localStorageMock.setItem('access_token', 'invalid_token');
+    it('logs a warning if initialization cannot restore the current user', async () => {
+      persistTokens({ accessToken: 'invalid_token' });
 
-      const mockError = {
+      apiClient.get.mockRejectedValueOnce({
         response: { status: 401 },
         message: 'Unauthorized',
-      };
-
-      apiClient.get.mockRejectedValueOnce(mockError);
-      apiClient.post.mockResolvedValueOnce({ data: {} }); // Mock logout call
+      });
+      apiClient.post.mockResolvedValueOnce({ data: {} });
 
       const authStore = useAuthStore();
       await authStore.initialize();
 
-      // initialize() catches error and logs warning, doesn't throw
       expect(window.logService.warn).toHaveBeenCalledWith(
         'Failed to initialize user session',
         expect.any(Object)
       );
-    });
-  });
-
-  describe('Permission Checks', () => {
-    it('should check if user has specific permission', () => {
-      const authStore = useAuthStore();
-
-      authStore.user = {
-        permissions: ['phenopackets:read', 'variants:write', 'users:delete'],
-      };
-
-      expect(authStore.userPermissions).toContain('phenopackets:read');
-      expect(authStore.userPermissions).toContain('variants:write');
-      expect(authStore.userPermissions).not.toContain('system:manage');
-    });
-  });
-
-  describe('Error Handling', () => {
-    it('should clear error when starting new login', async () => {
-      const authStore = useAuthStore();
-
-      authStore.error = 'Previous error';
-
-      apiClient.post.mockResolvedValueOnce({
-        data: {
-          access_token: 'token',
-          refresh_token: 'refresh',
-          token_type: 'bearer',
-          expires_in: 1800,
-        },
-      });
-
-      apiClient.get.mockResolvedValueOnce({
-        data: { id: 1, username: 'test' },
-      });
-
-      await authStore.login({ username: 'test', password: 'pass' });
-
-      expect(authStore.error).toBeNull();
     });
   });
 });

--- a/frontend/tests/unit/stores/authStore.spec.js
+++ b/frontend/tests/unit/stores/authStore.spec.js
@@ -31,17 +31,24 @@ globalThis.window.logService = {
 };
 
 describe('Auth Store', () => {
+  const originalDev = import.meta.env.DEV;
+  const originalFlag = import.meta.env.VITE_ENABLE_DEV_AUTH;
+
   beforeEach(() => {
     setActivePinia(createPinia());
     clearTokens();
     vi.clearAllMocks();
     apiClient.post.mockReset();
     apiClient.get.mockReset();
+    import.meta.env.DEV = true;
+    import.meta.env.VITE_ENABLE_DEV_AUTH = 'true';
   });
 
   afterEach(() => {
     clearTokens();
     vi.restoreAllMocks();
+    import.meta.env.DEV = originalDev;
+    import.meta.env.VITE_ENABLE_DEV_AUTH = originalFlag;
   });
 
   describe('Initial State', () => {
@@ -394,6 +401,32 @@ describe('Auth Store', () => {
         'Failed to initialize user session',
         expect.any(Object)
       );
+    });
+  });
+
+  describe('Dev Quick Login', () => {
+    it('refuses quick-login when the frontend flag is disabled', async () => {
+      import.meta.env.VITE_ENABLE_DEV_AUTH = 'false';
+      const authStore = useAuthStore();
+
+      await expect(authStore.devLoginAs('dev-curator')).rejects.toThrow(
+        'Dev quick-login is disabled'
+      );
+
+      expect(authStore.error).toContain('VITE_ENABLE_DEV_AUTH=true');
+      expect(apiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('surfaces backend dev-auth misconfiguration on 404', async () => {
+      const authStore = useAuthStore();
+      apiClient.post.mockRejectedValueOnce({
+        response: { status: 404, data: { detail: 'Not Found' } },
+        message: 'Request failed with status code 404',
+      });
+
+      await expect(authStore.devLoginAs('dev-curator')).rejects.toThrow();
+
+      expect(authStore.error).toContain('ENABLE_DEV_AUTH=true');
     });
   });
 });


### PR DESCRIPTION
## Summary
- harden auth token issuance and refresh invalidation for inactive and locked users
- move frontend session tokens to in-memory storage and add regression coverage
- close workflow visibility and delete-race gaps with timeline and soft-delete fixes

## Testing
- `cd frontend && make check`
- `cd frontend && npx vitest run tests/unit/api/session.spec.js tests/unit/api/transport.spec.js tests/unit/stores/authStore.spec.js`
- `cd backend && make lint`
- `cd backend && make typecheck`
- `cd backend && uv run pytest tests/test_auth.py tests/test_auth_password_reset.py tests/test_dev_endpoints.py tests/test_pwdlib_rehash.py -v`
- `cd backend && uv run pytest tests/test_state_flows.py tests/test_api_transitions.py tests/test_phenopackets_delete_revision.py tests/test_crud_related_and_timeline.py -v`
- `cd backend && make check`
