### PR TITLE
fix: harden workflow integrity races and timeline visibility

### DIFF
--- a/.planning/plans/2026-04-15-release-hardening-and-8plus-plan.md
+++ b/.planning/plans/2026-04-15-release-hardening-and-8plus-plan.md
@@ -121,7 +121,7 @@ This is the highest-leverage work. It should start before any additional collabo
 
 ### Workstream B: Workflow Integrity
 
-- [ ] Lock down the timeline endpoint to the same visibility rules as detail/list routes.
+- [x] Lock down the timeline endpoint to the same visibility rules as detail/list routes.
   Files:
   `backend/app/phenopackets/routers/crud_timeline.py`
   related detail/list visibility helpers and tests.

--- a/backend/app/phenopackets/routers/crud.py
+++ b/backend/app/phenopackets/routers/crud.py
@@ -421,6 +421,7 @@ async def update_phenopacket(
     - Any other state → 409 ``invalid_transition`` (withdraw or resubmit first).
 
     Exception → HTTP mapping:
+    - ``RecordNotFound``     → 404 not found / soft-deleted during race
     - ``RevisionMismatch``  → 409 revision_mismatch
     - ``EditInProgress``    → 409 edit_in_progress
     - ``ForbiddenNotOwner`` → 403 forbidden_not_owner
@@ -458,6 +459,8 @@ async def update_phenopacket(
             ),
             actor=current_user,
         )
+    except PhenopacketStateService.RecordNotFound as exc:
+        raise HTTPException(status_code=404, detail="Phenopacket not found") from exc
     except PhenopacketStateService.RevisionMismatch as exc:
         raise HTTPException(
             status_code=409,

--- a/backend/app/phenopackets/routers/crud_timeline.py
+++ b/backend/app/phenopackets/routers/crud_timeline.py
@@ -148,8 +148,9 @@ async def get_phenotype_timeline(
     ``{"subject_id": ..., "current_age": ..., "features": [...]}``.
 
     Public callers only see published head content. Curators/admins can
-    inspect the working copy, including soft-deleted rows, so the timeline
-    remains usable for audit and review flows.
+    inspect the working copy allowed by the standard curator visibility
+    filter, but soft-deleted rows are hidden here just like they are on the
+    detail and list endpoints.
     """
     is_curator = is_curator_or_admin(current_user)
     stmt = (

--- a/backend/app/phenopackets/routers/crud_timeline.py
+++ b/backend/app/phenopackets/routers/crud_timeline.py
@@ -16,13 +16,17 @@ import re
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.auth import get_optional_user, is_curator_or_admin
 from app.database import get_db
 from app.models.user import User
-from app.phenopackets.repositories import PhenopacketRepository
+from app.phenopackets.models import Phenopacket
 from app.phenopackets.repositories.visibility import (
+    curator_filter,
+    public_filter,
     resolve_curator_content,
     resolve_public_content,
 )
@@ -147,11 +151,25 @@ async def get_phenotype_timeline(
     inspect the working copy, including soft-deleted rows, so the timeline
     remains usable for audit and review flows.
     """
-    repo = PhenopacketRepository(db)
     is_curator = is_curator_or_admin(current_user)
-    phenopacket_record = await repo.get_by_id(
-        phenopacket_id, include_deleted=is_curator
+    stmt = (
+        select(Phenopacket)
+        .where(Phenopacket.phenopacket_id == phenopacket_id)
+        .options(
+            selectinload(Phenopacket.created_by_user),
+            selectinload(Phenopacket.updated_by_user),
+            selectinload(Phenopacket.deleted_by_user),
+            selectinload(Phenopacket.draft_owner),
+            selectinload(Phenopacket.editing_revision),
+        )
     )
+    if is_curator:
+        stmt = curator_filter(stmt)
+    else:
+        stmt = public_filter(stmt)
+
+    result = await db.execute(stmt)
+    phenopacket_record = result.scalar_one_or_none()
     if phenopacket_record is None:
         raise HTTPException(
             status_code=404, detail=f"Phenopacket '{phenopacket_id}' not found"
@@ -161,16 +179,6 @@ async def get_phenotype_timeline(
     if is_curator:
         phenopacket_data = resolve_curator_content(phenopacket_record)
     else:
-        # Public / viewer callers must obey the published-only visibility
-        # model used by the main detail and list routes.
-        if (
-            phenopacket_record.state != "published"
-            or phenopacket_record.head_published_revision_id is None
-        ):
-            raise HTTPException(
-                status_code=404,
-                detail=f"Phenopacket '{phenopacket_id}' not found",
-            )
         public_content = await resolve_public_content(db, phenopacket_record)
         if public_content is None:
             raise HTTPException(

--- a/backend/app/phenopackets/routers/transitions.py
+++ b/backend/app/phenopackets/routers/transitions.py
@@ -111,6 +111,7 @@ async def post_transition(
     Returns ``{"phenopacket": PhenopacketResponse, "revision": RevisionResponse}``.
 
     HTTP error mapping:
+    - ``RecordNotFound``     → 404
     - ``RevisionMismatch``    → 409  code=revision_mismatch
     - ``InvalidTransition``   → 409  code=invalid_transition
     - ``ForbiddenNotOwner``   → 403  code=forbidden_not_owner
@@ -128,6 +129,8 @@ async def post_transition(
             expected_revision=body.revision,
             actor=current_user,
         )
+    except PhenopacketStateService.RecordNotFound as exc:
+        raise HTTPException(status_code=404, detail="Phenopacket not found") from exc
     except PhenopacketStateService.RevisionMismatch as exc:
         raise HTTPException(
             status_code=409,

--- a/backend/app/phenopackets/services/state_service.py
+++ b/backend/app/phenopackets/services/state_service.py
@@ -51,6 +51,9 @@ class PhenopacketStateService:
     class ForbiddenNotOwner(Exception):
         """Curator is not the draft owner and not admin."""
 
+    class RecordNotFound(Exception):
+        """Record does not exist anymore by the time the mutation acquires its lock."""
+
     # ------------------------------------------------------------------
 
     def __init__(self, db: AsyncSession) -> None:
@@ -68,7 +71,7 @@ class PhenopacketStateService:
         stmt = select(Phenopacket).where(Phenopacket.id == record_id).with_for_update()
         pp = (await self.db.execute(stmt)).scalar_one_or_none()
         if pp is None:
-            raise KeyError(f"Phenopacket {record_id!r} not found")
+            raise self.RecordNotFound(f"Phenopacket {record_id!r} not found")
         if pp.revision != expected_revision:
             raise self.RevisionMismatch(
                 f"expected revision {expected_revision}, current is {pp.revision}"

--- a/backend/tests/test_crud_related_and_timeline.py
+++ b/backend/tests/test_crud_related_and_timeline.py
@@ -375,10 +375,10 @@ class TestCrudTimelineEndpoint:
         response = await async_client.get("/api/v2/phenopackets/TL-EP-DELETED/timeline")
         assert response.status_code == 404
 
-    async def test_timeline_returns_curator_view_for_soft_deleted_phenopacket(
+    async def test_timeline_hides_soft_deleted_phenopacket_from_curator_client(
         self, async_client, db_session, admin_user, curator_headers
     ):
-        """Curators should still be able to inspect deleted history."""
+        """Timeline should obey the same no-deleted rule as detail/list routes."""
         row = _make_phenopacket_row(
             phenopacket_id="TL-EP-DELETED-CURATOR",
             subject_id="SUB-TL-DELETED-CURATOR",
@@ -392,8 +392,7 @@ class TestCrudTimelineEndpoint:
             "/api/v2/phenopackets/TL-EP-DELETED-CURATOR/timeline",
             headers=curator_headers,
         )
-        assert response.status_code == 200
-        assert response.json()["subject_id"] == "SUB-TL-DELETED-CURATOR"
+        assert response.status_code == 404
 
     async def test_timeline_returns_head_content_for_public_client_during_clone(
         self, async_client, db_session, admin_user, curator_headers

--- a/backend/tests/test_phenopackets_delete_revision.py
+++ b/backend/tests/test_phenopackets_delete_revision.py
@@ -20,6 +20,7 @@ from app.phenopackets.services.phenopacket_service import (
     PhenopacketService,
     ServiceConflict,
 )
+from app.phenopackets.services.state_service import PhenopacketStateService
 
 
 def _valid_payload(phenopacket_id: str, subject_id: str = "s", sex: str = "MALE"):
@@ -203,3 +204,131 @@ async def test_delete_fails_when_revision_changes_before_commit(
         update_done.set()
 
     await __import__("asyncio").gather(actor_a_delete(), actor_b_update())
+
+
+@pytest.mark.asyncio
+async def test_transition_fails_cleanly_when_delete_wins_after_preread(
+    db_session,
+    admin_user,
+):
+    """A state transition that loses to a concurrent delete must not leak KeyError.
+
+    The HTTP transition route currently performs an unlocked pre-read to resolve the
+    phenopacket id into the internal UUID before delegating to the state service.
+    If another session soft-deletes the row after that pre-read but before
+    ``SELECT .. FOR UPDATE`` runs inside ``_lock_and_check()``, the service should
+    raise a stable domain error that the router can map to 404 instead of leaking a
+    raw ``KeyError`` as a 500.
+    """
+    phenopacket = Phenopacket(
+        phenopacket_id="transition-delete-race",
+        phenopacket=_valid_payload("transition-delete-race")["phenopacket"],
+        subject_id="s",
+        subject_sex="MALE",
+        created_by_id=admin_user.id,
+        state="draft",
+        revision=1,
+    )
+    db_session.add(phenopacket)
+    await db_session.commit()
+
+    preread_complete = __import__("asyncio").Event()
+    delete_complete = __import__("asyncio").Event()
+
+    async def actor_a_transition() -> None:
+        async with async_session_maker() as session:
+            repo = PhenopacketRepository(session)
+            loaded = await repo.get_by_id("transition-delete-race")
+            assert loaded is not None
+            preread_complete.set()
+            await delete_complete.wait()
+
+            svc = PhenopacketStateService(session)
+            with pytest.raises(PhenopacketStateService.RecordNotFound):
+                await svc.transition(
+                    loaded.id,
+                    to_state="in_review",
+                    reason="submit after stale preread",
+                    expected_revision=loaded.revision,
+                    actor=admin_user,
+                )
+
+    async def actor_b_delete() -> None:
+        await preread_complete.wait()
+        async with async_session_maker() as session:
+            service = PhenopacketService(PhenopacketRepository(session))
+            result = await service.soft_delete(
+                "transition-delete-race",
+                "delete wins race",
+                actor_id=admin_user.id,
+                actor_username=admin_user.username,
+                expected_revision=1,
+            )
+            assert result["deleted_at"] is not None
+        delete_complete.set()
+
+    await __import__("asyncio").gather(actor_a_transition(), actor_b_delete())
+
+
+@pytest.mark.asyncio
+async def test_edit_fails_cleanly_when_delete_wins_after_preread(
+    db_session,
+    admin_user,
+):
+    """An edit that loses to a concurrent delete must surface a stable not-found error."""
+    payload = _valid_payload("edit-delete-race")
+    phenopacket = Phenopacket(
+        phenopacket_id="edit-delete-race",
+        phenopacket=payload["phenopacket"],
+        subject_id=payload["phenopacket"]["subject"]["id"],
+        subject_sex=payload["phenopacket"]["subject"].get("sex", "UNKNOWN_SEX"),
+        created_by_id=admin_user.id,
+        state="draft",
+        revision=1,
+    )
+    db_session.add(phenopacket)
+    await db_session.commit()
+
+    preread_complete = __import__("asyncio").Event()
+    delete_complete = __import__("asyncio").Event()
+
+    async def actor_a_edit() -> None:
+        async with async_session_maker() as session:
+            repo = PhenopacketRepository(session)
+            loaded = await repo.get_by_id("edit-delete-race")
+            assert loaded is not None
+            preread_complete.set()
+            await delete_complete.wait()
+
+            svc = PhenopacketStateService(session)
+            with pytest.raises(PhenopacketStateService.RecordNotFound):
+                await svc.edit_record(
+                    loaded.id,
+                    new_content={
+                        **payload["phenopacket"],
+                        "phenotypicFeatures": [
+                            {
+                                "type": {"id": "HP:0000001", "label": "updated"},
+                            }
+                        ],
+                    },
+                    change_reason="edit after stale preread",
+                    expected_revision=loaded.revision,
+                    actor=admin_user,
+                )
+
+    async def actor_b_delete() -> None:
+        await preread_complete.wait()
+        async with async_session_maker() as session:
+            service = PhenopacketService(PhenopacketRepository(session))
+            result = await service.soft_delete(
+                "edit-delete-race",
+                "delete wins race",
+                actor_id=admin_user.id,
+                actor_username=admin_user.username,
+                expected_revision=1,
+            )
+            assert result["deleted_at"] is not None
+        delete_complete.set()
+
+    await __import__("asyncio").gather(actor_a_edit(), actor_b_delete())


### PR DESCRIPTION
## Summary
- harden phenopacket edit/transition races so delete-after-preread loses cleanly with a 404 instead of leaking a server error
- align the timeline endpoint with the same visibility filters used by detail/list routes
- mark the completed timeline-visibility item in the active release-hardening plan

## Verification
- `cd backend && uv run pytest tests/test_phenopackets_delete_revision.py tests/test_state_flows.py tests/test_api_transitions.py tests/test_crud_state_branching.py -v`
- `cd backend && uv run pytest tests/test_crud_related_and_timeline.py -v`
- `cd backend && make lint`
- `cd backend && make typecheck`

## Notes
- delete without a revision remains backward-compatible in this PR; this change only hardens the race/error behavior of existing mutation paths
- commit: `1a953da`
