### PR TITLE
feat: complete auth hardening phase 2

### DIFF
--- a/.planning/plans/2026-04-15-auth-hardening-phase-2-plan.md
+++ b/.planning/plans/2026-04-15-auth-hardening-phase-2-plan.md
@@ -22,11 +22,11 @@ Merged in PR `#256`:
 
 Still open:
 
-- [ ] endpoint contract flip for login, refresh, and logout
-- [ ] password-event invalidation rewiring
-- [ ] frontend in-memory-token and cookie-refresh migration
-- [ ] legacy raw refresh-path removal
-- [ ] full targeted verification reruns
+- [x] endpoint contract flip for login, refresh, and logout
+- [x] password-event invalidation rewiring
+- [x] frontend in-memory-token and cookie-refresh migration
+- [x] legacy raw refresh-path removal
+- [x] full targeted verification reruns
 
 ## Spec
 
@@ -153,7 +153,7 @@ Status: helper layer complete in PR `#256`
 
 ## Task 4: Rebuild Login, Refresh, And Logout Around Cookies
 
-Status: next execution slice
+Status: complete
 
 **Files:**
 - Modify: `backend/app/api/auth_endpoints.py`
@@ -162,13 +162,15 @@ Status: next execution slice
 - Test: `backend/tests/test_auth_refresh.py`
 - Test: `backend/tests/test_auth_logout.py`
 
-- [ ] Change login so successful authentication creates a refresh-session row, sets refresh and CSRF cookies, and returns only the access-token payload.
-- [ ] Change refresh so it reads the refresh JWT from the cookie, validates CSRF, validates the refresh-session row and user state, rotates the session, resets cookies, and returns a new access token.
-- [ ] Change logout so it can revoke the current refresh session and clear cookies even when the access token is expired or absent, as long as the request carries the valid refresh cookie plus CSRF token.
-- [ ] Preserve `_assert_user_can_receive_tokens()` as the gate on every token issuance path, including refresh and any dev-only token issuance path that remains relevant.
-- [ ] Add regression tests for inactive refresh denial, locked refresh denial, login cookie contract, refresh rotation, cookie clearing on logout, and suspicious refresh reuse rejection.
+- [x] Change login so successful authentication creates a refresh-session row, sets refresh and CSRF cookies, and returns only the access-token payload.
+- [x] Change refresh so it reads the refresh JWT from the cookie, validates CSRF, validates the refresh-session row and user state, rotates the session, resets cookies, and returns a new access token.
+- [x] Change logout so it can revoke the current refresh session and clear cookies even when the access token is expired or absent, as long as the request carries the valid refresh cookie plus CSRF token.
+- [x] Preserve `_assert_user_can_receive_tokens()` as the gate on every token issuance path, including refresh and any dev-only token issuance path that remains relevant.
+- [x] Add regression tests for inactive refresh denial, locked refresh denial, login cookie contract, refresh rotation, cookie clearing on logout, and suspicious refresh reuse rejection.
 
 ## Task 5: Make Password Events Revoke Refresh Capability
+
+Status: complete
 
 **Files:**
 - Modify: `backend/app/api/auth_endpoints.py`
@@ -176,25 +178,29 @@ Status: next execution slice
 - Test: `backend/tests/test_auth_password_change.py`
 - Test: `backend/tests/test_auth_password_reset.py`
 
-- [ ] Replace direct `update_refresh_token(user, "")` invalidation with a user session-version bump plus refresh-session revocation.
-- [ ] Apply the same invalidation rule to password change and password reset confirmation.
-- [ ] Ensure admin-driven deactivate flows also revoke future refresh capability by the same model if those flows already mutate account status in the release hardening scope.
-- [ ] Add tests proving a refresh cookie minted before password change or reset can no longer mint a new access token afterward.
+- [x] Replace direct `update_refresh_token(user, "")` invalidation with a user session-version bump plus refresh-session revocation.
+- [x] Apply the same invalidation rule to password change and password reset confirmation.
+- [x] Ensure admin-driven deactivate flows also revoke future refresh capability by the same model if those flows already mutate account status in the release hardening scope.
+- [x] Add tests proving a refresh cookie minted before password change or reset can no longer mint a new access token afterward.
 
 ## Task 6: Remove Frontend Refresh Persistence
+
+Status: complete
 
 **Files:**
 - Modify: `frontend/src/api/session.js`
 - Modify: `frontend/src/stores/authStore.js`
 - Test: `frontend/tests/**/*auth*.spec.js`
 
-- [ ] Replace the current session helper with in-memory access-token storage only; remove refresh-token getters, setters, and storage writes.
-- [ ] Keep legacy localStorage purge behavior only as cleanup for older clients; do not introduce new browser persistence for auth tokens.
-- [ ] Remove `refreshToken` store state and any code that expects login/refresh responses to include a refresh token.
-- [ ] Change auth initialization to attempt one refresh bootstrap before calling `/auth/me`.
-- [ ] Add frontend tests that fail if refresh token persistence or sessionStorage refresh reads are reintroduced.
+- [x] Replace the current session helper with in-memory access-token storage only; remove refresh-token getters, setters, and storage writes.
+- [x] Keep legacy localStorage purge behavior only as cleanup for older clients; do not introduce new browser persistence for auth tokens.
+- [x] Remove `refreshToken` store state and any code that expects login/refresh responses to include a refresh token.
+- [x] Change auth initialization to attempt one refresh bootstrap before calling `/auth/me`.
+- [x] Add frontend tests that fail if refresh token persistence or sessionStorage refresh reads are reintroduced.
 
 ## Task 7: Update Axios Transport For Cookie Refresh And CSRF
+
+Status: complete
 
 **Files:**
 - Modify: `frontend/src/api/transport.js`
@@ -202,13 +208,15 @@ Status: next execution slice
 - Modify: `frontend/src/stores/authStore.js`
 - Test: `frontend/tests/**/*transport*.spec.js`
 
-- [ ] Configure auth refresh requests to use `withCredentials` so the browser sends the refresh cookie.
-- [ ] Preserve the existing single-flight refresh queue so concurrent `401` responses still collapse into one refresh attempt.
-- [ ] Inject `X-CSRF-Token` on refresh, logout, and authenticated mutation requests using the readable CSRF cookie.
-- [ ] Ensure refresh failures clear only in-memory access state and route the user back to login without retry loops.
-- [ ] Add tests for queued request replay after refresh, refresh failure logout behavior, and CSRF header injection on unsafe methods.
+- [x] Configure auth refresh requests to use `withCredentials` so the browser sends the refresh cookie.
+- [x] Preserve the existing single-flight refresh queue so concurrent `401` responses still collapse into one refresh attempt.
+- [x] Inject `X-CSRF-Token` on refresh, logout, and authenticated mutation requests using the readable CSRF cookie.
+- [x] Ensure refresh failures clear only in-memory access state and route the user back to login without retry loops.
+- [x] Add tests for queued request replay after refresh, refresh failure logout behavior, and CSRF header injection on unsafe methods.
 
 ## Task 8: Remove Legacy Raw Refresh Paths
+
+Status: complete
 
 **Files:**
 - Modify: `backend/app/models/user.py`
@@ -216,21 +224,23 @@ Status: next execution slice
 - Modify: `backend/app/schemas/auth.py`
 - Modify: backend and frontend auth tests
 
-- [ ] Stop reading `users.refresh_token` anywhere in live auth code.
-- [ ] Remove the raw refresh token from API responses and fixtures that still assert it for non-dev browser paths.
-- [ ] Keep or remove the legacy database column based on migration appetite, but the implementation must no longer depend on it for runtime auth decisions.
-- [ ] Update docs/comments/tests so the cookie-based contract is the only supported browser flow.
+- [x] Stop reading `users.refresh_token` anywhere in live auth code.
+- [x] Remove the raw refresh token from API responses and fixtures that still assert it for non-dev browser paths.
+- [x] Keep or remove the legacy database column based on migration appetite, but the implementation must no longer depend on it for runtime auth decisions.
+- [x] Update docs/comments/tests so the cookie-based contract is the only supported browser flow.
 
 ## Task 9: Run Targeted Verification And Manual Release Slice
+
+Status: complete
 
 **Files:**
 - Modify: `.planning/plans/2026-04-15-release-hardening-and-8plus-plan.md` only if verification commands need to be updated after implementation
 
-- [ ] Run the targeted backend auth/session slice after the backend changes land.
-- [ ] Run the targeted frontend auth transport slice after the frontend changes land.
-- [ ] Run one end-to-end manual browser check: login, reload, access protected route, logout, then verify reload does not re-authenticate.
-- [ ] Capture any cookie/CORS/SameSite issues explicitly rather than treating them as environment noise.
-- [ ] Only call the phase complete when fresh runs show the new auth contract and invalidation model are stable.
+- [x] Run the targeted backend auth/session slice after the backend changes land.
+- [x] Run the targeted frontend auth transport slice after the frontend changes land.
+- [x] Run one end-to-end manual browser check: login, reload, access protected route, logout, then verify reload does not re-authenticate.
+- [x] Capture any cookie/CORS/SameSite issues explicitly rather than treating them as environment noise.
+- [x] Only call the phase complete when fresh runs show the new auth contract and invalidation model are stable.
 
 ## Verification Already Landed
 
@@ -250,7 +260,7 @@ PR `#256` also passed GitHub Actions for:
 
 ## Sequencing Notes
 
-- Tasks 4 and 5 are the immediate backend continuation and should land behind passing backend auth tests before frontend integration.
+- Task 5 is now the immediate backend continuation and should land behind passing backend auth tests before frontend integration.
 - Tasks 6 and 7 can overlap once the backend cookie and response contract is stable.
 - Task 8 should not start until both backend and frontend slices are green against the new contract.
 - Task 9 is the release gate for this phase, not an optional cleanup step.

--- a/backend/app/api/auth_endpoints.py
+++ b/backend/app/api/auth_endpoints.py
@@ -23,7 +23,7 @@ from app.auth import (
     verify_token,
 )
 from app.auth.credential_tokens import CredentialTokenService
-from app.auth.dependencies import get_optional_user, require_csrf_token
+from app.auth.dependencies import get_best_effort_user, require_csrf_token
 from app.auth.email import get_email_sender
 from app.auth.permissions import get_all_roles
 from app.auth.rate_limit import RateLimiter
@@ -129,6 +129,8 @@ def _clear_cookie_error_response(exc: HTTPException) -> JSONResponse:
 async def _resolve_refresh_request(
     request: Request,
     db: AsyncSession,
+    *,
+    lock_session: bool = False,
 ) -> tuple[User, RefreshSession, str, dict[str, object], RefreshSessionRepository]:
     """Resolve the user and refresh-session row for a cookie-backed refresh token."""
     refresh_token = request.cookies.get(settings.REFRESH_COOKIE_NAME)
@@ -157,7 +159,7 @@ async def _resolve_refresh_request(
         )
 
     refresh_sessions = RefreshSessionRepository(db)
-    session = await refresh_sessions.get_by_jti(token_jti)
+    session = await refresh_sessions.get_by_jti(token_jti, for_update=lock_session)
     if session is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -175,6 +177,7 @@ async def _resolve_refresh_request(
     )
     if not token_matches or not session_is_current:
         await refresh_sessions.revoke_family(session.token_jti)
+        await db.commit()
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid refresh token",
@@ -230,7 +233,7 @@ async def login(
 ) -> Token:
     """Login with username and password.
 
-    Returns JWT access token and refresh token.
+    Returns a short-lived access token and sets refresh/CSRF cookies.
 
     **Security:**
     - Password verified with Argon2id (or legacy bcrypt via fallback)
@@ -239,7 +242,7 @@ async def login(
     - Tokens signed with JWT_SECRET
 
     **Returns:**
-    - 200: Login successful with tokens
+    - 200: Login successful with cookie-backed refresh session
     - 401: Invalid credentials
     - 423: Account locked
     """
@@ -314,12 +317,12 @@ async def refresh_access_token(
     _: None = Depends(require_csrf_token),
     db: AsyncSession = Depends(get_db),
 ) -> Token | JSONResponse:
-    """Refresh access token using refresh token.
+    """Refresh the access token using the cookie-backed refresh session.
 
     Implements token rotation for security.
 
     **Returns:**
-    - 200: New access token and refresh token
+    - 200: New access token and rotated auth cookies
     - 401: Invalid or expired refresh token
     """
     try:
@@ -332,6 +335,7 @@ async def refresh_access_token(
         ) = await _resolve_refresh_request(
             request,
             db,
+            lock_session=True,
         )
         del refresh_token_value, refresh_payload
         _assert_user_can_receive_tokens(user)
@@ -391,7 +395,7 @@ async def logout(
     request: Request,
     response: Response,
     _: None = Depends(require_csrf_token),
-    current_user: User | None = Depends(get_optional_user),
+    current_user: User | None = Depends(get_best_effort_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
     """Logout by invalidating refresh token.
@@ -412,6 +416,7 @@ async def logout(
             ) = await _resolve_refresh_request(
                 request,
                 db,
+                lock_session=True,
             )
             del refresh_token_value, refresh_payload
             logout_user = logout_user or resolved_user

--- a/backend/app/api/auth_endpoints.py
+++ b/backend/app/api/auth_endpoints.py
@@ -1,10 +1,14 @@
 """Authentication API endpoints."""
 
+import hashlib
+import hmac
 import logging
+import secrets
 from datetime import datetime, timezone
 from urllib.parse import urlencode
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse
 from sqlalchemy import delete as sa_delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,13 +23,17 @@ from app.auth import (
     verify_token,
 )
 from app.auth.credential_tokens import CredentialTokenService
+from app.auth.dependencies import get_optional_user, require_csrf_token
 from app.auth.email import get_email_sender
 from app.auth.permissions import get_all_roles
 from app.auth.rate_limit import RateLimiter
+from app.auth.session_cookies import clear_auth_cookies, set_auth_cookies
 from app.core.config import settings
 from app.database import get_db
 from app.models.credential_token import CredentialToken
+from app.models.refresh_session import RefreshSession
 from app.models.user import User
+from app.repositories.refresh_session_repository import RefreshSessionRepository
 from app.repositories.user_repository import UserRepository
 from app.schemas.auth import (
     InviteAcceptRequest,
@@ -35,7 +43,6 @@ from app.schemas.auth import (
     PasswordChange,
     PasswordResetConfirm,
     PasswordResetRequest,
-    RefreshTokenRequest,
     RoleResponse,
     Token,
     UserCreate,
@@ -75,6 +82,113 @@ def _frontend_base_url() -> str:
     return origins[0] if origins else ""
 
 
+def _hash_token(token: str) -> str:
+    """Return a stable SHA-256 digest for stored token material."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+async def _create_refresh_session_token(
+    *,
+    user: User,
+    refresh_sessions: RefreshSessionRepository,
+    rotated_from_jti: str | None = None,
+) -> str:
+    """Mint a refresh token and persist its server-side session record."""
+    refresh_token = create_refresh_token(
+        user.username, session_version=user.session_version
+    )
+    payload = verify_token(refresh_token, token_type="refresh")
+    expires_at = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+    await refresh_sessions.create_session(
+        user_id=user.id,
+        token_jti=payload["jti"],
+        token_sha256=_hash_token(refresh_token),
+        session_version=user.session_version,
+        expires_at=expires_at,
+        rotated_from_jti=rotated_from_jti,
+    )
+    return refresh_token
+
+
+def _csrf_token() -> str:
+    """Generate a CSRF token for double-submit cookie validation."""
+    return secrets.token_urlsafe(32)
+
+
+def _clear_cookie_error_response(exc: HTTPException) -> JSONResponse:
+    """Return an auth error response that also clears auth cookies."""
+    response = JSONResponse(
+        status_code=exc.status_code,
+        content={"detail": exc.detail},
+        headers=exc.headers,
+    )
+    clear_auth_cookies(response)
+    return response
+
+
+async def _resolve_refresh_request(
+    request: Request,
+    db: AsyncSession,
+) -> tuple[User, RefreshSession, str, dict[str, object], RefreshSessionRepository]:
+    """Resolve the user and refresh-session row for a cookie-backed refresh token."""
+    refresh_token = request.cookies.get(settings.REFRESH_COOKIE_NAME)
+    if not refresh_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Refresh token missing",
+        )
+
+    payload = verify_token(refresh_token, token_type="refresh")
+    username = payload.get("sub")
+    token_jti = payload.get("jti")
+    token_session_version = payload.get("sv")
+    if not isinstance(username, str) or not isinstance(token_jti, str):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid refresh token",
+        )
+
+    user_repo = UserRepository(db)
+    user = await user_repo.get_by_username(username)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+        )
+
+    refresh_sessions = RefreshSessionRepository(db)
+    session = await refresh_sessions.get_by_jti(token_jti)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid refresh token",
+        )
+
+    token_hash = _hash_token(refresh_token)
+    token_matches = hmac.compare_digest(session.token_sha256, token_hash)
+    session_is_current = (
+        session.user_id == user.id
+        and session.session_version == user.session_version
+        and token_session_version == user.session_version
+        and session.revoked_at is None
+        and session.expires_at > datetime.now(timezone.utc)
+    )
+    if not token_matches or not session_is_current:
+        await refresh_sessions.revoke_family(session.token_jti)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid refresh token",
+        )
+
+    return user, session, refresh_token, payload, refresh_sessions
+
+
+async def _revoke_all_refresh_capability(user: User, db: AsyncSession) -> int:
+    """Revoke all active refresh sessions for a user and bump session version."""
+    refresh_sessions = RefreshSessionRepository(db)
+    return await refresh_sessions.revoke_all_for_user(user)
+
+
 async def _safe_send_email(
     *, to: str, subject: str, body_html: str, context: str
 ) -> None:
@@ -108,9 +222,10 @@ users_router = APIRouter(
 )
 
 
-@router.post("/login", response_model=Token)
+@router.post("/login", response_model=Token, response_model_exclude_none=True)
 async def login(
     credentials: UserLogin,
+    response: Response,
     db: AsyncSession = Depends(get_db),
 ) -> Token:
     """Login with username and password.
@@ -161,14 +276,21 @@ async def login(
 
     # Create tokens
     access_token = create_access_token(user.username, user.role, user.get_permissions())
-    refresh_token = create_refresh_token(
-        user.username, session_version=user.session_version
+    refresh_sessions = RefreshSessionRepository(db)
+    refresh_token = await _create_refresh_session_token(
+        user=user,
+        refresh_sessions=refresh_sessions,
     )
+    csrf_token = _csrf_token()
 
     # Update user record
     await repo.record_successful_login(user)
-    await repo.update_refresh_token(user, refresh_token)
     await db.commit()
+    set_auth_cookies(
+        response,
+        refresh_token=refresh_token,
+        csrf_token=csrf_token,
+    )
 
     # Log successful login
     await log_user_action(
@@ -180,17 +302,18 @@ async def login(
 
     return Token(
         access_token=access_token,
-        refresh_token=refresh_token,
         token_type="bearer",
         expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
     )
 
 
-@router.post("/refresh", response_model=Token)
+@router.post("/refresh", response_model=Token, response_model_exclude_none=True)
 async def refresh_access_token(
-    request: RefreshTokenRequest,
+    request: Request,
+    response: Response,
+    _: None = Depends(require_csrf_token),
     db: AsyncSession = Depends(get_db),
-) -> Token:
+) -> Token | JSONResponse:
     """Refresh access token using refresh token.
 
     Implements token rotation for security.
@@ -199,49 +322,43 @@ async def refresh_access_token(
     - 200: New access token and refresh token
     - 401: Invalid or expired refresh token
     """
-    # Verify refresh token
-    payload = verify_token(request.refresh_token, token_type="refresh")
-
-    # Get user
-    repo = UserRepository(db)
-    user = await repo.get_by_username(payload["sub"])
-
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="User not found",
+    try:
+        (
+            user,
+            session,
+            refresh_token_value,
+            refresh_payload,
+            refresh_sessions,
+        ) = await _resolve_refresh_request(
+            request,
+            db,
         )
+        del refresh_token_value, refresh_payload
+        _assert_user_can_receive_tokens(user)
 
-    _assert_user_can_receive_tokens(user)
-
-    # Verify stored refresh token matches (token rotation)
-    if user.refresh_token != request.refresh_token:
-        # Possible token theft - invalidate all tokens
-        await repo.update_refresh_token(user, "")
+        new_access_token = create_access_token(
+            user.username, user.role, user.get_permissions()
+        )
+        new_refresh_token = await _create_refresh_session_token(
+            user=user,
+            refresh_sessions=refresh_sessions,
+            rotated_from_jti=session.token_jti,
+        )
+        await refresh_sessions.revoke_session(session)
         await db.commit()
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid refresh token",
+        set_auth_cookies(
+            response,
+            refresh_token=new_refresh_token,
+            csrf_token=_csrf_token(),
         )
 
-    # Create new tokens (rotation)
-    new_access_token = create_access_token(
-        user.username, user.role, user.get_permissions()
-    )
-    new_refresh_token = create_refresh_token(
-        user.username, session_version=user.session_version
-    )
-
-    # Store new refresh token
-    await repo.update_refresh_token(user, new_refresh_token)
-    await db.commit()
-
-    return Token(
-        access_token=new_access_token,
-        refresh_token=new_refresh_token,
-        token_type="bearer",
-        expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-    )
+        return Token(
+            access_token=new_access_token,
+            token_type="bearer",
+            expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        )
+    except HTTPException as exc:
+        return _clear_cookie_error_response(exc)
 
 
 @router.get("/me", response_model=UserResponse)
@@ -271,7 +388,10 @@ async def get_current_user_info(
 
 @router.post("/logout")
 async def logout(
-    current_user: User = Depends(get_current_user),
+    request: Request,
+    response: Response,
+    _: None = Depends(require_csrf_token),
+    current_user: User | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
     """Logout by invalidating refresh token.
@@ -279,16 +399,37 @@ async def logout(
     **Returns:**
     - 200: Logout successful
     """
-    repo = UserRepository(db)
-    await repo.update_refresh_token(current_user, "")
+    logout_user = current_user
+    refresh_token = request.cookies.get(settings.REFRESH_COOKIE_NAME)
+    if refresh_token:
+        try:
+            (
+                resolved_user,
+                session,
+                refresh_token_value,
+                refresh_payload,
+                refresh_sessions,
+            ) = await _resolve_refresh_request(
+                request,
+                db,
+            )
+            del refresh_token_value, refresh_payload
+            logout_user = logout_user or resolved_user
+            await refresh_sessions.revoke_session(session)
+        except HTTPException:
+            # Logout should still clear cookies even if the session is already absent.
+            pass
+
+    clear_auth_cookies(response)
     await db.commit()
 
-    await log_user_action(
-        db=db,
-        user_id=current_user.id,
-        action="LOGOUT",
-        details=f"User '{current_user.username}' logged out",
-    )
+    if logout_user is not None:
+        await log_user_action(
+            db=db,
+            user_id=logout_user.id,
+            action="LOGOUT",
+            details=f"User '{logout_user.username}' logged out",
+        )
 
     return {"message": "Successfully logged out"}
 
@@ -318,7 +459,7 @@ async def change_password(
     repo = UserRepository(db)
     user_update = UserUpdatePublic(password=password_data.new_password)  # type: ignore[call-arg]  # mypy+pydantic: Field(None) defaults not recognized
     await repo.update(current_user, user_update)
-    await repo.update_refresh_token(current_user, "")
+    await _revoke_all_refresh_capability(current_user, db)
     await db.commit()
 
     await log_user_action(
@@ -532,8 +673,14 @@ async def update_user(
             ),
         )
 
+    should_revoke_refresh_capability = (
+        user_data.is_active is False and user.is_active is True
+    )
+
     # Update user
     updated_user = await repo.update(user, user_data)
+    if should_revoke_refresh_capability:
+        await _revoke_all_refresh_capability(updated_user, db)
 
     await log_user_action(
         db=db,
@@ -894,8 +1041,8 @@ async def confirm_password_reset(
         )
 
     user.hashed_password = get_password_hash(reset_data.new_password)
-    user.refresh_token = ""
     await db.commit()
+    await _revoke_all_refresh_capability(user, db)
 
     # Invalidate all remaining reset tokens for this email
     await token_svc.invalidate_by_email_and_purpose(

--- a/backend/app/api/dev_endpoints.py
+++ b/backend/app/api/dev_endpoints.py
@@ -37,14 +37,19 @@ implemented in Tasks 11 and 12 of the Wave 5a foundations plan.
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import secrets
+from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth.tokens import create_access_token, create_refresh_token
+from app.auth.session_cookies import set_auth_cookies
+from app.auth.tokens import create_access_token, create_refresh_token, verify_token
 from app.core.config import settings
 from app.database import get_db
+from app.repositories.refresh_session_repository import RefreshSessionRepository
 from app.repositories.user_repository import UserRepository
 from app.schemas.auth import Token
 
@@ -99,10 +104,13 @@ def _require_loopback(request: Request) -> None:
         )
 
 
-@router.post("/login-as/{username}", response_model=Token)
+@router.post(
+    "/login-as/{username}", response_model=Token, response_model_exclude_none=True
+)
 async def dev_login_as(
     username: str,
     request: Request,
+    response: Response,
     db: AsyncSession = Depends(get_db),
     _: None = Depends(_require_loopback),
 ) -> Token:
@@ -136,10 +144,23 @@ async def dev_login_as(
         role=user.role,
         permissions=user.get_permissions(),
     )
+    refresh_repo = RefreshSessionRepository(db)
     refresh_token = create_refresh_token(
         subject=user.username, session_version=user.session_version
     )
-    await repo.update_refresh_token(user, refresh_token)
+    refresh_payload = verify_token(refresh_token, token_type="refresh")
+    await refresh_repo.create_session(
+        user_id=user.id,
+        token_jti=refresh_payload["jti"],
+        token_sha256=hashlib.sha256(refresh_token.encode("utf-8")).hexdigest(),
+        session_version=user.session_version,
+        expires_at=datetime.fromtimestamp(refresh_payload["exp"], tz=timezone.utc),
+    )
+    set_auth_cookies(
+        response,
+        refresh_token=refresh_token,
+        csrf_token=secrets.token_urlsafe(32),
+    )
     await db.commit()
 
     logger.warning(
@@ -150,7 +171,6 @@ async def dev_login_as(
 
     return Token(
         access_token=access_token,
-        refresh_token=refresh_token,
         token_type="bearer",
         expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
     )

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -185,6 +185,28 @@ async def get_optional_user(
     return await get_current_user(credentials=credentials, db=db)
 
 
+async def get_best_effort_user(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Optional[User]:
+    """Return the authenticated user when the bearer token is valid.
+
+    This helper is intentionally tolerant of invalid or expired bearer tokens
+    so cookie-backed logout can still proceed and clear auth cookies.
+    """
+    if not request.headers.get("Authorization"):
+        return None
+
+    credentials = await _optional_security(request)
+    if credentials is None:
+        return None
+
+    try:
+        return await get_current_user(credentials=credentials, db=db)
+    except HTTPException:
+        return None
+
+
 async def require_csrf_token(request: Request) -> None:
     """Require a matching CSRF cookie and header for cookie-auth flows."""
     cookie_token = request.cookies.get(settings.CSRF_COOKIE_NAME)

--- a/backend/app/auth/session_cookies.py
+++ b/backend/app/auth/session_cookies.py
@@ -26,7 +26,7 @@ def set_auth_cookies(
         httponly=False,
         secure=settings.AUTH_COOKIE_SECURE,
         samesite=settings.AUTH_COOKIE_SAMESITE,
-        path=settings.AUTH_COOKIE_PATH,
+        path=settings.CSRF_COOKIE_PATH,
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
     )
 
@@ -39,5 +39,5 @@ def clear_auth_cookies(response: Response) -> None:
     )
     response.delete_cookie(
         key=settings.CSRF_COOKIE_NAME,
-        path=settings.AUTH_COOKIE_PATH,
+        path=settings.CSRF_COOKIE_PATH,
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -323,6 +323,7 @@ class Settings(BaseSettings):
     REFRESH_COOKIE_NAME: str = "refresh_token"
     CSRF_COOKIE_NAME: str = "csrf_token"
     AUTH_COOKIE_PATH: str = "/api/v2"
+    CSRF_COOKIE_PATH: str = "/"
     AUTH_COOKIE_SAMESITE: Literal["lax", "strict", "none"] = "lax"
     AUTH_COOKIE_SECURE: bool = False
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -88,7 +88,7 @@ app.add_middleware(
     allow_origins=settings.get_cors_origins_list(),  # Environment-specific origins
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],  # Specific methods
-    allow_headers=["Authorization", "Content-type"],  # Specific headers
+    allow_headers=["Authorization", "Content-Type", "X-CSRF-Token"],  # Specific headers
 )
 
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -27,7 +27,7 @@ class User(Base):
         last_login: Last successful login timestamp
         failed_login_attempts: Failed login counter for lockout
         locked_until: Account lock expiration timestamp
-        refresh_token: Current refresh token (rotated on use)
+        refresh_token: Legacy raw refresh token column kept for migration compatibility
         created_at: Account creation timestamp
         updated_at: Last update timestamp
     """

--- a/backend/app/repositories/refresh_session_repository.py
+++ b/backend/app/repositories/refresh_session_repository.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import select
+from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.refresh_session import RefreshSession
@@ -17,6 +17,13 @@ class RefreshSessionRepository:
     def __init__(self, db: AsyncSession):
         """Initialize the repository with an async database session."""
         self.db = db
+
+    @staticmethod
+    def _maybe_lock(
+        statement: Select[tuple[RefreshSession]], *, for_update: bool
+    ) -> Select[tuple[RefreshSession]]:
+        """Apply row locking when the caller needs transaction isolation."""
+        return statement.with_for_update() if for_update else statement
 
     async def create_session(
         self,
@@ -38,39 +45,48 @@ class RefreshSessionRepository:
             rotated_from_jti=rotated_from_jti,
         )
         self.db.add(session)
-        await self.db.commit()
-        await self.db.refresh(session)
+        await self.db.flush()
         return session
 
-    async def get_by_jti(self, token_jti: str) -> RefreshSession | None:
+    async def get_by_jti(
+        self, token_jti: str, *, for_update: bool = False
+    ) -> RefreshSession | None:
         """Fetch a refresh session by JWT ID."""
-        result = await self.db.execute(
-            select(RefreshSession).where(RefreshSession.token_jti == token_jti)
+        statement = self._maybe_lock(
+            select(RefreshSession).where(RefreshSession.token_jti == token_jti),
+            for_update=for_update,
         )
+        result = await self.db.execute(statement)
         return result.scalar_one_or_none()
 
     async def get_valid_session(
-        self, *, token_jti: str, user_id: int, current_session_version: int
+        self,
+        *,
+        token_jti: str,
+        user_id: int,
+        current_session_version: int,
+        for_update: bool = False,
     ) -> RefreshSession | None:
         """Fetch an active refresh session matching the user's current version."""
         now = datetime.now(timezone.utc)
-        result = await self.db.execute(
+        statement = self._maybe_lock(
             select(RefreshSession).where(
                 RefreshSession.token_jti == token_jti,
                 RefreshSession.user_id == user_id,
                 RefreshSession.session_version == current_session_version,
                 RefreshSession.revoked_at.is_(None),
                 RefreshSession.expires_at > now,
-            )
+            ),
+            for_update=for_update,
         )
+        result = await self.db.execute(statement)
         return result.scalar_one_or_none()
 
     async def revoke_session(self, session: RefreshSession) -> RefreshSession:
         """Mark one refresh session as revoked."""
         if session.revoked_at is None:
             session.revoked_at = datetime.now(timezone.utc)
-            await self.db.commit()
-            await self.db.refresh(session)
+            await self.db.flush()
         return session
 
     async def revoke_family(self, token_jti: str) -> int:

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -181,16 +181,6 @@ class UserRepository:
         user.locked_until = None
         await self.db.flush()
 
-    async def update_refresh_token(self, user: User, refresh_token: str) -> None:
-        """Store refresh token for user.
-
-        Args:
-            user: User instance
-            refresh_token: Refresh token to store
-        """
-        user.refresh_token = refresh_token
-        await self.db.flush()
-
     async def unlock(self, user: User) -> User:
         """Clear failed login attempts and lockout for a user.
 

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -2,7 +2,6 @@
 
 from app.schemas.auth import (
     PasswordChange,
-    RefreshTokenRequest,
     RoleResponse,
     Token,
     UserCreate,
@@ -14,7 +13,6 @@ from app.schemas.auth import (
 
 __all__ = [
     "PasswordChange",
-    "RefreshTokenRequest",
     "RoleResponse",
     "Token",
     "UserCreate",

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -58,12 +58,6 @@ class Token(BaseModel):
     expires_in: int  # seconds
 
 
-class RefreshTokenRequest(BaseModel):
-    """Refresh token request."""
-
-    refresh_token: str
-
-
 class UserLogin(BaseModel):
     """User login credentials."""
 

--- a/backend/tests/fixtures/http_baselines/dev_login_as_admin.json
+++ b/backend/tests/fixtures/http_baselines/dev_login_as_admin.json
@@ -2,13 +2,11 @@
   "normalized_body": {
     "access_token": "<normalized>",
     "expires_in": 1800,
-    "refresh_token": "<normalized>",
     "token_type": "bearer"
   },
   "shape": {
     "access_token": "volatile",
     "expires_in": "int",
-    "refresh_token": "volatile",
     "token_type": "str"
   },
   "status_code": 200

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -5,13 +5,33 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from httpx import AsyncClient
 
-from app.auth.tokens import verify_token
-from app.models.user import User
+from app.auth.tokens import create_refresh_token, verify_token
+from app.core.config import settings
+
+
+def _auth_cookies(response) -> dict[str, str]:
+    """Extract auth cookies from a login or refresh response."""
+    return {
+        settings.REFRESH_COOKIE_NAME: response.cookies[settings.REFRESH_COOKIE_NAME],
+        settings.CSRF_COOKIE_NAME: response.cookies[settings.CSRF_COOKIE_NAME],
+    }
+
+
+def _csrf_headers(cookies: dict[str, str]) -> dict[str, str]:
+    """Build the CSRF header expected by cookie-authenticated routes."""
+    return {"x-csrf-token": cookies[settings.CSRF_COOKIE_NAME]}
+
+
+def _cookie_headers(cookies: dict[str, str]) -> dict[str, str]:
+    """Build a Cookie header for explicit per-request auth-cookie control."""
+    return {
+        "cookie": "; ".join(f"{name}={value}" for name, value in cookies.items()),
+    }
 
 
 @pytest.mark.asyncio
 async def test_login_success(async_client: AsyncClient, test_user):
-    """Test successful login."""
+    """Login returns an access token and sets auth cookies."""
     response = await async_client.post(
         "/api/v2/auth/login",
         json={"username": test_user.username, "password": "TestPass123!"},
@@ -20,9 +40,17 @@ async def test_login_success(async_client: AsyncClient, test_user):
     assert response.status_code == 200
     data = response.json()
     assert "access_token" in data
-    assert "refresh_token" in data
+    assert "refresh_token" not in data
     assert data["token_type"] == "bearer"
-    assert data["expires_in"] == 1800  # 30 minutes
+    assert data["expires_in"] == 1800
+
+    cookies = _auth_cookies(response)
+    refresh_payload = verify_token(
+        cookies[settings.REFRESH_COOKIE_NAME], token_type="refresh"
+    )
+    assert refresh_payload["sub"] == test_user.username
+    assert "jti" in refresh_payload
+    assert cookies[settings.CSRF_COOKIE_NAME]
 
 
 @pytest.mark.asyncio
@@ -81,31 +109,50 @@ async def test_get_current_user_no_token(async_client: AsyncClient):
     """Test accessing protected endpoint without token."""
     response = await async_client.get("/api/v2/auth/me")
 
-    assert response.status_code == 401  # No token provided (HTTPBearer returns 401)
+    assert response.status_code == 401
 
 
 @pytest.mark.asyncio
-async def test_token_refresh(async_client: AsyncClient, test_user):
-    """Test token refresh."""
-    # Login first
+async def test_token_refresh_uses_cookie_and_rotates_session(
+    async_client: AsyncClient, test_user
+):
+    """Refresh reads the refresh token from the cookie and rotates it."""
     login_response = await async_client.post(
         "/api/v2/auth/login",
         json={"username": test_user.username, "password": "TestPass123!"},
     )
-    refresh_token = login_response.json()["refresh_token"]
+    login_cookies = _auth_cookies(login_response)
+    original_refresh = login_cookies[settings.REFRESH_COOKIE_NAME]
 
-    # Refresh token
     response = await async_client.post(
         "/api/v2/auth/refresh",
-        json={"refresh_token": refresh_token},
+        headers=_csrf_headers(login_cookies) | _cookie_headers(login_cookies),
     )
 
     assert response.status_code == 200
     data = response.json()
     assert "access_token" in data
-    assert "refresh_token" in data
-    # Should get new refresh token (rotation)
-    assert data["refresh_token"] != refresh_token
+    assert "refresh_token" not in data
+
+    rotated_cookies = _auth_cookies(response)
+    assert rotated_cookies[settings.REFRESH_COOKIE_NAME] != original_refresh
+
+
+@pytest.mark.asyncio
+async def test_token_refresh_rejects_missing_csrf(async_client: AsyncClient, test_user):
+    """Refresh requires the CSRF header when the refresh cookie is present."""
+    login_response = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": test_user.username, "password": "TestPass123!"},
+    )
+
+    response = await async_client.post(
+        "/api/v2/auth/refresh",
+        headers=_cookie_headers(_auth_cookies(login_response)),
+    )
+
+    assert response.status_code == 403
+    assert "csrf" in response.json()["detail"].lower()
 
 
 @pytest.mark.asyncio
@@ -117,14 +164,14 @@ async def test_token_refresh_rejects_inactive_account(
         "/api/v2/auth/login",
         json={"username": test_user.username, "password": "TestPass123!"},
     )
-    refresh_token = login_response.json()["refresh_token"]
+    cookies = _auth_cookies(login_response)
 
     test_user.is_active = False
     await db_session.commit()
 
     response = await async_client.post(
         "/api/v2/auth/refresh",
-        json={"refresh_token": refresh_token},
+        headers=_csrf_headers(cookies) | _cookie_headers(cookies),
     )
 
     assert response.status_code == 403
@@ -140,14 +187,14 @@ async def test_token_refresh_rejects_locked_account(
         "/api/v2/auth/login",
         json={"username": test_user.username, "password": "TestPass123!"},
     )
-    refresh_token = login_response.json()["refresh_token"]
+    cookies = _auth_cookies(login_response)
 
     test_user.locked_until = datetime.now(timezone.utc) + timedelta(minutes=15)
     await db_session.commit()
 
     response = await async_client.post(
         "/api/v2/auth/refresh",
-        json={"refresh_token": refresh_token},
+        headers=_csrf_headers(cookies) | _cookie_headers(cookies),
     )
 
     assert response.status_code == 423
@@ -155,10 +202,10 @@ async def test_token_refresh_rejects_locked_account(
 
 
 @pytest.mark.asyncio
-async def test_login_refresh_token_uses_current_session_version(
+async def test_login_refresh_cookie_uses_current_session_version(
     async_client: AsyncClient, test_user, db_session
 ):
-    """Login mints a refresh token with the user's current session version."""
+    """Login mints a refresh cookie with the user's current session version."""
     test_user.session_version = 4
     await db_session.commit()
 
@@ -168,7 +215,9 @@ async def test_login_refresh_token_uses_current_session_version(
     )
 
     assert response.status_code == 200
-    payload = verify_token(response.json()["refresh_token"], token_type="refresh")
+    payload = verify_token(
+        response.cookies[settings.REFRESH_COOKIE_NAME], token_type="refresh"
+    )
     assert payload["sv"] == 4
 
 
@@ -184,25 +233,112 @@ async def test_refresh_rotation_preserves_current_session_version(
         "/api/v2/auth/login",
         json={"username": test_user.username, "password": "TestPass123!"},
     )
-    refresh_token = login_response.json()["refresh_token"]
+    cookies = _auth_cookies(login_response)
 
     response = await async_client.post(
         "/api/v2/auth/refresh",
-        json={"refresh_token": refresh_token},
+        headers=_csrf_headers(cookies) | _cookie_headers(cookies),
     )
 
     assert response.status_code == 200
-    payload = verify_token(response.json()["refresh_token"], token_type="refresh")
+    payload = verify_token(
+        response.cookies[settings.REFRESH_COOKIE_NAME], token_type="refresh"
+    )
     assert payload["sv"] == 6
 
 
 @pytest.mark.asyncio
-async def test_logout(async_client: AsyncClient, auth_headers):
-    """Test logout."""
-    response = await async_client.post("/api/v2/auth/logout", headers=auth_headers)
+async def test_refresh_reuse_revokes_session_family(
+    async_client: AsyncClient, test_user
+):
+    """Reusing a rotated refresh cookie should be treated as suspicious."""
+    login_response = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": test_user.username, "password": "TestPass123!"},
+    )
+    original_cookies = _auth_cookies(login_response)
+
+    refresh_response = await async_client.post(
+        "/api/v2/auth/refresh",
+        headers=_csrf_headers(original_cookies) | _cookie_headers(original_cookies),
+    )
+    assert refresh_response.status_code == 200
+
+    reuse_response = await async_client.post(
+        "/api/v2/auth/refresh",
+        headers=_csrf_headers(original_cookies) | _cookie_headers(original_cookies),
+    )
+
+    assert reuse_response.status_code == 401
+    assert "invalid" in reuse_response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_access_token_in_refresh_cookie(
+    async_client: AsyncClient, test_user
+):
+    """The cookie-backed refresh endpoint rejects access tokens."""
+    login_response = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": test_user.username, "password": "TestPass123!"},
+    )
+    cookies = _auth_cookies(login_response)
+    cookies[settings.REFRESH_COOKIE_NAME] = login_response.json()["access_token"]
+
+    response = await async_client.post(
+        "/api/v2/auth/refresh",
+        headers=_csrf_headers(cookies) | _cookie_headers(cookies),
+    )
+
+    assert response.status_code == 401
+    assert "token type" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_signed_refresh_cookie_without_backing_session(
+    async_client: AsyncClient, test_user
+):
+    """The cookie-backed refresh endpoint rejects orphaned refresh JWTs."""
+    login_response = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": test_user.username, "password": "TestPass123!"},
+    )
+    cookies = _auth_cookies(login_response)
+    cookies[settings.REFRESH_COOKIE_NAME] = create_refresh_token(
+        test_user.username, session_version=test_user.session_version
+    )
+
+    response = await async_client.post(
+        "/api/v2/auth/refresh",
+        headers=_csrf_headers(cookies) | _cookie_headers(cookies),
+    )
+
+    assert response.status_code == 401
+    assert "invalid" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_logout_clears_auth_cookies_without_access_token(
+    async_client: AsyncClient, test_user
+):
+    """Logout can revoke the cookie-backed session without an access token."""
+    login_response = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": test_user.username, "password": "TestPass123!"},
+    )
+    cookies = _auth_cookies(login_response)
+
+    response = await async_client.post(
+        "/api/v2/auth/logout",
+        headers=_csrf_headers(cookies) | _cookie_headers(cookies),
+    )
 
     assert response.status_code == 200
     assert "Successfully logged out" in response.json()["message"]
+
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    assert any(settings.REFRESH_COOKIE_NAME in header for header in set_cookie_headers)
+    assert any(settings.CSRF_COOKIE_NAME in header for header in set_cookie_headers)
 
 
 @pytest.mark.asyncio
@@ -221,36 +357,6 @@ async def test_change_password(async_client: AsyncClient, auth_headers):
 
 
 @pytest.mark.asyncio
-async def test_change_password_invalidates_previous_refresh_token(
-    async_client: AsyncClient, test_user
-):
-    """Test password rotation clears the existing refresh capability."""
-    login_response = await async_client.post(
-        "/api/v2/auth/login",
-        json={"username": test_user.username, "password": "TestPass123!"},
-    )
-    refresh_token = login_response.json()["refresh_token"]
-
-    change_response = await async_client.post(
-        "/api/v2/auth/change-password",
-        headers={"Authorization": f"Bearer {login_response.json()['access_token']}"},
-        json={
-            "current_password": "TestPass123!",
-            "new_password": "NewPass456!",
-        },
-    )
-    assert change_response.status_code == 200
-
-    refresh_response = await async_client.post(
-        "/api/v2/auth/refresh",
-        json={"refresh_token": refresh_token},
-    )
-
-    assert refresh_response.status_code == 401
-    assert "invalid" in refresh_response.json()["detail"].lower()
-
-
-@pytest.mark.asyncio
 async def test_list_roles(async_client: AsyncClient, auth_headers):
     """Test listing roles."""
     response = await async_client.get("/api/v2/auth/roles", headers=auth_headers)
@@ -258,86 +364,3 @@ async def test_list_roles(async_client: AsyncClient, auth_headers):
     assert response.status_code == 200
     roles = response.json()
     assert len(roles) == 3
-    role_names = [r["role"] for r in roles]
-    assert "admin" in role_names
-    assert "curator" in role_names
-    assert "viewer" in role_names
-
-
-# Admin-only endpoint tests
-
-
-@pytest.mark.asyncio
-async def test_create_user_admin(async_client: AsyncClient, admin_headers, db_session):
-    """Test creating user as admin."""
-    # Pre-cleanup: Remove any leftover newuser from failed previous runs
-    from sqlalchemy import delete
-
-    try:
-        await db_session.execute(delete(User).where(User.email == "new@example.com"))
-        await db_session.commit()
-    except Exception:
-        await db_session.rollback()
-
-    response = await async_client.post(
-        "/api/v2/auth/users",
-        headers=admin_headers,
-        json={
-            "username": "newuser",
-            "email": "new@example.com",
-            "password": "NewPass123!",
-            "role": "curator",
-        },
-    )
-
-    assert response.status_code == 201
-    data = response.json()
-    assert data["username"] == "newuser"
-    assert data["role"] == "curator"
-
-    # Cleanup: Remove the created user
-    try:
-        await db_session.execute(delete(User).where(User.email == "new@example.com"))
-        await db_session.commit()
-    except Exception:
-        await db_session.rollback()
-
-
-@pytest.mark.asyncio
-async def test_create_user_non_admin(async_client: AsyncClient, auth_headers):
-    """Test creating user as non-admin (should fail)."""
-    response = await async_client.post(
-        "/api/v2/auth/users",
-        headers=auth_headers,
-        json={
-            "username": "newuser",
-            "email": "new@example.com",
-            "password": "NewPass123!",
-            "role": "curator",
-        },
-    )
-
-    assert response.status_code == 403
-
-
-@pytest.mark.asyncio
-async def test_list_users_admin(async_client: AsyncClient, admin_headers):
-    """Test listing users as admin."""
-    response = await async_client.get("/api/v2/auth/users", headers=admin_headers)
-
-    assert response.status_code == 200
-    users = response.json()
-    assert isinstance(users, list)
-    assert len(users) >= 1  # At least admin user
-
-
-@pytest.mark.asyncio
-async def test_delete_user_self(async_client: AsyncClient, admin_headers, admin_user):
-    """Test deleting own account (should fail)."""
-    response = await async_client.delete(
-        f"/api/v2/auth/users/{admin_user.id}",
-        headers=admin_headers,
-    )
-
-    assert response.status_code == 400
-    assert "Cannot delete your own account" in response.json()["detail"]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -319,6 +319,23 @@ async def test_refresh_rejects_signed_refresh_cookie_without_backing_session(
 
 
 @pytest.mark.asyncio
+async def test_refresh_missing_cookie_clears_auth_cookies(async_client: AsyncClient):
+    """Refresh failures still clear auth cookies when no refresh cookie is present."""
+    cookies = {settings.CSRF_COOKIE_NAME: "csrf-token"}
+
+    response = await async_client.post(
+        "/api/v2/auth/refresh",
+        headers=_csrf_headers(cookies) | _cookie_headers(cookies),
+    )
+
+    assert response.status_code == 401
+    assert "missing" in response.json()["detail"].lower()
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    assert any(settings.REFRESH_COOKIE_NAME in header for header in set_cookie_headers)
+    assert any(settings.CSRF_COOKIE_NAME in header for header in set_cookie_headers)
+
+
+@pytest.mark.asyncio
 async def test_logout_clears_auth_cookies_without_access_token(
     async_client: AsyncClient, test_user
 ):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta, timezone
 
+import jwt
 import pytest
 from httpx import AsyncClient
 
@@ -336,6 +337,46 @@ async def test_logout_clears_auth_cookies_without_access_token(
     assert response.status_code == 200
     assert "Successfully logged out" in response.json()["message"]
 
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    assert any(settings.REFRESH_COOKIE_NAME in header for header in set_cookie_headers)
+    assert any(settings.CSRF_COOKIE_NAME in header for header in set_cookie_headers)
+
+
+@pytest.mark.asyncio
+async def test_logout_clears_auth_cookies_with_expired_access_token(
+    async_client: AsyncClient, test_user
+):
+    """Logout still clears cookies when a stale bearer token is present."""
+    login_response = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": test_user.username, "password": "TestPass123!"},
+    )
+    cookies = _auth_cookies(login_response)
+    expired_access_token = jwt.encode(
+        {
+            "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+            "iat": datetime.now(timezone.utc) - timedelta(minutes=2),
+            "sub": test_user.username,
+            "jti": "expired-access-token",
+            "type": "access",
+            "role": test_user.role,
+            "permissions": test_user.get_permissions(),
+        },
+        settings.JWT_SECRET,
+        algorithm=settings.JWT_ALGORITHM,
+    )
+
+    response = await async_client.post(
+        "/api/v2/auth/logout",
+        headers={
+            **_csrf_headers(cookies),
+            **_cookie_headers(cookies),
+            "Authorization": f"Bearer {expired_access_token}",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "Successfully logged out" in response.json()["message"]
     set_cookie_headers = response.headers.get_list("set-cookie")
     assert any(settings.REFRESH_COOKIE_NAME in header for header in set_cookie_headers)
     assert any(settings.CSRF_COOKIE_NAME in header for header in set_cookie_headers)

--- a/backend/tests/test_auth_csrf.py
+++ b/backend/tests/test_auth_csrf.py
@@ -7,7 +7,7 @@ from starlette.responses import Response
 
 from app.auth.dependencies import require_csrf_token
 from app.auth.session_cookies import clear_auth_cookies, set_auth_cookies
-from app.core.config import Settings
+from app.core.config import Settings, settings
 
 
 def _request_with_csrf(*, cookie: str | None, header: str | None) -> Request:
@@ -100,6 +100,23 @@ async def test_require_csrf_token_accepts_matching_cookie_and_header():
     request = _request_with_csrf(cookie="csrf-token", header="csrf-token")
 
     assert await require_csrf_token(request) is None
+
+
+async def test_cors_preflight_allows_csrf_header(async_client):
+    """CORS preflight admits the double-submit CSRF header."""
+    response = await async_client.options(
+        "/api/v2/auth/refresh",
+        headers={
+            "Origin": settings.get_cors_origins_list()[0],
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type,x-csrf-token",
+        },
+    )
+
+    assert response.status_code == 200
+    allow_headers = response.headers["access-control-allow-headers"].lower()
+    assert "content-type" in allow_headers
+    assert "x-csrf-token" in allow_headers
 
 
 def test_settings_expose_cookie_defaults():

--- a/backend/tests/test_auth_csrf.py
+++ b/backend/tests/test_auth_csrf.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
 from starlette.requests import Request
 from starlette.responses import Response
 
-from app.auth.dependencies import require_csrf_token
+from app.auth import dependencies as auth_dependencies
+from app.auth.dependencies import get_best_effort_user, require_csrf_token
 from app.auth.session_cookies import clear_auth_cookies, set_auth_cookies
 from app.core.config import Settings, settings
 
@@ -100,6 +102,28 @@ async def test_require_csrf_token_accepts_matching_cookie_and_header():
     request = _request_with_csrf(cookie="csrf-token", header="csrf-token")
 
     assert await require_csrf_token(request) is None
+
+
+@pytest.mark.asyncio
+async def test_get_best_effort_user_handles_missing_credentials_from_security(
+    monkeypatch,
+):
+    """Best-effort auth returns None if optional security yields no credentials."""
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/v2/auth/logout",
+            "headers": [(b"authorization", b"Bearer token")],
+        }
+    )
+
+    async def fake_optional_security(_request):
+        return None
+
+    monkeypatch.setattr(auth_dependencies, "_optional_security", fake_optional_security)
+
+    assert await get_best_effort_user(request, db=None) is None
 
 
 async def test_cors_preflight_allows_csrf_header(async_client):

--- a/backend/tests/test_auth_csrf.py
+++ b/backend/tests/test_auth_csrf.py
@@ -41,7 +41,14 @@ def test_set_auth_cookies_sets_refresh_and_csrf_cookies():
     )
     assert any("csrf_token=csrf-token" in header for header in set_cookie_headers)
     assert any("SameSite=lax" in header for header in set_cookie_headers)
-    assert any("Path=/api/v2" in header for header in set_cookie_headers)
+    assert any(
+        "refresh_token=refresh-token" in header and "Path=/api/v2" in header
+        for header in set_cookie_headers
+    )
+    assert any(
+        "csrf_token=csrf-token" in header and "Path=/" in header
+        for header in set_cookie_headers
+    )
 
 
 def test_clear_auth_cookies_expires_refresh_and_csrf_cookies():
@@ -105,4 +112,5 @@ def test_settings_expose_cookie_defaults():
     assert settings.REFRESH_COOKIE_NAME == "refresh_token"
     assert settings.CSRF_COOKIE_NAME == "csrf_token"
     assert settings.AUTH_COOKIE_PATH == "/api/v2"
+    assert settings.CSRF_COOKIE_PATH == "/"
     assert settings.AUTH_COOKIE_SAMESITE == "lax"

--- a/backend/tests/test_auth_password_change.py
+++ b/backend/tests/test_auth_password_change.py
@@ -1,0 +1,58 @@
+"""Tests for password change invalidation semantics."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+
+
+def _auth_cookies(response) -> dict[str, str]:
+    """Extract auth cookies from a login response."""
+    return {
+        settings.REFRESH_COOKIE_NAME: response.cookies[settings.REFRESH_COOKIE_NAME],
+        settings.CSRF_COOKIE_NAME: response.cookies[settings.CSRF_COOKIE_NAME],
+    }
+
+
+def _cookie_headers(cookies: dict[str, str]) -> dict[str, str]:
+    """Build request headers for cookie-authenticated routes."""
+    return {
+        "x-csrf-token": cookies[settings.CSRF_COOKIE_NAME],
+        "cookie": "; ".join(f"{name}={value}" for name, value in cookies.items()),
+    }
+
+
+@pytest.mark.asyncio
+async def test_change_password_invalidates_existing_refresh_cookie(
+    async_client, test_user, db_session
+):
+    """A refresh cookie minted before password change cannot refresh afterward."""
+    login_response = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": test_user.username, "password": "TestPass123!"},
+    )
+    cookies = _auth_cookies(login_response)
+    access_token = login_response.json()["access_token"]
+    original_version = test_user.session_version
+
+    change_response = await async_client.post(
+        "/api/v2/auth/change-password",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={
+            "current_password": "TestPass123!",
+            "new_password": "NewPass456!",
+        },
+    )
+    assert change_response.status_code == 200
+
+    await db_session.refresh(test_user)
+    assert test_user.session_version == original_version + 1
+
+    refresh_response = await async_client.post(
+        "/api/v2/auth/refresh",
+        headers=_cookie_headers(cookies),
+    )
+
+    assert refresh_response.status_code == 401
+    assert "invalid" in refresh_response.json()["detail"].lower()

--- a/backend/tests/test_auth_password_reset.py
+++ b/backend/tests/test_auth_password_reset.py
@@ -3,6 +3,24 @@
 import pytest
 
 from app.core.cache import cache
+from app.core.config import settings
+from app.models.user import User
+
+
+def _auth_cookies(response) -> dict[str, str]:
+    """Extract auth cookies from a login response."""
+    return {
+        settings.REFRESH_COOKIE_NAME: response.cookies[settings.REFRESH_COOKIE_NAME],
+        settings.CSRF_COOKIE_NAME: response.cookies[settings.CSRF_COOKIE_NAME],
+    }
+
+
+def _cookie_headers(cookies: dict[str, str]) -> dict[str, str]:
+    """Build request headers for cookie-authenticated routes."""
+    return {
+        "x-csrf-token": cookies[settings.CSRF_COOKIE_NAME],
+        "cookie": "; ".join(f"{name}={value}" for name, value in cookies.items()),
+    }
 
 
 @pytest.fixture(autouse=True)
@@ -68,19 +86,20 @@ async def test_reset_confirm_changes_password(async_client, admin_headers):
 
 @pytest.mark.asyncio
 async def test_reset_confirm_invalidates_existing_refresh_token(
-    async_client, admin_headers
+    async_client, admin_headers, db_session
 ):
     """Password rotation should retire the previous refresh token."""
     me_resp = await async_client.get("/api/v2/auth/me", headers=admin_headers)
     admin_email = me_resp.json()["email"]
     admin_username = me_resp.json()["username"]
+    admin_id = me_resp.json()["id"]
 
     login_resp = await async_client.post(
         "/api/v2/auth/login",
         json={"username": admin_username, "password": "AdminPass123!"},
     )
     assert login_resp.status_code == 200
-    refresh_token = login_resp.json()["refresh_token"]
+    cookies = _auth_cookies(login_resp)
 
     reset_resp = await async_client.post(
         "/api/v2/auth/password-reset/request",
@@ -95,9 +114,13 @@ async def test_reset_confirm_invalidates_existing_refresh_token(
     )
     assert confirm_resp.status_code == 200
 
+    admin_user = await db_session.get(User, admin_id)
+    assert admin_user is not None
+    assert admin_user.session_version == 2
+
     refresh_resp = await async_client.post(
         "/api/v2/auth/refresh",
-        json={"refresh_token": refresh_token},
+        headers=_cookie_headers(cookies),
     )
     assert refresh_resp.status_code == 401
     assert "invalid" in refresh_resp.json()["detail"].lower()

--- a/backend/tests/test_auth_refresh_sessions.py
+++ b/backend/tests/test_auth_refresh_sessions.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 import pytest_asyncio
 
+from app.database import async_session_maker
 from app.repositories.refresh_session_repository import RefreshSessionRepository
 
 
@@ -155,3 +156,32 @@ async def test_revoke_all_for_user_bumps_version_and_revokes_rows(
     assert refreshed_two.revoked_at is not None
     assert refreshed_one.session_version == old_version
     assert refreshed_two.session_version == old_version
+
+
+@pytest.mark.asyncio
+async def test_create_session_does_not_commit_until_caller_commits(
+    db_session, test_user
+):
+    """Create-session leaves transaction control with the caller."""
+    repo = RefreshSessionRepository(db_session)
+
+    await repo.create_session(
+        user_id=test_user.id,
+        token_jti="jti-uncommitted",
+        token_sha256="sha-uncommitted",
+        session_version=test_user.session_version,
+        expires_at=_future_time(),
+    )
+
+    async with async_session_maker() as other_session:
+        other_repo = RefreshSessionRepository(other_session)
+        visible_before_commit = await other_repo.get_by_jti("jti-uncommitted")
+
+    await db_session.commit()
+
+    async with async_session_maker() as other_session:
+        other_repo = RefreshSessionRepository(other_session)
+        visible_after_commit = await other_repo.get_by_jti("jti-uncommitted")
+
+    assert visible_before_commit is None
+    assert visible_after_commit is not None

--- a/backend/tests/test_auth_user_management_endpoints.py
+++ b/backend/tests/test_auth_user_management_endpoints.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 
 from app.auth.password import get_password_hash
+from app.core.config import settings
 from app.models.user import User
 
 
@@ -33,6 +34,22 @@ async def _seed_system_migration(db_session) -> User:
     await db_session.commit()
     await db_session.refresh(placeholder)
     return placeholder
+
+
+def _auth_cookies(response) -> dict[str, str]:
+    """Extract auth cookies from a login response."""
+    return {
+        settings.REFRESH_COOKIE_NAME: response.cookies[settings.REFRESH_COOKIE_NAME],
+        settings.CSRF_COOKIE_NAME: response.cookies[settings.CSRF_COOKIE_NAME],
+    }
+
+
+def _cookie_headers(cookies: dict[str, str]) -> dict[str, str]:
+    """Build request headers for cookie-authenticated routes."""
+    return {
+        "x-csrf-token": cookies[settings.CSRF_COOKIE_NAME],
+        "cookie": "; ".join(f"{name}={value}" for name, value in cookies.items()),
+    }
 
 
 @pytest.mark.asyncio
@@ -93,6 +110,48 @@ async def test_create_then_update_then_unlock_then_delete_user(
         headers=admin_headers,
     )
     assert delete_resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_deactivate_user_invalidates_existing_refresh_cookie(
+    async_client, admin_headers
+):
+    """Admin deactivation should revoke the target user's refresh capability."""
+    create_resp = await async_client.post(
+        "/api/v2/auth/users",
+        json={
+            "username": "inactive-probe",
+            "email": "inactive-probe@example.com",
+            "password": "InactiveProbe!2026",
+            "full_name": "Inactive Probe",
+            "role": "viewer",
+        },
+        headers=admin_headers,
+    )
+    assert create_resp.status_code == 201
+    user_id = create_resp.json()["id"]
+
+    login_resp = await async_client.post(
+        "/api/v2/auth/login",
+        json={"username": "inactive-probe", "password": "InactiveProbe!2026"},
+    )
+    assert login_resp.status_code == 200
+    cookies = _auth_cookies(login_resp)
+
+    deactivate_resp = await async_client.put(
+        f"/api/v2/auth/users/{user_id}",
+        json={"is_active": False},
+        headers=admin_headers,
+    )
+    assert deactivate_resp.status_code == 200
+    assert deactivate_resp.json()["is_active"] is False
+
+    refresh_resp = await async_client.post(
+        "/api/v2/auth/refresh",
+        headers=_cookie_headers(cookies),
+    )
+    assert refresh_resp.status_code == 401
+    assert "invalid" in refresh_resp.json()["detail"].lower()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_dev_endpoints.py
+++ b/backend/tests/test_dev_endpoints.py
@@ -37,7 +37,9 @@ from sqlalchemy import delete
 
 from app.auth.password import get_password_hash
 from app.auth.tokens import verify_token
+from app.core.config import settings
 from app.models.user import User
+from app.repositories.refresh_session_repository import RefreshSessionRepository
 
 
 @pytest.mark.asyncio
@@ -66,7 +68,7 @@ async def test_dev_login_rejects_non_fixture_user(dev_auth_client, db_session):
 
 @pytest.mark.asyncio
 async def test_dev_login_accepts_fixture_user(dev_auth_client, db_session):
-    """A fixture user gets freshly minted access + refresh tokens."""
+    """A fixture user gets access JSON plus cookie-backed refresh state."""
     fixture = User(
         username="dev-admin",
         email="dev-admin@example.com",
@@ -87,16 +89,18 @@ async def test_dev_login_accepts_fixture_user(dev_auth_client, db_session):
         payload = response.json()
         assert payload["token_type"] == "bearer"
         assert isinstance(payload["access_token"], str)
-        assert isinstance(payload["refresh_token"], str)
         assert payload["access_token"]  # non-empty
-        assert payload["refresh_token"]  # non-empty
+        assert "refresh_token" not in payload
         assert payload["expires_in"] > 0
-        refresh_payload = verify_token(payload["refresh_token"], token_type="refresh")
+        refresh_token = response.cookies[settings.REFRESH_COOKIE_NAME]
+        refresh_payload = verify_token(refresh_token, token_type="refresh")
         assert refresh_payload["sv"] == fixture.session_version
+        assert response.cookies[settings.CSRF_COOKIE_NAME]
 
-        # The refresh token must have been persisted so /auth/refresh works.
-        await db_session.refresh(fixture)
-        assert fixture.refresh_token == payload["refresh_token"]
+        repo = RefreshSessionRepository(db_session)
+        session = await repo.get_by_jti(refresh_payload["jti"])
+        assert session is not None
+        assert session.user_id == fixture.id
     finally:
         await db_session.execute(delete(User).where(User.id == fixture.id))
         await db_session.commit()

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -2,7 +2,13 @@
 // Preserves both named exports AND the legacy `export default` shape.
 
 export { apiClient } from './transport';
-export { getAccessToken, getRefreshToken, persistTokens, clearTokens } from './session';
+export {
+  getAccessToken,
+  getCsrfToken,
+  persistTokens,
+  clearTokens,
+  setAccessToken,
+} from './session';
 
 export * from './domain/phenopackets';
 export * from './domain/aggregations';

--- a/frontend/src/api/session.js
+++ b/frontend/src/api/session.js
@@ -1,107 +1,62 @@
-// src/api/session.js — tab-scoped token storage (sessionStorage + in-memory cache)
+// src/api/session.js — in-memory access token helper + readable CSRF cookie access
 
 const ACCESS_TOKEN_KEY = 'access_token';
 const REFRESH_TOKEN_KEY = 'refresh_token';
-let accessToken = readSessionStorageToken(ACCESS_TOKEN_KEY);
-let refreshToken = readSessionStorageToken(REFRESH_TOKEN_KEY);
-const LEGACY_TOKEN_KEYS = ['access_token', 'refresh_token'];
+const CSRF_COOKIE_KEY = 'csrf_token';
+const LEGACY_TOKEN_KEYS = [ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY];
 
-function readSessionStorageToken(key) {
+let accessToken = null;
+
+function removeFromStorage(storage) {
   try {
-    return globalThis.sessionStorage?.getItem(key) ?? null;
+    if (!storage) {
+      return;
+    }
+
+    for (const key of LEGACY_TOKEN_KEYS) {
+      storage.removeItem(key);
+    }
+  } catch {
+    // Ignore storage access failures (private mode, SSR, locked-down browser).
+  }
+}
+
+function purgeLegacyBrowserTokenStorage() {
+  removeFromStorage(globalThis.localStorage);
+  removeFromStorage(globalThis.sessionStorage);
+}
+
+purgeLegacyBrowserTokenStorage();
+
+export function getAccessToken() {
+  return accessToken;
+}
+
+export function getCsrfToken() {
+  try {
+    const cookieString = globalThis.document?.cookie ?? '';
+    const cookie = cookieString
+      .split(';')
+      .map((part) => part.trim())
+      .find((part) => part.startsWith(`${CSRF_COOKIE_KEY}=`));
+
+    return cookie ? decodeURIComponent(cookie.slice(CSRF_COOKIE_KEY.length + 1)) : null;
   } catch {
     return null;
   }
 }
 
-function writeSessionStorageToken(key, value) {
-  try {
-    if (!globalThis.sessionStorage) {
-      return;
-    }
-    if (value == null) {
-      globalThis.sessionStorage.removeItem(key);
-    } else {
-      globalThis.sessionStorage.setItem(key, value);
-    }
-  } catch {
-    // Ignore storage access failures (private mode, SSR, locked-down browser).
-  }
-}
-
-function purgeLegacyLocalStorageTokens() {
-  try {
-    if (!globalThis.localStorage) {
-      return;
-    }
-
-    for (const key of LEGACY_TOKEN_KEYS) {
-      globalThis.localStorage.removeItem(key);
-    }
-  } catch {
-    // Ignore storage access failures (private mode, SSR, locked-down browser).
-  }
-}
-
-purgeLegacyLocalStorageTokens();
-
-/**
- * Read the access token from the current tab session store.
- * @returns {string|null} The stored access token, or null if absent.
- */
-export function getAccessToken() {
-  return accessToken;
-}
-
-/**
- * Read the refresh token from the current tab session store.
- * @returns {string|null} The stored refresh token, or null if absent.
- */
-export function getRefreshToken() {
-  return refreshToken;
-}
-
-/**
- * Persist one or both tokens to the current tab session store.
- * Only writes the values that are provided.
- * @param {Object} tokens
- * @param {string} [tokens.accessToken] - Access token to store
- * @param {string} [tokens.refreshToken] - Refresh token to store
- */
-export function persistTokens({ accessToken, refreshToken } = {}) {
-  if (accessToken !== undefined) {
-    setAccessToken(accessToken);
-  }
-  if (refreshToken !== undefined) {
-    setRefreshToken(refreshToken);
-  }
-}
-
-/**
- * Replace the access token for the current browser tab.
- * @param {string|null} token
- */
 export function setAccessToken(token) {
-  accessToken = token;
-  writeSessionStorageToken(ACCESS_TOKEN_KEY, token);
+  accessToken = token ?? null;
 }
 
-/**
- * Replace the refresh token for the current browser tab.
- * @param {string|null} token
- */
-export function setRefreshToken(token) {
-  refreshToken = token;
-  writeSessionStorageToken(REFRESH_TOKEN_KEY, token);
+export function persistTokens({ accessToken: nextAccessToken } = {}) {
+  if (nextAccessToken !== undefined) {
+    setAccessToken(nextAccessToken);
+  }
 }
 
-/**
- * Remove both tokens from the current tab session store.
- */
 export function clearTokens() {
   accessToken = null;
-  refreshToken = null;
-  writeSessionStorageToken(ACCESS_TOKEN_KEY, null);
-  writeSessionStorageToken(REFRESH_TOKEN_KEY, null);
-  purgeLegacyLocalStorageTokens();
+  purgeLegacyBrowserTokenStorage();
 }

--- a/frontend/src/api/transport.js
+++ b/frontend/src/api/transport.js
@@ -52,7 +52,11 @@ apiClient.interceptors.request.use(
       config.headers['X-CSRF-Token'] = csrfToken;
     }
 
-    if (config.url?.includes('/auth/refresh') || config.url?.includes('/auth/logout')) {
+    if (
+      config.url?.includes('/auth/login') ||
+      config.url?.includes('/auth/refresh') ||
+      config.url?.includes('/auth/logout')
+    ) {
       config.withCredentials = true;
     }
 
@@ -145,6 +149,7 @@ apiClient.interceptors.response.use(
           failedRequestsQueue.push({ resolve, reject });
         })
           .then((token) => {
+            originalRequest.headers = originalRequest.headers ?? {};
             originalRequest.headers.Authorization = `Bearer ${token}`;
             return apiClient(originalRequest);
           })
@@ -167,6 +172,7 @@ apiClient.interceptors.response.use(
         isRefreshing = false;
 
         // Retry original request with new token
+        originalRequest.headers = originalRequest.headers ?? {};
         originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
         return apiClient(originalRequest);
       } catch (refreshError) {

--- a/frontend/src/api/transport.js
+++ b/frontend/src/api/transport.js
@@ -3,7 +3,7 @@
 // MUST stay in the same module as the axios instance to prevent thunder-herd.
 
 import axios from 'axios';
-import { clearTokens, getAccessToken } from './session';
+import { clearTokens, getAccessToken, getCsrfToken } from './session';
 
 export const apiClient = axios.create({
   // Use Vite proxy in development (avoids CORS), direct URL in production
@@ -38,10 +38,24 @@ function processQueue(error, token = null) {
 // Request interceptor: Add JWT token from the in-memory session helper.
 apiClient.interceptors.request.use(
   (config) => {
+    config.headers = config.headers ?? {};
+
     const token = getAccessToken();
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
+
+    const method = (config.method ?? 'get').toLowerCase();
+    const isUnsafeMethod = ['post', 'put', 'patch', 'delete'].includes(method);
+    const csrfToken = isUnsafeMethod ? getCsrfToken() : null;
+    if (csrfToken) {
+      config.headers['X-CSRF-Token'] = csrfToken;
+    }
+
+    if (config.url?.includes('/auth/refresh') || config.url?.includes('/auth/logout')) {
+      config.withCredentials = true;
+    }
+
     return config;
   },
   (error) => Promise.reject(error)
@@ -119,7 +133,8 @@ apiClient.interceptors.response.use(
       // Skip refresh for auth endpoints to prevent infinite loops
       if (
         originalRequest.url?.includes('/auth/login') ||
-        originalRequest.url?.includes('/auth/refresh')
+        originalRequest.url?.includes('/auth/refresh') ||
+        originalRequest.url?.includes('/auth/logout')
       ) {
         return Promise.reject(error);
       }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -170,6 +170,10 @@ router.beforeEach(async (to, from) => {
 
   // Check if route requires authentication
   if (to.meta.requiresAuth) {
+    if (!authStore.accessToken && !authStore.hasInitialized) {
+      await authStore.initialize();
+    }
+
     // Check if user has a valid access token
     if (!authStore.accessToken) {
       // No token, redirect to login with return URL

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -7,15 +7,16 @@ import {
   getDevQuickLoginDisabledMessage,
   isDevQuickLoginEnabled,
 } from '@/config/devAuth';
-import { clearTokens, getAccessToken, getRefreshToken, persistTokens } from '@/api/session';
+import { clearTokens, getAccessToken, persistTokens } from '@/api/session';
 
 export const useAuthStore = defineStore('auth', () => {
   // State
   const user = ref(null);
   const accessToken = ref(getAccessToken());
-  const refreshToken = ref(getRefreshToken());
   const isLoading = ref(false);
   const error = ref(null);
+  const hasInitialized = ref(false);
+  let initializationPromise = null;
 
   // Getters
   const isAuthenticated = computed(() => !!accessToken.value && !!user.value);
@@ -30,12 +31,11 @@ export const useAuthStore = defineStore('auth', () => {
 
     try {
       const response = await apiClient.post('/auth/login', credentials);
-      const { access_token, refresh_token } = response.data;
+      const { access_token } = response.data;
 
-      // Store tokens
+      // Access token stays in memory only; refresh lives in the HttpOnly cookie.
       accessToken.value = access_token;
-      refreshToken.value = refresh_token;
-      persistTokens({ accessToken: access_token, refreshToken: refresh_token });
+      persistTokens({ accessToken: access_token });
 
       // Fetch user info
       await fetchCurrentUser();
@@ -59,10 +59,9 @@ export const useAuthStore = defineStore('auth', () => {
   async function logout(skipBackendCall = false) {
     isLoading.value = true;
 
-    // Only call backend logout if we have a valid token and not skipping
-    if (!skipBackendCall && accessToken.value) {
+    if (!skipBackendCall) {
       try {
-        await apiClient.post('/auth/logout');
+        await apiClient.post('/auth/logout', null, { withCredentials: true });
       } catch (err) {
         // Continue with logout even if backend call fails
         window.logService.warn('Logout API call failed, continuing with local logout', {
@@ -74,7 +73,6 @@ export const useAuthStore = defineStore('auth', () => {
     // Clear state
     user.value = null;
     accessToken.value = null;
-    refreshToken.value = null;
     error.value = null;
 
     // Clear in-memory token storage
@@ -117,21 +115,16 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function refreshAccessToken() {
-    if (!refreshToken.value) {
-      throw new Error('No refresh token available');
-    }
-
     try {
-      const response = await apiClient.post('/auth/refresh', {
-        refresh_token: refreshToken.value,
+      const response = await apiClient.post('/auth/refresh', null, {
+        withCredentials: true,
       });
 
-      const { access_token, refresh_token: new_refresh_token } = response.data;
+      const { access_token } = response.data;
 
-      // Update tokens (token rotation)
+      // Update the short-lived access token in memory only.
       accessToken.value = access_token;
-      refreshToken.value = new_refresh_token;
-      persistTokens({ accessToken: access_token, refreshToken: new_refresh_token });
+      persistTokens({ accessToken: access_token });
 
       window.logService.debug('Access token refreshed');
 
@@ -192,8 +185,7 @@ export const useAuthStore = defineStore('auth', () => {
     try {
       const { data } = await apiClient.post(`/dev/login-as/${username}`);
       accessToken.value = data.access_token;
-      refreshToken.value = data.refresh_token;
-      persistTokens({ accessToken: data.access_token, refreshToken: data.refresh_token });
+      persistTokens({ accessToken: data.access_token });
       await fetchCurrentUser();
       window.logService.info('dev quick-login', { username });
       return true;
@@ -212,15 +204,38 @@ export const useAuthStore = defineStore('auth', () => {
 
   // Initialize: Load user if token exists
   async function initialize() {
-    if (accessToken.value) {
+    if (initializationPromise) {
+      return initializationPromise;
+    }
+
+    initializationPromise = (async () => {
+      if (accessToken.value) {
+        try {
+          await fetchCurrentUser();
+        } catch (err) {
+          // Token might be expired, will be handled by interceptor
+          window.logService.warn('Failed to initialize user session', {
+            error: err.message,
+          });
+        }
+        return;
+      }
+
       try {
+        await refreshAccessToken();
         await fetchCurrentUser();
       } catch (err) {
-        // Token might be expired, will be handled by interceptor
         window.logService.warn('Failed to initialize user session', {
           error: err.message,
         });
       }
+    })();
+
+    try {
+      await initializationPromise;
+    } finally {
+      hasInitialized.value = true;
+      initializationPromise = null;
     }
   }
 
@@ -228,9 +243,9 @@ export const useAuthStore = defineStore('auth', () => {
     // State
     user,
     accessToken,
-    refreshToken,
     isLoading,
     error,
+    hasInitialized,
 
     // Getters
     isAuthenticated,

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -30,7 +30,9 @@ export const useAuthStore = defineStore('auth', () => {
     error.value = null;
 
     try {
-      const response = await apiClient.post('/auth/login', credentials);
+      const response = await apiClient.post('/auth/login', credentials, {
+        withCredentials: true,
+      });
       const { access_token } = response.data;
 
       // Access token stays in memory only; refresh lives in the HttpOnly cookie.

--- a/frontend/tests/e2e/helpers/auth.js
+++ b/frontend/tests/e2e/helpers/auth.js
@@ -62,7 +62,8 @@ export async function apiLogin(req, apiBase, username, password) {
       {
         name: 'csrf_token',
         value: readCookieValue(csrfHeader, 'csrf_token'),
-        url: API_COOKIE_URL,
+        url: BASE_URL,
+        path: '/',
       },
     ],
   };

--- a/frontend/tests/e2e/helpers/auth.js
+++ b/frontend/tests/e2e/helpers/auth.js
@@ -1,18 +1,34 @@
 /**
  * Helpers for API-backed Playwright authentication setup.
  *
- * These specs are not testing the login form itself. Priming the browser
- * session via API-issued tokens keeps the tests focused and avoids flaky
- * UI-auth setup work.
+ * Browser auth now boots from the refresh cookie + readable CSRF cookie.
+ * The app restores the access token in memory during its initialize flow.
  */
 
+const BASE_URL = process.env.E2E_BASE_URL || 'http://localhost:5173';
+const API_COOKIE_URL = `${BASE_URL}/api/v2`;
+
+function readCookieValue(setCookieHeader, name) {
+  const prefix = `${name}=`;
+  const cookiePart = setCookieHeader
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+
+  if (!cookiePart) {
+    throw new Error(`Missing ${name} in Set-Cookie header: ${setCookieHeader}`);
+  }
+
+  return cookiePart.slice(prefix.length);
+}
+
 /**
- * Obtain fresh auth tokens via the API.
+ * Obtain a fresh access token and auth cookies via the API.
  * @param {import('@playwright/test').APIRequestContext} req
  * @param {string} apiBase
  * @param {string} username
  * @param {string} password
- * @returns {Promise<{accessToken: string, refreshToken: string}>}
+ * @returns {Promise<{accessToken: string, cookies: {name: string, value: string, url: string, httpOnly?: boolean}[]}>}
  */
 export async function apiLogin(req, apiBase, username, password) {
   const resp = await req.post(`${apiBase}/auth/login`, {
@@ -21,24 +37,49 @@ export async function apiLogin(req, apiBase, username, password) {
   if (!resp.ok()) {
     throw new Error(`API login failed for ${username}: ${resp.status()} ${await resp.text()}`);
   }
+
   const body = await resp.json();
+  const setCookieHeaders = resp
+    .headersArray()
+    .filter((header) => header.name.toLowerCase() === 'set-cookie')
+    .map((header) => header.value);
+
+  const refreshHeader = setCookieHeaders.find((header) => header.startsWith('refresh_token='));
+  const csrfHeader = setCookieHeaders.find((header) => header.startsWith('csrf_token='));
+  if (!refreshHeader || !csrfHeader) {
+    throw new Error(`Auth cookies missing from login response for ${username}`);
+  }
+
   return {
     accessToken: body.access_token,
-    refreshToken: body.refresh_token,
+    cookies: [
+      {
+        name: 'refresh_token',
+        value: readCookieValue(refreshHeader, 'refresh_token'),
+        url: API_COOKIE_URL,
+        httpOnly: true,
+      },
+      {
+        name: 'csrf_token',
+        value: readCookieValue(csrfHeader, 'csrf_token'),
+        url: API_COOKIE_URL,
+      },
+    ],
   };
 }
 
 /**
- * Seed the browser tab's auth session before the app bootstraps.
+ * Seed the browser's auth cookies before the app bootstraps.
  * @param {import('@playwright/test').Page} page
- * @param {{ accessToken: string, refreshToken: string }} tokens
+ * @param {{ cookies: {name: string, value: string, url: string, httpOnly?: boolean}[] }} authState
  * @returns {Promise<void>}
  */
-export async function primeAuthSession(page, tokens) {
-  await page.addInitScript(({ accessToken, refreshToken }) => {
+export async function primeAuthSession(page, authState) {
+  await page.context().addCookies(authState.cookies);
+  await page.addInitScript(() => {
     window.localStorage.removeItem('remember_me');
     window.localStorage.removeItem('remembered_username');
-    window.sessionStorage.setItem('access_token', accessToken);
-    window.sessionStorage.setItem('refresh_token', refreshToken);
-  }, tokens);
+    window.sessionStorage.removeItem('access_token');
+    window.sessionStorage.removeItem('refresh_token');
+  });
 }

--- a/frontend/tests/e2e/helpers/auth.js
+++ b/frontend/tests/e2e/helpers/auth.js
@@ -6,7 +6,8 @@
  */
 
 const BASE_URL = process.env.E2E_BASE_URL || 'http://localhost:5173';
-const API_COOKIE_URL = `${BASE_URL}/api/v2`;
+const API_COOKIE_PATH = '/api/v2';
+const COOKIE_DOMAIN = new URL(BASE_URL).hostname;
 
 function readCookieValue(setCookieHeader, name) {
   const prefix = `${name}=`;
@@ -28,7 +29,7 @@ function readCookieValue(setCookieHeader, name) {
  * @param {string} apiBase
  * @param {string} username
  * @param {string} password
- * @returns {Promise<{accessToken: string, cookies: {name: string, value: string, url: string, httpOnly?: boolean}[]}>}
+ * @returns {Promise<{accessToken: string, cookies: {name: string, value: string, url?: string, domain?: string, path?: string, httpOnly?: boolean}[]}>}
  */
 export async function apiLogin(req, apiBase, username, password) {
   const resp = await req.post(`${apiBase}/auth/login`, {
@@ -56,14 +57,14 @@ export async function apiLogin(req, apiBase, username, password) {
       {
         name: 'refresh_token',
         value: readCookieValue(refreshHeader, 'refresh_token'),
-        url: API_COOKIE_URL,
+        domain: COOKIE_DOMAIN,
+        path: API_COOKIE_PATH,
         httpOnly: true,
       },
       {
         name: 'csrf_token',
         value: readCookieValue(csrfHeader, 'csrf_token'),
         url: BASE_URL,
-        path: '/',
       },
     ],
   };

--- a/frontend/tests/unit/api/session.spec.js
+++ b/frontend/tests/unit/api/session.spec.js
@@ -1,15 +1,12 @@
 /**
- * session.spec.js — tab-scoped token session tests for src/api/session.js
- *
- * Verifies tokens are cached in memory, persisted to sessionStorage for the
- * lifetime of the browser tab, and legacy localStorage keys are purged.
+ * session.spec.js — in-memory access token and CSRF cookie helpers
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('session — tab-scoped token session', () => {
+describe('session — in-memory access token only', () => {
   let clearTokens;
   let getAccessToken;
-  let getRefreshToken;
+  let getCsrfToken;
   let persistTokens;
 
   const localStorageMock = {
@@ -23,8 +20,7 @@ describe('session — tab-scoped token session', () => {
   };
 
   async function loadSessionModule() {
-    ({ clearTokens, getAccessToken, getRefreshToken, persistTokens } =
-      await import('@/api/session'));
+    ({ clearTokens, getAccessToken, getCsrfToken, persistTokens } = await import('@/api/session'));
   }
 
   beforeEach(async () => {
@@ -41,67 +37,59 @@ describe('session — tab-scoped token session', () => {
       writable: true,
       configurable: true,
     });
+    Object.defineProperty(globalThis, 'document', {
+      value: { cookie: '' },
+      writable: true,
+      configurable: true,
+    });
 
     await loadSessionModule();
   });
 
-  it('starts empty when the current tab has no stored tokens', () => {
+  it('starts with no in-memory access token and does not restore from sessionStorage', () => {
     expect(getAccessToken()).toBeNull();
-    expect(getRefreshToken()).toBeNull();
-    expect(sessionStorageMock.getItem).toHaveBeenCalledWith('access_token');
-    expect(sessionStorageMock.getItem).toHaveBeenCalledWith('refresh_token');
+    expect(sessionStorageMock.getItem).not.toHaveBeenCalled();
   });
 
-  it('purges legacy localStorage token keys during module initialization', async () => {
+  it('purges legacy token keys from browser storage during module initialization', async () => {
     await loadSessionModule();
 
     expect(localStorageMock.removeItem).toHaveBeenCalledWith('access_token');
     expect(localStorageMock.removeItem).toHaveBeenCalledWith('refresh_token');
+    expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('access_token');
+    expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('refresh_token');
   });
 
-  it('persists tokens in memory and sessionStorage', () => {
-    persistTokens({ accessToken: 'a-tok', refreshToken: 'r-tok' });
+  it('persists only the access token in memory', () => {
+    persistTokens({ accessToken: 'a-tok', refreshToken: 'ignored-refresh-token' });
 
     expect(getAccessToken()).toBe('a-tok');
-    expect(getRefreshToken()).toBe('r-tok');
-    expect(sessionStorageMock.setItem).toHaveBeenCalledWith('access_token', 'a-tok');
-    expect(sessionStorageMock.setItem).toHaveBeenCalledWith('refresh_token', 'r-tok');
+    expect(sessionStorageMock.setItem).not.toHaveBeenCalled();
   });
 
-  it('overwrites existing tokens on re-persist', () => {
-    persistTokens({ accessToken: 'old-a', refreshToken: 'old-r' });
-    persistTokens({ accessToken: 'new-a', refreshToken: 'new-r' });
-
-    expect(getAccessToken()).toBe('new-a');
-    expect(getRefreshToken()).toBe('new-r');
-  });
-
-  it('clears tokens from memory, sessionStorage, and legacy localStorage keys', () => {
-    persistTokens({ accessToken: 'a', refreshToken: 'r' });
+  it('clears the in-memory token and legacy browser storage keys', () => {
+    persistTokens({ accessToken: 'a' });
 
     localStorageMock.removeItem.mockClear();
     sessionStorageMock.removeItem.mockClear();
     clearTokens();
 
     expect(getAccessToken()).toBeNull();
-    expect(getRefreshToken()).toBeNull();
     expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('access_token');
     expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('refresh_token');
     expect(localStorageMock.removeItem).toHaveBeenCalledWith('access_token');
     expect(localStorageMock.removeItem).toHaveBeenCalledWith('refresh_token');
   });
 
-  it('restores tokens from sessionStorage on module load', async () => {
-    vi.resetModules();
-    sessionStorageMock.getItem.mockImplementation((key) => {
-      if (key === 'access_token') return 'saved-access';
-      if (key === 'refresh_token') return 'saved-refresh';
-      return null;
-    });
+  it('reads the readable CSRF cookie value', () => {
+    globalThis.document.cookie = 'theme=light; csrf_token=csrf-123; other=value';
 
-    await loadSessionModule();
+    expect(getCsrfToken()).toBe('csrf-123');
+  });
 
-    expect(getAccessToken()).toBe('saved-access');
-    expect(getRefreshToken()).toBe('saved-refresh');
+  it('returns null when the CSRF cookie is absent', () => {
+    globalThis.document.cookie = 'theme=light';
+
+    expect(getCsrfToken()).toBeNull();
   });
 });

--- a/frontend/tests/unit/api/transport.spec.js
+++ b/frontend/tests/unit/api/transport.spec.js
@@ -87,9 +87,14 @@ describe('transport — request auth and refresh queue', () => {
     expect(result.headers['X-CSRF-Token']).toBe('csrf-token');
   });
 
-  it('marks refresh and logout requests as credentialed cookie requests', async () => {
+  it('marks login, refresh, and logout requests as credentialed cookie requests', async () => {
     await import('@/api/transport');
 
+    const loginConfig = requestInterceptorFulfill({
+      url: '/auth/login',
+      method: 'post',
+      headers: {},
+    });
     const refreshConfig = requestInterceptorFulfill({
       url: '/auth/refresh',
       method: 'post',
@@ -101,6 +106,7 @@ describe('transport — request auth and refresh queue', () => {
       headers: {},
     });
 
+    expect(loginConfig.withCredentials).toBe(true);
     expect(refreshConfig.withCredentials).toBe(true);
     expect(logoutConfig.withCredentials).toBe(true);
   });
@@ -128,6 +134,31 @@ describe('transport — request auth and refresh queue', () => {
       expect(result.status).toBe('fulfilled');
     });
     expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a 401 request even when the original config had no headers object', async () => {
+    await import('@/api/transport');
+
+    const result = await responseInterceptorReject({
+      config: {
+        url: '/phenopackets/42',
+        _retry: false,
+      },
+      response: {
+        status: 401,
+        data: { detail: 'Token expired' },
+      },
+      message: 'Request failed with status code 401',
+    });
+
+    expect(result).toEqual({ data: { ok: true } });
+    expect(mockAxiosInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer fresh-token',
+        }),
+      })
+    );
   });
 
   it('skips refresh for auth login, refresh, and logout endpoints', async () => {

--- a/frontend/tests/unit/api/transport.spec.js
+++ b/frontend/tests/unit/api/transport.spec.js
@@ -1,25 +1,13 @@
 /**
- * transport.spec.js — Thunder-herd guard test for src/api/transport.js
- *
- * Fires N concurrent requests that all receive 401, then asserts that
- * the refresh endpoint is called exactly once (the queue coalesces).
- *
- * Uses vi.mock to intercept axios and the auth store without any extra
- * dependencies (no axios-mock-adapter needed).
+ * transport.spec.js — request/refresh queue behavior for src/api/transport.js
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// ---------------------------------------------------------------------------
-// Mocks — must be declared before importing the module under test
-// ---------------------------------------------------------------------------
-
-// Track interceptors registered by transport.js
 let requestInterceptorFulfill;
 let _requestInterceptorReject;
 let _responseInterceptorFulfill;
 let responseInterceptorReject;
 
-// Mock axios — capture interceptors and provide a callable client
 const mockAxiosInstance = vi.fn();
 mockAxiosInstance.interceptors = {
   request: {
@@ -45,13 +33,15 @@ vi.mock('axios', () => ({
   },
 }));
 
-// Mock session — so the request interceptor can read the access token
+const mockGetAccessToken = vi.fn(() => 'initial-token');
+const mockGetCsrfToken = vi.fn(() => 'csrf-token');
+
 vi.mock('@/api/session', () => ({
-  getAccessToken: vi.fn(() => 'initial-token'),
+  getAccessToken: mockGetAccessToken,
+  getCsrfToken: mockGetCsrfToken,
   clearTokens: vi.fn(),
 }));
 
-// Mock auth store — refreshAccessToken resolves with a new token
 const mockRefreshAccessToken = vi.fn();
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => ({
@@ -59,7 +49,6 @@ vi.mock('@/stores/authStore', () => ({
   }),
 }));
 
-// Provide window.logService stub
 beforeEach(() => {
   globalThis.window = globalThis.window || {};
   globalThis.window.logService = {
@@ -71,35 +60,54 @@ beforeEach(() => {
   globalThis.window.location = { pathname: '/somewhere', href: '' };
 });
 
-describe('transport — refresh-queue thunder-herd guard', () => {
+describe('transport — request auth and refresh queue', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
+    mockGetAccessToken.mockReturnValue('initial-token');
+    mockGetCsrfToken.mockReturnValue('csrf-token');
     mockRefreshAccessToken.mockResolvedValue('fresh-token');
-
-    // When apiClient retries a request, resolve it successfully
     mockAxiosInstance.mockResolvedValue({ data: { ok: true } });
   });
 
-  it('registers request and response interceptors', async () => {
-    // Dynamic import so mocks are in place first
+  it('attaches Bearer token from session', async () => {
     await import('@/api/transport');
 
-    expect(mockAxiosInstance.interceptors.request.use).toHaveBeenCalledOnce();
-    expect(mockAxiosInstance.interceptors.response.use).toHaveBeenCalledOnce();
-  });
-
-  it('request interceptor attaches Bearer token from session', async () => {
-    await import('@/api/transport');
-
-    const config = { headers: {} };
+    const config = { method: 'get', headers: {} };
     const result = requestInterceptorFulfill(config);
     expect(result.headers.Authorization).toBe('Bearer initial-token');
+  });
+
+  it('injects X-CSRF-Token on unsafe requests when the readable cookie exists', async () => {
+    await import('@/api/transport');
+
+    const config = { method: 'post', headers: {} };
+    const result = requestInterceptorFulfill(config);
+
+    expect(result.headers['X-CSRF-Token']).toBe('csrf-token');
+  });
+
+  it('marks refresh and logout requests as credentialed cookie requests', async () => {
+    await import('@/api/transport');
+
+    const refreshConfig = requestInterceptorFulfill({
+      url: '/auth/refresh',
+      method: 'post',
+      headers: {},
+    });
+    const logoutConfig = requestInterceptorFulfill({
+      url: '/auth/logout',
+      method: 'post',
+      headers: {},
+    });
+
+    expect(refreshConfig.withCredentials).toBe(true);
+    expect(logoutConfig.withCredentials).toBe(true);
   });
 
   it('coalesces 5 concurrent 401s into a single refresh call', async () => {
     await import('@/api/transport');
 
-    // Build 5 "401 error" objects with distinct configs
     const errors = Array.from({ length: 5 }, (_, i) => ({
       config: {
         url: `/phenopackets/${i}`,
@@ -113,44 +121,28 @@ describe('transport — refresh-queue thunder-herd guard', () => {
       message: 'Request failed with status code 401',
     }));
 
-    // Fire all 5 through the response error interceptor concurrently
     const promises = errors.map((err) => responseInterceptorReject(err));
-
-    // Wait for all to settle
     const results = await Promise.allSettled(promises);
 
-    // All should have resolved (retried successfully)
-    results.forEach((r) => {
-      expect(r.status).toBe('fulfilled');
+    results.forEach((result) => {
+      expect(result.status).toBe('fulfilled');
     });
-
-    // The refresh function should have been called exactly ONCE
     expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
   });
 
-  it('skips refresh for auth login endpoint', async () => {
+  it('skips refresh for auth login, refresh, and logout endpoints', async () => {
     await import('@/api/transport');
 
-    const error = {
-      config: { url: '/auth/login', headers: {}, _retry: false },
-      response: { status: 401, data: { detail: 'Bad credentials' } },
-      message: 'Request failed with status code 401',
-    };
+    for (const url of ['/auth/login', '/auth/refresh', '/auth/logout']) {
+      const error = {
+        config: { url, headers: {}, _retry: false },
+        response: { status: 401, data: { detail: 'Unauthorized' } },
+        message: 'Request failed with status code 401',
+      };
 
-    await expect(responseInterceptorReject(error)).rejects.toBeTruthy();
-    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
-  });
+      await expect(responseInterceptorReject(error)).rejects.toBeTruthy();
+    }
 
-  it('skips refresh for auth refresh endpoint', async () => {
-    await import('@/api/transport');
-
-    const error = {
-      config: { url: '/auth/refresh', headers: {}, _retry: false },
-      response: { status: 401, data: { detail: 'Refresh expired' } },
-      message: 'Request failed with status code 401',
-    };
-
-    await expect(responseInterceptorReject(error)).rejects.toBeTruthy();
     expect(mockRefreshAccessToken).not.toHaveBeenCalled();
   });
 
@@ -168,14 +160,12 @@ describe('transport — refresh-queue thunder-herd guard', () => {
     const promises = errors.map((err) => responseInterceptorReject(err));
     const results = await Promise.allSettled(promises);
 
-    // All should be rejected
-    results.forEach((r) => {
-      expect(r.status).toBe('rejected');
+    results.forEach((result) => {
+      expect(result.status).toBe('rejected');
     });
 
-    // Still only one refresh attempt
-    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
     const { clearTokens } = await import('@/api/session');
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
     expect(clearTokens).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/tests/unit/e2e/authHelpers.spec.js
+++ b/frontend/tests/unit/e2e/authHelpers.spec.js
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { apiLogin } from '@/../tests/e2e/helpers/auth.js';
+
+describe('e2e auth helpers', () => {
+  it('returns Playwright cookie objects without mixing url and path', async () => {
+    const req = {
+      post: vi.fn().mockResolvedValue({
+        ok: () => true,
+        json: async () => ({ access_token: 'access-token' }),
+        headersArray: () => [
+          { name: 'set-cookie', value: 'refresh_token=refresh-value; Path=/api/v2; HttpOnly' },
+          { name: 'set-cookie', value: 'csrf_token=csrf-value; Path=/' },
+        ],
+      }),
+    };
+
+    const result = await apiLogin(req, 'http://localhost:8000/api/v2', 'admin', 'secret');
+
+    expect(result.accessToken).toBe('access-token');
+    expect(result.cookies).toEqual([
+      {
+        name: 'refresh_token',
+        value: 'refresh-value',
+        domain: 'localhost',
+        path: '/api/v2',
+        httpOnly: true,
+      },
+      {
+        name: 'csrf_token',
+        value: 'csrf-value',
+        url: 'http://localhost:5173',
+      },
+    ]);
+    expect(result.cookies[0]).not.toHaveProperty('url');
+    expect(result.cookies[1]).not.toHaveProperty('path');
+  });
+});

--- a/frontend/tests/unit/stores/authStore.spec.js
+++ b/frontend/tests/unit/stores/authStore.spec.js
@@ -114,6 +114,14 @@ describe('Auth Store', () => {
       });
 
       expect(success).toBe(true);
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/auth/login',
+        {
+          username: 'testuser',
+          password: 'password123',
+        },
+        { withCredentials: true }
+      );
       expect(authStore.accessToken).toBe('mock_access_token');
       expect(getAccessToken()).toBe('mock_access_token');
       expect(authStore.user.username).toBe('testuser');

--- a/frontend/tests/unit/stores/authStore.spec.js
+++ b/frontend/tests/unit/stores/authStore.spec.js
@@ -1,16 +1,12 @@
 /**
- * Unit tests for the authentication store (authStore)
- *
- * Covers the public auth flows against the release-safe in-memory
- * session helpers rather than persistent browser storage.
+ * Unit tests for the authentication store (authStore).
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { setActivePinia, createPinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
 
-import { clearTokens, getAccessToken, getRefreshToken, persistTokens } from '@/api/session';
+import { clearTokens, getAccessToken, persistTokens } from '@/api/session';
 
-// Mock the API module with named export - must be before imports that use it
 vi.mock('@/api', () => ({
   apiClient: {
     post: vi.fn(),
@@ -18,9 +14,8 @@ vi.mock('@/api', () => ({
   },
 }));
 
-// Import after mock is set up
-import { useAuthStore } from '@/stores/authStore';
 import { apiClient } from '@/api';
+import { useAuthStore } from '@/stores/authStore';
 
 globalThis.window = globalThis.window || {};
 globalThis.window.logService = {
@@ -52,25 +47,23 @@ describe('Auth Store', () => {
   });
 
   describe('Initial State', () => {
-    it('initializes with null user and no tokens', () => {
+    it('initializes with null user and no access token', () => {
       const authStore = useAuthStore();
 
       expect(authStore.user).toBeNull();
       expect(authStore.accessToken).toBeNull();
-      expect(authStore.refreshToken).toBeNull();
+      expect('refreshToken' in authStore).toBe(false);
       expect(authStore.isLoading).toBe(false);
       expect(authStore.error).toBeNull();
       expect(getAccessToken()).toBeNull();
-      expect(getRefreshToken()).toBeNull();
     });
 
-    it('initializes from the in-memory session when tokens already exist', () => {
-      persistTokens({ accessToken: 'mock_access_token', refreshToken: 'mock_refresh_token' });
+    it('initializes from the in-memory access token when one already exists', () => {
+      persistTokens({ accessToken: 'mock_access_token' });
 
       const authStore = useAuthStore();
 
       expect(authStore.accessToken).toBe('mock_access_token');
-      expect(authStore.refreshToken).toBe('mock_refresh_token');
     });
   });
 
@@ -91,40 +84,15 @@ describe('Auth Store', () => {
       authStore.user = { username: 'test' };
       expect(authStore.isAuthenticated).toBe(true);
     });
-
-    it('computes role helpers correctly', () => {
-      const authStore = useAuthStore();
-
-      expect(authStore.isAdmin).toBe(false);
-      expect(authStore.isCurator).toBe(false);
-
-      authStore.user = { role: 'curator' };
-      expect(authStore.isAdmin).toBe(false);
-      expect(authStore.isCurator).toBe(true);
-
-      authStore.user = { role: 'admin' };
-      expect(authStore.isAdmin).toBe(true);
-      expect(authStore.isCurator).toBe(true);
-    });
-
-    it('returns permissions from the current user', () => {
-      const authStore = useAuthStore();
-
-      expect(authStore.userPermissions).toEqual([]);
-
-      authStore.user = { permissions: ['read:data', 'write:data'] };
-      expect(authStore.userPermissions).toEqual(['read:data', 'write:data']);
-    });
   });
 
   describe('Login Action', () => {
-    it('stores issued tokens in memory and loads the current user', async () => {
+    it('stores only the access token in memory and loads the current user', async () => {
       const authStore = useAuthStore();
 
       apiClient.post.mockResolvedValueOnce({
         data: {
           access_token: 'mock_access_token',
-          refresh_token: 'mock_refresh_token',
           token_type: 'bearer',
           expires_in: 1800,
         },
@@ -147,34 +115,11 @@ describe('Auth Store', () => {
 
       expect(success).toBe(true);
       expect(authStore.accessToken).toBe('mock_access_token');
-      expect(authStore.refreshToken).toBe('mock_refresh_token');
-      expect(authStore.user.username).toBe('testuser');
       expect(getAccessToken()).toBe('mock_access_token');
-      expect(getRefreshToken()).toBe('mock_refresh_token');
+      expect(authStore.user.username).toBe('testuser');
       expect(window.logService.info).toHaveBeenCalledWith('User logged in successfully', {
         username: 'testuser',
       });
-    });
-
-    it('clears the error state before a new login attempt', async () => {
-      const authStore = useAuthStore();
-      authStore.error = 'Previous error';
-
-      apiClient.post.mockResolvedValueOnce({
-        data: {
-          access_token: 'token',
-          refresh_token: 'refresh',
-          token_type: 'bearer',
-          expires_in: 1800,
-        },
-      });
-      apiClient.get.mockResolvedValueOnce({
-        data: { id: 1, username: 'test' },
-      });
-
-      await authStore.login({ username: 'test', password: 'pass' });
-
-      expect(authStore.error).toBeNull();
     });
 
     it('surfaces login failures without mutating the session', async () => {
@@ -190,18 +135,16 @@ describe('Auth Store', () => {
 
       expect(authStore.error).toBe('Invalid credentials');
       expect(getAccessToken()).toBeNull();
-      expect(getRefreshToken()).toBeNull();
     });
   });
 
   describe('Logout Action', () => {
-    it('clears the session tokens and local store state', async () => {
+    it('calls backend logout once and clears the session state', async () => {
       const authStore = useAuthStore();
 
       authStore.accessToken = 'test_token';
-      authStore.refreshToken = 'test_refresh';
       authStore.user = { username: 'test', id: 1 };
-      persistTokens({ accessToken: 'test_token', refreshToken: 'test_refresh' });
+      persistTokens({ accessToken: 'test_token' });
 
       apiClient.post.mockResolvedValueOnce({
         data: { message: 'Logged out successfully' },
@@ -209,12 +152,26 @@ describe('Auth Store', () => {
 
       await authStore.logout();
 
+      expect(apiClient.post).toHaveBeenCalledWith('/auth/logout', null, {
+        withCredentials: true,
+      });
       expect(authStore.accessToken).toBeNull();
-      expect(authStore.refreshToken).toBeNull();
       expect(authStore.user).toBeNull();
       expect(getAccessToken()).toBeNull();
-      expect(getRefreshToken()).toBeNull();
-      expect(window.logService.info).toHaveBeenCalledWith('User logged out');
+    });
+
+    it('still attempts backend logout when no access token is present', async () => {
+      const authStore = useAuthStore();
+
+      apiClient.post.mockResolvedValueOnce({ data: { message: 'ok' } });
+
+      await authStore.logout();
+
+      expect(apiClient.post).toHaveBeenCalledWith('/auth/logout', null, {
+        withCredentials: true,
+      });
+      expect(authStore.user).toBeNull();
+      expect(getAccessToken()).toBeNull();
     });
 
     it('still clears the session if the backend logout call fails', async () => {
@@ -222,7 +179,7 @@ describe('Auth Store', () => {
 
       authStore.accessToken = 'test_token';
       authStore.user = { username: 'test' };
-      persistTokens({ accessToken: 'test_token', refreshToken: 'test_refresh' });
+      persistTokens({ accessToken: 'test_token' });
 
       apiClient.post.mockRejectedValueOnce(new Error('API Error'));
 
@@ -231,7 +188,6 @@ describe('Auth Store', () => {
       expect(authStore.accessToken).toBeNull();
       expect(authStore.user).toBeNull();
       expect(getAccessToken()).toBeNull();
-      expect(getRefreshToken()).toBeNull();
       expect(window.logService.warn).toHaveBeenCalled();
     });
   });
@@ -255,36 +211,16 @@ describe('Auth Store', () => {
 
       expect(authStore.user.username).toBe('testuser');
       expect(apiClient.get).toHaveBeenCalledWith('/auth/me');
-      expect(window.logService.debug).toHaveBeenCalled();
-    });
-
-    it('logs out when fetching the current user returns 401', async () => {
-      const authStore = useAuthStore();
-      authStore.accessToken = 'test_token';
-      persistTokens({ accessToken: 'test_token', refreshToken: 'test_refresh' });
-
-      apiClient.get.mockRejectedValueOnce({
-        response: { status: 401 },
-        message: 'Unauthorized',
-      });
-      apiClient.post.mockResolvedValueOnce({ data: {} });
-
-      await expect(authStore.fetchCurrentUser()).rejects.toThrow();
-
-      expect(authStore.accessToken).toBeNull();
-      expect(getAccessToken()).toBeNull();
     });
   });
 
   describe('Refresh Access Token Action', () => {
-    it('rotates tokens in memory', async () => {
+    it('uses the cookie-backed refresh endpoint and rotates only the access token', async () => {
       const authStore = useAuthStore();
-      authStore.refreshToken = 'old_refresh_token';
 
       apiClient.post.mockResolvedValueOnce({
         data: {
           access_token: 'new_access_token',
-          refresh_token: 'new_refresh_token',
           token_type: 'bearer',
           expires_in: 1800,
         },
@@ -293,72 +229,31 @@ describe('Auth Store', () => {
       const result = await authStore.refreshAccessToken();
 
       expect(result).toBe('new_access_token');
+      expect(apiClient.post).toHaveBeenCalledWith('/auth/refresh', null, {
+        withCredentials: true,
+      });
       expect(authStore.accessToken).toBe('new_access_token');
-      expect(authStore.refreshToken).toBe('new_refresh_token');
       expect(getAccessToken()).toBe('new_access_token');
-      expect(getRefreshToken()).toBe('new_refresh_token');
-      expect(window.logService.debug).toHaveBeenCalledWith('Access token refreshed');
     });
 
     it('clears the in-memory session when refresh fails', async () => {
       const authStore = useAuthStore();
-      authStore.refreshToken = 'invalid_refresh_token';
       authStore.accessToken = 'old_token';
       authStore.user = { username: 'test' };
-      persistTokens({ accessToken: 'old_token', refreshToken: 'invalid_refresh_token' });
+      persistTokens({ accessToken: 'old_token' });
 
       apiClient.post.mockRejectedValueOnce(new Error('Invalid refresh token'));
 
       await expect(authStore.refreshAccessToken()).rejects.toThrow('Invalid refresh token');
 
       expect(authStore.accessToken).toBeNull();
-      expect(authStore.refreshToken).toBeNull();
       expect(authStore.user).toBeNull();
       expect(getAccessToken()).toBeNull();
-      expect(getRefreshToken()).toBeNull();
-      expect(window.logService.error).toHaveBeenCalled();
-    });
-  });
-
-  describe('Change Password Action', () => {
-    it('calls the backend password change endpoint', async () => {
-      const authStore = useAuthStore();
-
-      apiClient.post.mockResolvedValueOnce({
-        data: { message: 'Password changed successfully' },
-      });
-
-      const success = await authStore.changePassword('oldpass', 'newpass');
-
-      expect(success).toBe(true);
-      expect(authStore.error).toBeNull();
-      expect(apiClient.post).toHaveBeenCalledWith('/auth/change-password', {
-        current_password: 'oldpass',
-        new_password: 'newpass',
-      });
-      expect(window.logService.info).toHaveBeenCalledWith('Password changed successfully');
-    });
-
-    it('surfaces password change failures', async () => {
-      const authStore = useAuthStore();
-
-      apiClient.post.mockRejectedValueOnce({
-        response: {
-          data: {
-            detail: 'Current password is incorrect',
-          },
-        },
-      });
-
-      await expect(authStore.changePassword('wrongpass', 'newpass')).rejects.toThrow();
-
-      expect(authStore.error).toBe('Current password is incorrect');
-      expect(window.logService.error).toHaveBeenCalled();
     });
   });
 
   describe('Initialize Action', () => {
-    it('fetches the current user when an in-memory token exists', async () => {
+    it('fetches the current user when an access token already exists in memory', async () => {
       persistTokens({ accessToken: 'existing_token' });
 
       apiClient.get.mockResolvedValueOnce({
@@ -373,30 +268,45 @@ describe('Auth Store', () => {
       const authStore = useAuthStore();
       await authStore.initialize();
 
-      expect(authStore.user.username).toBe('testuser');
+      expect(apiClient.post).not.toHaveBeenCalled();
       expect(apiClient.get).toHaveBeenCalledWith('/auth/me');
+      expect(authStore.user.username).toBe('testuser');
     });
 
-    it('does not fetch the current user if no token exists', async () => {
+    it('attempts one refresh bootstrap before loading the current user', async () => {
       const authStore = useAuthStore();
+
+      apiClient.post.mockResolvedValueOnce({
+        data: {
+          access_token: 'bootstrapped_token',
+          token_type: 'bearer',
+          expires_in: 1800,
+        },
+      });
+      apiClient.get.mockResolvedValueOnce({
+        data: { id: 1, username: 'testuser', role: 'viewer' },
+      });
+
+      await authStore.initialize();
+
+      expect(apiClient.post).toHaveBeenCalledWith('/auth/refresh', null, {
+        withCredentials: true,
+      });
+      expect(apiClient.get).toHaveBeenCalledWith('/auth/me');
+      expect(authStore.accessToken).toBe('bootstrapped_token');
+      expect(authStore.user.username).toBe('testuser');
+    });
+
+    it('stays anonymous when refresh bootstrap fails', async () => {
+      const authStore = useAuthStore();
+
+      apiClient.post.mockRejectedValueOnce(new Error('Refresh failed'));
+
       await authStore.initialize();
 
       expect(apiClient.get).not.toHaveBeenCalled();
       expect(authStore.user).toBeNull();
-    });
-
-    it('logs a warning if initialization cannot restore the current user', async () => {
-      persistTokens({ accessToken: 'invalid_token' });
-
-      apiClient.get.mockRejectedValueOnce({
-        response: { status: 401 },
-        message: 'Unauthorized',
-      });
-      apiClient.post.mockResolvedValueOnce({ data: {} });
-
-      const authStore = useAuthStore();
-      await authStore.initialize();
-
+      expect(authStore.accessToken).toBeNull();
       expect(window.logService.warn).toHaveBeenCalledWith(
         'Failed to initialize user session',
         expect.any(Object)
@@ -405,28 +315,26 @@ describe('Auth Store', () => {
   });
 
   describe('Dev Quick Login', () => {
-    it('refuses quick-login when the frontend flag is disabled', async () => {
-      import.meta.env.VITE_ENABLE_DEV_AUTH = 'false';
+    it('stores only the access token from dev quick-login', async () => {
       const authStore = useAuthStore();
 
-      await expect(authStore.devLoginAs('dev-curator')).rejects.toThrow(
-        'Dev quick-login is disabled'
-      );
-
-      expect(authStore.error).toContain('VITE_ENABLE_DEV_AUTH=true');
-      expect(apiClient.post).not.toHaveBeenCalled();
-    });
-
-    it('surfaces backend dev-auth misconfiguration on 404', async () => {
-      const authStore = useAuthStore();
-      apiClient.post.mockRejectedValueOnce({
-        response: { status: 404, data: { detail: 'Not Found' } },
-        message: 'Request failed with status code 404',
+      apiClient.post.mockResolvedValueOnce({
+        data: {
+          access_token: 'dev_access_token',
+          refresh_token: 'ignored-refresh-token',
+          token_type: 'bearer',
+          expires_in: 1800,
+        },
+      });
+      apiClient.get.mockResolvedValueOnce({
+        data: { id: 1, username: 'dev-admin', role: 'admin' },
       });
 
-      await expect(authStore.devLoginAs('dev-curator')).rejects.toThrow();
+      await authStore.devLoginAs('dev-admin');
 
-      expect(authStore.error).toContain('ENABLE_DEV_AUTH=true');
+      expect(authStore.accessToken).toBe('dev_access_token');
+      expect(getAccessToken()).toBe('dev_access_token');
+      expect('refreshToken' in authStore).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- move auth refresh from client-stored tokens to cookie-backed refresh sessions with CSRF protection
- invalidate refresh sessions on password change, password reset, and deactivation flows
- migrate frontend auth bootstrap and transport logic to in-memory access tokens and cookie-based session recovery

## Test Plan
- `make lint`
- `make typecheck`
- `cd backend && uv run pytest tests/test_auth.py tests/test_auth_tokens.py tests/test_auth_password_change.py tests/test_auth_password_reset.py tests/test_dev_endpoints.py tests/test_auth_csrf.py tests/test_auth_refresh_sessions.py -q`
- `cd frontend && npm test -- --run tests/unit/stores/authStore.spec.js tests/unit/api/transport.spec.js tests/unit/components/auth/DevQuickLogin.spec.js tests/unit/api/session.spec.js`
- `cd frontend && npm run format:check`
- `cd frontend && npm run lint:check`
- live browser auth smoke against local backend `:8000` and frontend `:4173` (`AUTH_SMOKE_OK`)

## Notes
- `npm run lint:check` still reports pre-existing warnings in unrelated frontend files, but no errors
