### PR TITLE
fix: require revision for phenopacket delete

### DIFF
--- a/.planning/plans/2026-04-16-delete-revision-required-plan.md
+++ b/.planning/plans/2026-04-16-delete-revision-required-plan.md
@@ -1,0 +1,160 @@
+# Delete Revision Required Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Require optimistic-locking revision values on phenopacket delete requests end-to-end.
+
+**Architecture:** Tighten the backend delete contract so request validation requires `revision`, then update the single frontend delete caller to send the current revision in the JSON body already consumed by the backend route. Verification stays focused on the delete slice and the frontend request helper.
+
+**Tech Stack:** FastAPI, Pydantic 2, SQLAlchemy async, Vue 3, Axios, pytest, Vitest.
+
+---
+
+### Task 1: Backend Contract
+
+**Files:**
+- Modify: `backend/tests/test_phenopackets_delete_revision.py`
+- Modify: `backend/app/phenopackets/models.py`
+- Modify: `backend/app/phenopackets/services/phenopacket_service.py`
+
+- [ ] **Step 1: Write the failing backend test for missing revision**
+
+```python
+@pytest.mark.asyncio
+async def test_delete_without_revision_returns_422(
+    async_client: AsyncClient, admin_headers: dict
+):
+    create_payload = _valid_payload("delete-revision-required")
+    create_resp = await async_client.post(
+        "/api/v2/phenopackets/", json=create_payload, headers=admin_headers
+    )
+    assert create_resp.status_code == 200, create_resp.text
+
+    response = await async_client.request(
+        "DELETE",
+        "/api/v2/phenopackets/delete-revision-required",
+        json={"change_reason": "missing revision"},
+        headers=admin_headers,
+    )
+    assert response.status_code == 422, response.text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/test_phenopackets_delete_revision.py::test_delete_without_revision_returns_422 -v`
+Expected: FAIL because the current contract still accepts revision-less delete.
+
+- [ ] **Step 3: Write minimal backend implementation**
+
+```python
+class PhenopacketDelete(BaseModel):
+    change_reason: str = Field(
+        ..., min_length=1, description="Reason for deletion (audit trail)"
+    )
+    revision: int = Field(
+        ..., description="Required optimistic-locking revision for delete requests."
+    )
+```
+
+```python
+async def soft_delete(
+    self,
+    phenopacket_id: str,
+    change_reason: str,
+    *,
+    actor_id: Optional[int],
+    actor_username: Optional[str] = None,
+    expected_revision: int,
+) -> Dict[str, Optional[str]]:
+```
+
+```python
+if phenopacket.revision != expected_revision:
+    raise ServiceConflict(
+        {
+            "error": "Conflict detected",
+            "message": (
+                f"Phenopacket was modified by another user. "
+                f"Expected revision {expected_revision}, "
+                f"but current revision is {phenopacket.revision}"
+            ),
+            "current_revision": phenopacket.revision,
+            "expected_revision": expected_revision,
+        },
+        code="revision_mismatch",
+    )
+```
+
+- [ ] **Step 4: Run backend delete slice**
+
+Run: `cd backend && uv run pytest tests/test_phenopackets_delete_revision.py -v`
+Expected: PASS
+
+### Task 2: Frontend Delete Caller
+
+**Files:**
+- Modify: `frontend/src/api/domain/phenopackets.js`
+- Modify: `frontend/src/views/PagePhenopacket.vue`
+- Test: `frontend/tests/unit/...` if a focused test target exists for delete request wiring
+
+- [ ] **Step 1: Write the failing frontend test or targeted verification**
+
+```javascript
+await deletePhenopacket('PP-1', 7, 'cleanup');
+expect(apiClient.delete).toHaveBeenCalledWith('/phenopackets/PP-1', {
+  data: { revision: 7, change_reason: 'cleanup' },
+});
+```
+
+- [ ] **Step 2: Run the frontend test to verify it fails**
+
+Run: `cd frontend && npm test -- --runInBand <focused-test>`
+Expected: FAIL because delete currently sends only `change_reason` as query params.
+
+- [ ] **Step 3: Write minimal frontend implementation**
+
+```javascript
+export const deletePhenopacket = (id, revision, changeReason) =>
+  apiClient.delete(`/phenopackets/${id}`, {
+    data: {
+      revision,
+      change_reason: changeReason,
+    },
+  });
+```
+
+```javascript
+await deletePhenopacket(
+  this.phenopacket.id,
+  this.phenopacketMeta.revision,
+  deleteReason
+);
+```
+
+- [ ] **Step 4: Run the focused frontend test**
+
+Run: `cd frontend && npm test -- --runInBand <focused-test>`
+Expected: PASS
+
+### Task 3: Verification
+
+**Files:**
+- No additional edits expected
+
+- [ ] **Step 1: Run targeted backend verification**
+
+Run: `cd backend && uv run pytest tests/test_phenopackets_delete_revision.py tests/test_state_flows.py tests/test_api_transitions.py -v`
+Expected: PASS
+
+- [ ] **Step 2: Run targeted frontend verification**
+
+Run: `cd frontend && npm test -- --runInBand <focused-test>`
+Expected: PASS
+
+- [ ] **Step 3: Run lint and type checks**
+
+Run: `cd backend && make lint && make typecheck`
+Expected: PASS
+
+Run: `cd frontend && npm test -- --runInBand <focused-test>`
+Expected: PASS

--- a/.planning/specs/2026-04-16-delete-revision-required-design.md
+++ b/.planning/specs/2026-04-16-delete-revision-required-design.md
@@ -1,0 +1,57 @@
+# Delete Revision Required Design
+
+## Goal
+
+Remove the last blind-delete path from phenopacket mutations by requiring clients to send the current `revision` when issuing a delete.
+
+## Scope
+
+This slice only changes phenopacket delete behavior.
+
+- Backend request validation must require `revision` on delete requests.
+- Backend delete service must always compare the supplied revision to the locked row revision.
+- Frontend phenopacket delete calls must send the current revision in the request body.
+- Existing backward-compat behavior for revision-less delete must be removed.
+
+## Non-Goals
+
+- No change to update semantics, which remain optionally revision-guarded.
+- No change to state transition semantics.
+- No migration or compatibility shim for legacy callers.
+
+## Architecture
+
+The backend already uses optimistic locking for updates and transitions. Delete should follow the same pattern: the request carries the caller's last-seen revision, the service locks the row, and the mutation proceeds only if the current revision still matches.
+
+The frontend already has the active phenopacket revision available on the detail page, so the UI change is limited to passing that revision through the domain API helper into the existing delete request.
+
+## API Behavior
+
+### Success
+
+If the request body includes the current revision, delete succeeds as it does today.
+
+### Validation Failure
+
+If the request omits `revision`, FastAPI/Pydantic request validation rejects it before the service layer runs.
+
+### Conflict
+
+If the request supplies a stale revision, delete returns the existing `409` conflict payload with `current_revision` and `expected_revision`.
+
+## Files
+
+- Modify `backend/app/phenopackets/models.py`
+- Modify `backend/app/phenopackets/services/phenopacket_service.py`
+- Modify `frontend/src/api/domain/phenopackets.js`
+- Modify `frontend/src/views/PagePhenopacket.vue`
+- Modify `backend/tests/test_phenopackets_delete_revision.py`
+- Add or modify focused frontend unit coverage if a stable test target exists for the domain helper or page delete flow
+
+## Testing
+
+- Backend request validation test for missing delete revision
+- Backend success test for matching revision
+- Backend conflict test for stale revision
+- Existing concurrent delete race test remains green
+- Frontend test or focused verification that delete sends `change_reason` and `revision` in the request body

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -83,7 +83,7 @@ async def validation_exception_handler(
         f"{'.'.join(str(p) for p in err['loc'])}: {err['msg']}" for err in errors
     )
     return _build_error_response(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         detail=detail,
         error_code="validation_error",
         request=request,

--- a/backend/app/phenopackets/models.py
+++ b/backend/app/phenopackets/models.py
@@ -548,11 +548,11 @@ class PhenopacketDelete(BaseModel):
     change_reason: str = Field(
         ..., min_length=1, description="Reason for deletion (audit trail)"
     )
-    revision: Optional[int] = Field(
-        None,
+    revision: int = Field(
+        ...,
         description=(
-            "Optional optimistic-locking revision. If provided, the delete "
-            "returns 409 Conflict when the current row revision differs."
+            "Required optimistic-locking revision. Delete returns 409 Conflict "
+            "when the current row revision differs."
         ),
     )
 

--- a/backend/app/phenopackets/services/phenopacket_service.py
+++ b/backend/app/phenopackets/services/phenopacket_service.py
@@ -285,7 +285,7 @@ class PhenopacketService:
         *,
         actor_id: Optional[int],
         actor_username: Optional[str] = None,
-        expected_revision: Optional[int] = None,
+        expected_revision: int,
     ) -> Dict[str, Optional[str]]:
         """Soft-delete a phenopacket and create an audit entry.
 
@@ -295,12 +295,8 @@ class PhenopacketService:
         persisted FK is ``actor_id``. Raises ``ServiceNotFound`` if
         the row is missing or already soft-deleted; raises
         ``ServiceConflict`` (code="revision_mismatch") if
-        ``expected_revision`` is provided and does not match the
-        current row revision; raises ``ServiceDatabaseError`` on
-        commit failure.
-
-        ``expected_revision`` is optional for backwards compatibility —
-        callers that omit it get the original blind-delete behaviour.
+        ``expected_revision`` does not match the current row
+        revision; raises ``ServiceDatabaseError`` on commit failure.
         """
         lock_stmt = (
             select(Phenopacket)
@@ -317,7 +313,7 @@ class PhenopacketService:
                 f"Phenopacket {phenopacket_id} not found or already deleted"
             )
 
-        if expected_revision is not None and phenopacket.revision != expected_revision:
+        if phenopacket.revision != expected_revision:
             raise ServiceConflict(
                 {
                     "error": "Conflict detected",

--- a/backend/tests/test_phenopacket_curation.py
+++ b/backend/tests/test_phenopacket_curation.py
@@ -279,7 +279,7 @@ async def test_delete_phenopacket_soft_delete(
         "DELETE",
         f"/api/v2/phenopackets/{test_phenopacket.phenopacket_id}",
         headers=admin_headers,
-        json={"change_reason": "Test deletion"},
+        json={"change_reason": "Test deletion", "revision": test_phenopacket.revision},
     )
 
     assert response.status_code == 200
@@ -421,7 +421,7 @@ async def test_delete_already_deleted(
         "DELETE",
         f"/api/v2/phenopackets/{test_phenopacket.phenopacket_id}",
         headers=admin_headers,
-        json={"change_reason": "Delete again"},
+        json={"change_reason": "Delete again", "revision": test_phenopacket.revision},
     )
 
     # Should return 404 (not found because soft-deleted records are filtered)

--- a/backend/tests/test_phenopacket_service.py
+++ b/backend/tests/test_phenopacket_service.py
@@ -284,6 +284,7 @@ class TestPhenopacketServiceSoftDelete:
                 "DOES-NOT-EXIST",
                 change_reason="service test",
                 actor_id=None,
+                expected_revision=1,
             )
 
     @pytest.mark.asyncio
@@ -302,6 +303,7 @@ class TestPhenopacketServiceSoftDelete:
             "SERVICE-TEST-DEL",
             change_reason="service test delete",
             actor_id=None,
+            expected_revision=1,
         )
 
         assert "SERVICE-TEST-DEL" in result["message"]
@@ -328,6 +330,7 @@ class TestPhenopacketServiceSoftDelete:
             "SERVICE-TEST-HIDDEN",
             change_reason="service test",
             actor_id=None,
+            expected_revision=1,
         )
 
         service3 = make_service()

--- a/backend/tests/test_phenopackets_delete_revision.py
+++ b/backend/tests/test_phenopackets_delete_revision.py
@@ -111,16 +111,11 @@ async def test_delete_with_stale_revision_returns_409(
 
 
 @pytest.mark.asyncio
-async def test_delete_without_revision_still_works(
+async def test_delete_without_revision_returns_422(
     async_client: AsyncClient, admin_headers: dict
 ):
-    """Backwards compat: clients that omit `revision` are not broken.
-
-    Revision is optional; if not provided, the delete proceeds without
-    a check. This preserves existing client behavior until the frontend
-    is updated.
-    """
-    create_payload = _valid_payload("delete-revision-optional")
+    """DELETE without a revision is rejected at request validation."""
+    create_payload = _valid_payload("delete-revision-required")
     create_resp = await async_client.post(
         "/api/v2/phenopackets/", json=create_payload, headers=admin_headers
     )
@@ -128,11 +123,11 @@ async def test_delete_without_revision_still_works(
 
     response = await async_client.request(
         "DELETE",
-        "/api/v2/phenopackets/delete-revision-optional",
+        "/api/v2/phenopackets/delete-revision-required",
         json={"change_reason": "no revision"},
         headers=admin_headers,
     )
-    assert response.status_code == 200
+    assert response.status_code == 422, response.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_soft_delete_global_filter.py
+++ b/backend/tests/test_soft_delete_global_filter.py
@@ -62,7 +62,7 @@ async def test_global_filter_hides_deleted_from_list(
     delete_resp = await async_client.request(
         "DELETE",
         "/api/v2/phenopackets/soft-delete-001",
-        json={"change_reason": "test"},
+        json={"change_reason": "test", "revision": 1},
         headers=admin_headers,
     )
     assert delete_resp.status_code == 200, delete_resp.text
@@ -90,7 +90,7 @@ async def test_include_deleted_escape_hatch_still_works(
     delete_resp = await async_client.request(
         "DELETE",
         "/api/v2/phenopackets/soft-delete-002",
-        json={"change_reason": "test"},
+        json={"change_reason": "test", "revision": 1},
         headers=admin_headers,
     )
     assert delete_resp.status_code == 200, delete_resp.text

--- a/backend/tests/test_variant_query_soft_delete.py
+++ b/backend/tests/test_variant_query_soft_delete.py
@@ -125,7 +125,10 @@ async def test_soft_deleted_phenopacket_hidden_from_all_variants(
     del_resp = await async_client.request(
         "DELETE",
         f"/api/v2/phenopackets/{pid}",
-        json={"change_reason": "wave5b soft-delete leak test"},
+        json={
+            "change_reason": "wave5b soft-delete leak test",
+            "revision": rev,
+        },
         headers=admin_headers,
     )
     assert del_resp.status_code == 200, del_resp.text

--- a/frontend/src/api/domain/phenopackets.js
+++ b/frontend/src/api/domain/phenopackets.js
@@ -112,12 +112,16 @@ export const updatePhenopacket = (id, data) =>
 /**
  * Delete a phenopacket (soft delete, requires curator role).
  * @param {string} id - Phenopacket ID
+ * @param {number} revision - Current revision for optimistic locking
  * @param {string} changeReason - Reason for deletion (required for audit trail)
  * @returns {Promise} Axios promise with deletion confirmation
  */
-export const deletePhenopacket = (id, changeReason) =>
+export const deletePhenopacket = (id, revision, changeReason) =>
   apiClient.delete(`/phenopackets/${id}`, {
-    params: { change_reason: changeReason },
+    data: {
+      revision,
+      change_reason: changeReason,
+    },
   });
 
 /**

--- a/frontend/src/views/PagePhenopacket.vue
+++ b/frontend/src/views/PagePhenopacket.vue
@@ -684,7 +684,7 @@ export default {
     },
 
     async handleDeleteConfirm(deleteReason) {
-      if (!this.phenopacket) return;
+      if (!this.phenopacket || !this.phenopacketMeta) return;
 
       this.deleteLoading = true;
 
@@ -694,7 +694,7 @@ export default {
       });
 
       try {
-        await deletePhenopacket(this.phenopacket.id, deleteReason);
+        await deletePhenopacket(this.phenopacket.id, this.phenopacketMeta.revision, deleteReason);
 
         window.logService.info('Phenopacket deleted successfully', {
           phenopacketId: this.phenopacket.id,

--- a/frontend/tests/unit/api/phenopackets.spec.js
+++ b/frontend/tests/unit/api/phenopackets.spec.js
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDelete = vi.fn();
+
+vi.mock('@/api/transport', () => ({
+  apiClient: {
+    delete: mockDelete,
+  },
+}));
+
+describe('phenopackets API domain helper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends revision and change_reason in the delete request body', async () => {
+    const { deletePhenopacket } = await import('@/api/domain/phenopackets');
+
+    await deletePhenopacket('PP-1', 7, 'cleanup duplicate record');
+
+    expect(mockDelete).toHaveBeenCalledWith('/phenopackets/PP-1', {
+      data: {
+        revision: 7,
+        change_reason: 'cleanup duplicate record',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- require `revision` on phenopacket delete requests in the backend contract and service layer
- send delete requests from the frontend detail page using a JSON body with `revision` and `change_reason`
- add focused backend/frontend coverage and record the slice in `.planning/`

## Verification
- `cd backend && uv run pytest tests/test_phenopackets_delete_revision.py tests/test_state_flows.py tests/test_api_transitions.py -v`
- `cd frontend && npm test -- tests/unit/api/phenopackets.spec.js`
- `cd backend && make lint`
- `cd backend && make typecheck`

## Notes
- delete without `revision` now fails request validation instead of proceeding as a blind mutation
- this also updates the shared validation handler to use the non-deprecated 422 status constant
- commit: `6bb25f7`
