### PR TITLE
Fix phenopacket publication save binding and duplicate-email conflicts

### DIFF
--- a/.planning/plans/2026-04-16-workstream-b-publications-and-email-conflicts.md
+++ b/.planning/plans/2026-04-16-workstream-b-publications-and-email-conflicts.md
@@ -1,0 +1,127 @@
+# Workstream B Slices: Publication Binding And Duplicate-Email Conflicts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the next two Workstream B slices by fixing the phenopacket publication edit/save regression in the frontend and normalizing duplicate-email update failures to explicit `409` conflicts in backend update paths.
+
+**Architecture:** The frontend fix keeps publication edit state and payload generation on a single backend-aligned source of truth so edit-mode load, form binding, and save all operate on the same structure. The backend fix introduces explicit duplicate-email conflict handling in the user update path so admin/auth user updates fail predictably with API-level `409` semantics instead of leaking lower-level integrity behavior.
+
+**Tech Stack:** Vue 3, Vuetify 3, Vitest, FastAPI, SQLAlchemy async, pytest.
+
+---
+
+## Context
+
+Source of truth: `.planning/plans/2026-04-15-release-hardening-and-8plus-plan.md`
+
+This execution slice covers:
+
+- Workstream B: fix the phenopacket publication binding regression
+- Workstream B: normalize duplicate-email update handling to explicit conflict responses
+
+## File Map
+
+Frontend track:
+
+- Modify: `frontend/src/views/PhenopacketCreateEdit.vue`
+- Add/modify test: `frontend/tests/unit/views/PhenopacketCreateEdit.spec.js`
+
+Backend track:
+
+- Modify: `backend/app/repositories/user_repository.py`
+- Modify: `backend/app/api/auth_endpoints.py`
+- Modify/add tests: `backend/tests/test_auth_user_management_endpoints.py`
+
+## Task 1: Frontend Publication Binding Regression
+
+**Files:**
+- Modify: `frontend/src/views/PhenopacketCreateEdit.vue`
+- Test: `frontend/tests/unit/views/PhenopacketCreateEdit.spec.js`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Create a unit test that mounts the edit view with a fetched phenopacket whose `metaData.externalReferences` contains PMID references, verifies the input binds to those PMIDs, edits one PMID, submits, and asserts the `updatePhenopacket()` payload contains the updated PMID in `phenopacket.metaData.externalReferences`.
+
+- [ ] **Step 2: Run the test to verify it fails for the right reason**
+
+Run: `cd frontend && npm test -- frontend/tests/unit/views/PhenopacketCreateEdit.spec.js`
+Expected: FAIL because edit-mode load stores publications on a different property than the template/save path uses.
+
+- [ ] **Step 3: Implement the minimal fix**
+
+Update `PhenopacketCreateEdit.vue` so publication editing and payload generation use one source of truth. Keep the editable collection on the phenopacket object that is actually submitted, and normalize to/from `metaData.externalReferences` in one place.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && npm test -- frontend/tests/unit/views/PhenopacketCreateEdit.spec.js`
+Expected: PASS
+
+- [ ] **Step 5: Run nearby regression coverage**
+
+Run: `cd frontend && npm test -- frontend/tests/unit/api/phenopackets.spec.js frontend/tests/unit/views/PhenopacketCreateEdit.spec.js`
+Expected: PASS
+
+## Task 2: Backend Duplicate-Email Conflict Normalization
+
+**Files:**
+- Modify: `backend/app/repositories/user_repository.py`
+- Modify: `backend/app/api/auth_endpoints.py`
+- Test: `backend/tests/test_auth_user_management_endpoints.py`
+
+- [ ] **Step 1: Write the failing regression tests**
+
+Add tests that create two users, attempt to update one user’s email to the other user’s email through `PUT /api/v2/auth/users/{id}`, and assert a clean `409` response with a duplicate-email message. Add a second test that exercises the repository update path directly and asserts it raises an explicit domain conflict instead of surfacing a raw SQLAlchemy integrity exception.
+
+- [ ] **Step 2: Run the tests to verify they fail for the right reason**
+
+Run: `cd backend && uv run pytest tests/test_auth_user_management_endpoints.py -k "duplicate_email or duplicate email" -v`
+Expected: FAIL because the current update path does not preflight or normalize duplicate-email conflicts.
+
+- [ ] **Step 3: Implement the minimal fix**
+
+Add explicit duplicate-email detection/normalization in the repository update path and convert that conflict to an HTTP `409` in the admin/auth update endpoint.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/test_auth_user_management_endpoints.py -k "duplicate_email or duplicate email" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run nearby regression coverage**
+
+Run: `cd backend && uv run pytest tests/test_auth_user_management_endpoints.py tests/test_auth.py tests/test_auth_tokens.py -v`
+Expected: PASS
+
+## Task 3: Combined Verification And PR
+
+**Files:**
+- Review scoped git diff only
+
+- [ ] **Step 1: Run frontend verification**
+
+Run: `cd frontend && npm test -- frontend/tests/unit/views/PhenopacketCreateEdit.spec.js frontend/tests/unit/api/phenopackets.spec.js`
+Expected: PASS
+
+- [ ] **Step 2: Run backend verification**
+
+Run: `cd backend && uv run pytest tests/test_auth_user_management_endpoints.py -v`
+Expected: PASS
+
+- [ ] **Step 3: Run relevant lint and typecheck**
+
+Run: `cd frontend && npm run lint && npm run typecheck`
+Expected: PASS
+
+Run: `cd backend && uv run ruff check app tests && uv run mypy app`
+Expected: PASS
+
+- [ ] **Step 4: Inspect scoped diff and create one branch/PR**
+
+Run:
+`git status --short`
+`git diff -- frontend/src/views/PhenopacketCreateEdit.vue frontend/tests/unit/views/PhenopacketCreateEdit.spec.js backend/app/repositories/user_repository.py backend/app/api/auth_endpoints.py backend/tests/test_auth_user_management_endpoints.py`
+
+Expected: only the intended slice files are included in the scoped change set.
+
+- [ ] **Step 5: Push and open one PR**
+
+Push the combined branch and open one PR covering both slices. Inspect GitHub Actions for that PR and keep iterating until green or until a concrete blocker is identified.

--- a/backend/app/api/auth_endpoints.py
+++ b/backend/app/api/auth_endpoints.py
@@ -34,7 +34,7 @@ from app.models.credential_token import CredentialToken
 from app.models.refresh_session import RefreshSession
 from app.models.user import User
 from app.repositories.refresh_session_repository import RefreshSessionRepository
-from app.repositories.user_repository import UserRepository
+from app.repositories.user_repository import UserEmailConflictError, UserRepository
 from app.schemas.auth import (
     InviteAcceptRequest,
     InviteRequest,
@@ -683,7 +683,13 @@ async def update_user(
     )
 
     # Update user
-    updated_user = await repo.update(user, user_data)
+    try:
+        updated_user = await repo.update(user, user_data)
+    except UserEmailConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
     if should_revoke_refresh_capability:
         await _revoke_all_refresh_capability(updated_user, db)
 

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -3,12 +3,17 @@
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.password import get_password_hash
 from app.core.config import settings
 from app.models.user import User
 from app.schemas.auth import UserCreate, UserUpdateAdmin, UserUpdatePublic
+
+
+class UserEmailConflictError(Exception):
+    """Raised when an update would violate the unique email constraint."""
 
 
 class UserRepository:
@@ -99,6 +104,13 @@ class UserRepository:
         Returns:
             Updated user instance
         """
+        if user_data.email is not None:
+            existing_user = await self.get_by_email(user_data.email)
+            if existing_user is not None and existing_user.id != user.id:
+                raise UserEmailConflictError(
+                    f"Email '{user_data.email}' already exists"
+                )
+
         # Update only provided fields
         if user_data.email is not None:
             user.email = user_data.email
@@ -120,7 +132,17 @@ class UserRepository:
 
         user.updated_at = datetime.now(timezone.utc)
 
-        await self.db.commit()
+        try:
+            await self.db.commit()
+        except IntegrityError as exc:
+            await self.db.rollback()
+            if user_data.email is not None:
+                sqlstate = getattr(getattr(exc, "orig", None), "sqlstate", None)
+                if sqlstate == "23505":
+                    raise UserEmailConflictError(
+                        f"Email '{user_data.email}' already exists"
+                    ) from exc
+            raise
         await self.db.refresh(user)
         return user
 

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -16,6 +16,11 @@ class UserEmailConflictError(Exception):
     """Raised when an update would violate the unique email constraint."""
 
 
+def _duplicate_email_message(email: str) -> str:
+    """Return the canonical duplicate-email conflict message."""
+    return f"Email '{email}' already exists"
+
+
 class UserRepository:
     """Repository for user CRUD operations."""
 
@@ -107,9 +112,7 @@ class UserRepository:
         if user_data.email is not None:
             existing_user = await self.get_by_email(user_data.email)
             if existing_user is not None and existing_user.id != user.id:
-                raise UserEmailConflictError(
-                    f"Email '{user_data.email}' already exists"
-                )
+                raise UserEmailConflictError(_duplicate_email_message(user_data.email))
 
         # Update only provided fields
         if user_data.email is not None:
@@ -140,7 +143,7 @@ class UserRepository:
                 sqlstate = getattr(getattr(exc, "orig", None), "sqlstate", None)
                 if sqlstate == "23505":
                     raise UserEmailConflictError(
-                        f"Email '{user_data.email}' already exists"
+                        _duplicate_email_message(user_data.email)
                     ) from exc
             raise
         await self.db.refresh(user)

--- a/backend/tests/test_auth_user_management_endpoints.py
+++ b/backend/tests/test_auth_user_management_endpoints.py
@@ -238,7 +238,9 @@ async def test_user_repository_normalizes_integrity_error_on_email_update(
     monkeypatch.setattr(db_session, "commit", fake_commit)
 
     with pytest.raises(UserEmailConflictError) as excinfo:
-        await repo.update(target_user, UserUpdateAdmin(email="repo-email-c@example.com"))
+        await repo.update(
+            target_user, UserUpdateAdmin(email="repo-email-c@example.com")
+        )
 
     assert "already exists" in str(excinfo.value).lower()
 

--- a/backend/tests/test_auth_user_management_endpoints.py
+++ b/backend/tests/test_auth_user_management_endpoints.py
@@ -7,10 +7,16 @@ on list, full CRUD round-trip, and self-delete protection.
 from __future__ import annotations
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from app.auth.password import get_password_hash
 from app.core.config import settings
 from app.models.user import User
+from app.repositories.user_repository import (
+    UserEmailConflictError,
+    UserRepository,
+)
+from app.schemas.auth import UserUpdateAdmin
 
 
 async def _seed_system_migration(db_session) -> User:
@@ -152,6 +158,89 @@ async def test_deactivate_user_invalidates_existing_refresh_cookie(
     )
     assert refresh_resp.status_code == 401
     assert "invalid" in refresh_resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_update_user_rejects_duplicate_email(async_client, admin_headers):
+    """PUT /auth/users/{id} returns 409 when email matches another user."""
+    first_resp = await async_client.post(
+        "/api/v2/auth/users",
+        json={
+            "username": "duplicate-email-a",
+            "email": "duplicate-email-a@example.com",
+            "password": "DuplicateEmailA!2026",
+            "full_name": "Duplicate Email A",
+            "role": "viewer",
+        },
+        headers=admin_headers,
+    )
+    assert first_resp.status_code == 201
+
+    second_resp = await async_client.post(
+        "/api/v2/auth/users",
+        json={
+            "username": "duplicate-email-b",
+            "email": "duplicate-email-b@example.com",
+            "password": "DuplicateEmailB!2026",
+            "full_name": "Duplicate Email B",
+            "role": "viewer",
+        },
+        headers=admin_headers,
+    )
+    assert second_resp.status_code == 201
+
+    response = await async_client.put(
+        f"/api/v2/auth/users/{second_resp.json()['id']}",
+        json={"email": "duplicate-email-a@example.com"},
+        headers=admin_headers,
+    )
+    assert response.status_code == 409
+    assert "already exists" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_user_repository_normalizes_integrity_error_on_email_update(
+    db_session, monkeypatch
+):
+    """Repository update normalizes a lower-level duplicate-email IntegrityError."""
+    existing_user = User(
+        username="repo-email-a",
+        email="repo-email-a@example.com",
+        hashed_password=get_password_hash("RepoEmailA!2026"),
+        full_name="Repo Email A",
+        role="viewer",
+        is_active=True,
+        is_verified=False,
+    )
+    target_user = User(
+        username="repo-email-b",
+        email="repo-email-b@example.com",
+        hashed_password=get_password_hash("RepoEmailB!2026"),
+        full_name="Repo Email B",
+        role="viewer",
+        is_active=True,
+        is_verified=False,
+    )
+    db_session.add_all([existing_user, target_user])
+    await db_session.commit()
+    await db_session.refresh(existing_user)
+    await db_session.refresh(target_user)
+
+    repo = UserRepository(db_session)
+
+    async def fake_commit():
+        raise IntegrityError(
+            "UPDATE users SET email = ...",
+            params={"email": "repo-email-a@example.com"},
+            orig=type("FakeOrig", (), {"sqlstate": "23505"})(),
+        )
+
+    monkeypatch.setattr(db_session, "commit", fake_commit)
+
+    with pytest.raises(UserEmailConflictError) as excinfo:
+        await repo.update(target_user, UserUpdateAdmin(email="repo-email-c@example.com"))
+
+    assert "already exists" in str(excinfo.value).lower()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_auth_user_management_endpoints.py
+++ b/backend/tests/test_auth_user_management_endpoints.py
@@ -246,6 +246,39 @@ async def test_user_repository_normalizes_integrity_error_on_email_update(
 
 
 @pytest.mark.asyncio
+async def test_user_repository_reraises_non_unique_integrity_error_on_email_update(
+    db_session, monkeypatch
+):
+    """Repository re-raises unrelated IntegrityError values unchanged."""
+    target_user = User(
+        username="repo-email-non-unique",
+        email="repo-email-non-unique@example.com",
+        hashed_password=get_password_hash("RepoEmailNonUnique!2026"),
+        full_name="Repo Email Non Unique",
+        role="viewer",
+        is_active=True,
+        is_verified=False,
+    )
+    db_session.add(target_user)
+    await db_session.commit()
+    await db_session.refresh(target_user)
+
+    repo = UserRepository(db_session)
+
+    async def fake_commit():
+        raise IntegrityError(
+            "UPDATE users SET full_name = ...",
+            params={"full_name": "Updated Name"},
+            orig=type("FakeOrig", (), {"sqlstate": "23503"})(),
+        )
+
+    monkeypatch.setattr(db_session, "commit", fake_commit)
+
+    with pytest.raises(IntegrityError):
+        await repo.update(target_user, UserUpdateAdmin(full_name="Updated Name"))
+
+
+@pytest.mark.asyncio
 async def test_delete_system_migration_user_forbidden(
     async_client, admin_headers, db_session
 ):

--- a/frontend/src/views/PhenopacketCreateEdit.vue
+++ b/frontend/src/views/PhenopacketCreateEdit.vue
@@ -277,8 +277,9 @@ export default {
         // Capture state for toast message selection (Wave 7/D.1 §9.2)
         this.savedRecordState = response.data.state ?? null;
 
-        // Load existing publications from metaData.externalReferences
-        this.publications = (this.phenopacket.metaData?.externalReferences || [])
+        // Load existing publications into the same state the template and
+        // submit path use so edits stay round-trippable.
+        this.phenopacket.publications = (this.phenopacket.metaData?.externalReferences || [])
           .filter((ref) => ref.id?.startsWith('PMID:'))
           .map((ref) => ({
             pmid: ref.id.replace('PMID:', ''),
@@ -287,7 +288,7 @@ export default {
         window.logService.info('Phenopacket loaded for editing', {
           phenopacketId: this.phenopacket.id,
           revision: this.revision,
-          publicationsLoaded: this.publications.length,
+          publicationsLoaded: this.phenopacket.publications.length,
         });
       } catch (err) {
         this.error = 'Failed to load phenopacket: ' + err.message;
@@ -307,6 +308,27 @@ export default {
 
     removePublication(index) {
       this.phenopacket.publications.splice(index, 1);
+    },
+
+    buildSubmissionPhenopacket() {
+      const existingReferences = this.phenopacket.metaData?.externalReferences || [];
+      const nonPmidExternalReferences = existingReferences.filter(
+        (ref) => !ref.id?.startsWith('PMID:')
+      );
+      const pmidExternalReferences = this.phenopacket.publications
+        .map((pub) => `${pub.pmid || ''}`.trim())
+        .filter(Boolean)
+        .map((pmid) => ({
+          id: `PMID:${pmid}`,
+        }));
+
+      return {
+        ...this.phenopacket,
+        metaData: {
+          ...(this.phenopacket.metaData || {}),
+          externalReferences: [...nonPmidExternalReferences, ...pmidExternalReferences],
+        },
+      };
     },
 
     async handleSubmit() {
@@ -335,11 +357,12 @@ export default {
 
       try {
         let result;
+        const phenopacketPayload = this.buildSubmissionPhenopacket();
 
         if (this.isEditing) {
           // Update existing phenopacket with optimistic locking and audit trail
           result = await updatePhenopacket(this.phenopacket.id, {
-            phenopacket: this.phenopacket,
+            phenopacket: phenopacketPayload,
             revision: this.revision,
             change_reason: this.changeReason,
           });
@@ -369,7 +392,7 @@ export default {
         } else {
           // Create new phenopacket
           result = await createPhenopacket({
-            phenopacket: this.phenopacket,
+            phenopacket: phenopacketPayload,
           });
 
           window.logService.info('Phenopacket created successfully', {

--- a/frontend/tests/unit/views/PhenopacketCreateEdit.spec.js
+++ b/frontend/tests/unit/views/PhenopacketCreateEdit.spec.js
@@ -1,0 +1,180 @@
+/**
+ * Regression tests for PhenopacketCreateEdit.vue.
+ *
+ * The edit flow must keep PMID publications in the same source of truth that
+ * the template and save payload use: phenopacket.publications.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/api', () => ({
+  getPhenopacket: vi.fn(),
+  createPhenopacket: vi.fn(),
+  updatePhenopacket: vi.fn(),
+}));
+
+import { getPhenopacket, updatePhenopacket } from '@/api';
+import PhenopacketCreateEdit from '@/views/PhenopacketCreateEdit.vue';
+
+const EDIT_ROUTE = {
+  params: {
+    phenopacket_id: 'PP-001',
+  },
+};
+
+const phenopacketResponse = {
+  phenopacket: {
+    id: 'PP-001',
+    subject: {
+      id: 'SUB-001',
+      sex: 'UNKNOWN_SEX',
+    },
+    phenotypicFeatures: [],
+    interpretations: [],
+    publications: [],
+    metaData: {
+      externalReferences: [{ id: 'PMID:12345678' }, { id: 'DOI:10.1000/example' }],
+    },
+  },
+  revision: 7,
+  state: 'draft',
+};
+
+function createContext(overrides = {}) {
+  return {
+    $route: EDIT_ROUTE,
+    $router: {
+      push: vi.fn(),
+    },
+    $refs: {
+      form: {
+        validate: vi.fn().mockResolvedValue({ valid: true }),
+      },
+    },
+    loading: true,
+    saving: false,
+    error: null,
+    formSubmitted: false,
+    revision: null,
+    changeReason: '',
+    savedRecordState: null,
+    isEditing: true,
+    buildSubmissionPhenopacket: PhenopacketCreateEdit.methods.buildSubmissionPhenopacket,
+    phenopacket: {
+      id: 'PP-001',
+      subject: {
+        id: 'SUB-001',
+        sex: 'UNKNOWN_SEX',
+      },
+      phenotypicFeatures: [],
+      interpretations: [],
+      publications: [],
+      metaData: {
+        externalReferences: [],
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('PhenopacketCreateEdit.vue', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    window.logService = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+  });
+
+  it('loads PMID publications into phenopacket.publications', async () => {
+    getPhenopacket.mockResolvedValueOnce({ data: phenopacketResponse });
+    const ctx = createContext();
+
+    await PhenopacketCreateEdit.methods.loadPhenopacket.call(ctx);
+
+    expect(ctx.phenopacket.publications).toEqual([{ pmid: '12345678' }]);
+    expect(ctx.loading).toBe(false);
+    expect(ctx.revision).toBe(7);
+    expect(ctx.savedRecordState).toBe('draft');
+  });
+
+  it('submits PMID publications as backend-consumable externalReferences', async () => {
+    updatePhenopacket.mockResolvedValueOnce({
+      data: { phenopacket_id: 'PP-001' },
+    });
+    const ctx = createContext({
+      phenopacket: {
+        id: 'PP-001',
+        subject: {
+          id: 'SUB-001',
+          sex: 'UNKNOWN_SEX',
+        },
+        phenotypicFeatures: [{ id: 'HP:0000001' }],
+        interpretations: [],
+        publications: [{ pmid: '12345678' }],
+        metaData: {
+          externalReferences: [],
+        },
+      },
+      changeReason: 'Updated publication list',
+      revision: 7,
+      savedRecordState: 'draft',
+    });
+
+    await PhenopacketCreateEdit.methods.handleSubmit.call(ctx);
+
+    expect(ctx.$refs.form.validate).toHaveBeenCalledTimes(1);
+    expect(updatePhenopacket).toHaveBeenCalledWith('PP-001', {
+      phenopacket: expect.objectContaining({
+        publications: [{ pmid: '12345678' }],
+        metaData: expect.objectContaining({
+          externalReferences: [{ id: 'PMID:12345678' }],
+        }),
+      }),
+      revision: 7,
+      change_reason: 'Updated publication list',
+    });
+  });
+
+  it('normalizes PMID publications into metaData.externalReferences and preserves other refs', async () => {
+    updatePhenopacket.mockResolvedValueOnce({
+      data: { phenopacket_id: 'PP-001' },
+    });
+    const ctx = createContext({
+      phenopacket: {
+        id: 'PP-001',
+        subject: {
+          id: 'SUB-001',
+          sex: 'UNKNOWN_SEX',
+        },
+        phenotypicFeatures: [{ id: 'HP:0000001' }],
+        interpretations: [],
+        publications: [{ pmid: '12345678' }],
+        metaData: {
+          created: '2024-01-01T00:00:00.000Z',
+          createdBy: 'HNF1B-DB Curation Interface',
+          resources: [{ id: 'hp' }],
+          externalReferences: [{ id: 'DOI:10.1000/example' }, { id: 'PMID:87654321' }],
+        },
+      },
+      changeReason: 'Updated publication list',
+      revision: 7,
+      savedRecordState: 'draft',
+    });
+
+    await PhenopacketCreateEdit.methods.handleSubmit.call(ctx);
+
+    expect(updatePhenopacket).toHaveBeenCalledWith('PP-001', {
+      phenopacket: expect.objectContaining({
+        publications: [{ pmid: '12345678' }],
+        metaData: expect.objectContaining({
+          externalReferences: [{ id: 'DOI:10.1000/example' }, { id: 'PMID:12345678' }],
+        }),
+      }),
+      revision: 7,
+      change_reason: 'Updated publication list',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fix `PhenopacketCreateEdit` so PMID edits use one UI source of truth and are normalized back into `metaData.externalReferences` on save
- add frontend regression coverage for edit-mode PMID loading and backend-aligned save payload generation
- normalize duplicate-email user updates to explicit `409 Conflict` responses via repository-level conflict handling and endpoint translation

## Verification
- `cd frontend && npm test -- tests/unit/views/PhenopacketCreateEdit.spec.js tests/unit/api/phenopackets.spec.js`
- `cd backend && uv run pytest tests/test_auth_user_management_endpoints.py -v`
- `cd backend && uv run ruff check app tests`
- `cd backend && uv run mypy app`
- `cd frontend && npm run build`

## Notes
- `frontend` does not currently expose a dedicated `typecheck` script in `package.json`; `npm run build` was used as the nearest compile-time check.
- `npm run lint:check` reports existing repository warnings but no errors.
