### PR TITLE
fix: post-deploy hardening (#286, #287, #288)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -46,6 +46,22 @@ NPM_SHARED_NETWORK_NAME=npm_default
 IMAGE_TAG=latest
 
 # ============================================
+# Production runtime (REQUIRED for production)
+# ============================================
+# These are read by Wave 5c fail-closed validators in app/core/config.py.
+
+ENVIRONMENT=production
+AUTH_COOKIE_SECURE=true
+
+# Email delivery — must be 'smtp' in production (validator refuses 'console').
+# See backend/.env.example for SendGrid / Mailgun / AWS SES samples.
+EMAIL_BACKEND=smtp
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+
+# ============================================
 # Admin Credentials (for initial setup)
 # ============================================
 ADMIN_USERNAME=admin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
 
     - name: Run database migrations
       env:
+        # ENVIRONMENT=development lets the test job bypass the Wave 5c
+        # production-only validators (email backend, AUTH_COOKIE_SECURE).
+        # CI is not production; the validators are still exercised by
+        # dedicated unit tests in backend/tests/test_config_*.py.
+        ENVIRONMENT: development
         DATABASE_URL: postgresql+asyncpg://hnf1b_user:hnf1b_pass@localhost:5432/hnf1b_test
         JWT_SECRET: test-secret-key-for-ci
         ADMIN_PASSWORD: test-admin-password-ci-2026
@@ -85,6 +90,11 @@ jobs:
 
     - name: Run tests (pytest)
       env:
+        # ENVIRONMENT=development lets the test job bypass the Wave 5c
+        # production-only validators (email backend, AUTH_COOKIE_SECURE).
+        # CI is not production; the validators are still exercised by
+        # dedicated unit tests in backend/tests/test_config_*.py.
+        ENVIRONMENT: development
         DATABASE_URL: postgresql+asyncpg://hnf1b_user:hnf1b_pass@localhost:5432/hnf1b_test
         JWT_SECRET: test-secret-key-for-ci
         ADMIN_PASSWORD: test-admin-password-ci-2026

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,11 @@ jobs:
 
     - name: Run backend migrations
       env:
+        # ENVIRONMENT=development lets the e2e-tests job bypass the Wave 5c
+        # production-only validators (email backend, AUTH_COOKIE_SECURE).
+        # CI is not production; the validators are still exercised by
+        # dedicated unit tests in backend/tests/test_config_*.py.
+        ENVIRONMENT: development
         DATABASE_URL: postgresql+asyncpg://hnf1b_user:hnf1b_pass@localhost:5432/hnf1b_phenopackets_test
         JWT_SECRET: ${{ secrets.JWT_SECRET || 'CI_TEST_ONLY_NOT_A_REAL_SECRET_DO_NOT_REUSE_0000000000000000' }}
         ADMIN_PASSWORD: ci_test_admin_password_2026
@@ -254,6 +259,7 @@ jobs:
 
     - name: Seed admin user (required for E2E auth)
       env:
+        ENVIRONMENT: development
         DATABASE_URL: postgresql+asyncpg://hnf1b_user:hnf1b_pass@localhost:5432/hnf1b_phenopackets_test
         JWT_SECRET: ${{ secrets.JWT_SECRET || 'CI_TEST_ONLY_NOT_A_REAL_SECRET_DO_NOT_REUSE_0000000000000000' }}
         ADMIN_USERNAME: admin
@@ -265,6 +271,7 @@ jobs:
 
     - name: Start backend
       env:
+        ENVIRONMENT: development
         DATABASE_URL: postgresql+asyncpg://hnf1b_user:hnf1b_pass@localhost:5432/hnf1b_phenopackets_test
         JWT_SECRET: ${{ secrets.JWT_SECRET || 'CI_TEST_ONLY_NOT_A_REAL_SECRET_DO_NOT_REUSE_0000000000000000' }}
         ADMIN_PASSWORD: ci_test_admin_password_2026

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -84,6 +84,7 @@ COPY --chown=hnf1b:hnf1b ./alembic ./alembic
 COPY --chown=hnf1b:hnf1b ./alembic.ini ./
 COPY --chown=hnf1b:hnf1b ./migration ./migration
 COPY --chown=hnf1b:hnf1b ./scripts ./scripts
+COPY --chown=hnf1b:hnf1b ./config.yaml ./
 
 # Copy and make entrypoint executable (fix Windows CRLF line endings)
 COPY --chown=hnf1b:hnf1b ./docker-entrypoint.sh ./

--- a/backend/app/api/auth_endpoints.py
+++ b/backend/app/api/auth_endpoints.py
@@ -23,7 +23,11 @@ from app.auth import (
     verify_token,
 )
 from app.auth.credential_tokens import CredentialTokenService
-from app.auth.dependencies import get_best_effort_user, require_csrf_token
+from app.auth.dependencies import (
+    get_best_effort_user,
+    require_csrf_token,
+    require_session_then_csrf,
+)
 from app.auth.email import get_email_sender
 from app.auth.permissions import get_all_roles
 from app.auth.rate_limit import RateLimiter
@@ -336,7 +340,7 @@ async def login(
 async def refresh_access_token(
     request: Request,
     response: Response,
-    _: None = Depends(require_csrf_token),
+    _: None = Depends(require_session_then_csrf),
     db: AsyncSession = Depends(get_db),
 ) -> Token | JSONResponse:
     """Refresh the access token using the cookie-backed refresh session.

--- a/backend/app/api/auth_endpoints.py
+++ b/backend/app/api/auth_endpoints.py
@@ -9,7 +9,8 @@ from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import delete as sa_delete, select
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import (

--- a/backend/app/api/auth_endpoints.py
+++ b/backend/app/api/auth_endpoints.py
@@ -341,18 +341,23 @@ async def login(
 async def refresh_access_token(
     request: Request,
     response: Response,
-    _: None = Depends(require_session_then_csrf),
     db: AsyncSession = Depends(get_db),
 ) -> Token | JSONResponse:
     """Refresh the access token using the cookie-backed refresh session.
 
-    Implements token rotation for security.
+    Implements token rotation for security. The session/CSRF check is
+    performed inline (not via Depends) so its HTTPExceptions flow through
+    the same ``_clear_cookie_error_response`` handler below and the
+    response defensively clears stale auth cookies on every failure
+    path — including the anonymous-bootstrap-probe path (#288).
 
     **Returns:**
     - 200: New access token and rotated auth cookies
-    - 401: Invalid or expired refresh token
+    - 401: Anonymous probe (no session cookie) — see #288
+    - 403: Session cookie present but CSRF check fails
     """
     try:
+        await require_session_then_csrf(request)
         (
             user,
             session,

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -217,3 +217,21 @@ async def require_csrf_token(request: Request) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="CSRF token missing or invalid",
         )
+
+
+async def require_session_then_csrf(request: Request) -> None:
+    """Layered guard for cookie-auth endpoints invoked from anonymous SPAs.
+
+    Returns 401 when there is no refresh-session cookie at all (an anonymous
+    bootstrap probe), and only runs the CSRF check when a session is actually
+    claimed. This keeps 403 reserved for genuine CSRF rejections and gives
+    the frontend the more-correct status to discriminate on.
+
+    Used on /auth/refresh; logout keeps plain require_csrf_token.
+    """
+    if not request.cookies.get(settings.REFRESH_COOKIE_NAME):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="No active session",
+        )
+    await require_csrf_token(request)

--- a/backend/app/auth/email.py
+++ b/backend/app/auth/email.py
@@ -164,12 +164,16 @@ class SMTPEmailSender:
 def get_email_sender() -> EmailSender:
     """Return the configured email sender.
 
-    Reads ``email.backend`` from ``config.yaml``:
+    Reads the resolved email backend (``EMAIL_BACKEND`` env override winning
+    over ``email.backend`` from ``config.yaml``) so the runtime dispatch
+    matches the fail-closed validator in :mod:`app.core.config`. Production
+    deploys that pass startup validation also actually send via the
+    chosen backend.
 
-    - ``"console"`` → :class:`ConsoleEmailSender` (default)
+    - ``"console"`` → :class:`ConsoleEmailSender` (dev default)
     - ``"smtp"`` → :class:`SMTPEmailSender` (Wave 6)
     """
-    backend = settings.email.backend
+    backend = settings.resolved_email_backend
     if backend == "console":
         return ConsoleEmailSender()
     if backend == "smtp":

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -303,6 +303,11 @@ class Settings(BaseSettings):
     SMTP_USERNAME: str = ""
     SMTP_PASSWORD: str = ""
 
+    # Email backend override — when set, takes precedence over YAML
+    # `email.backend`. Production must set EMAIL_BACKEND=smtp in .env.docker
+    # because the Wave 5c validator refuses to start with backend='console'.
+    EMAIL_BACKEND: Literal["console", "smtp"] | None = None
+
     # Admin credentials (for initial setup)
     # SECURITY: ADMIN_PASSWORD is REQUIRED and has no default. The previous
     # default was removed in Wave 1 of the 2026-04-10 refactor roadmap to
@@ -415,8 +420,9 @@ class Settings(BaseSettings):
     def _validate_environment_security_requirements(self) -> "Settings":
         """Fail closed on environment-specific email and cookie settings."""
         email_cfg = self.yaml.email
+        resolved_backend = self.EMAIL_BACKEND or email_cfg.backend
 
-        if self.environment == "production" and email_cfg.backend == "console":
+        if self.environment == "production" and resolved_backend == "console":
             raise ValueError(
                 "REFUSING TO START: email.backend is 'console' while "
                 "ENVIRONMENT=production. Configure SMTP delivery before "
@@ -452,7 +458,8 @@ class Settings(BaseSettings):
     def _validate_smtp_config(self) -> "Settings":
         """Fail fast if email backend is smtp but SMTP_HOST is missing."""
         email_cfg = self.yaml.email
-        if email_cfg.backend == "smtp":
+        resolved_backend = self.EMAIL_BACKEND or email_cfg.backend
+        if resolved_backend == "smtp":
             if not self.SMTP_HOST or self.SMTP_HOST.strip() == "":
                 raise ValueError(
                     "REFUSING TO START: email.backend is 'smtp' but SMTP_HOST "
@@ -467,8 +474,6 @@ class Settings(BaseSettings):
                         "SMTP_PASSWORD is empty. Set them in .env or set "
                         "email.use_credentials: false in config.yaml."
                     )
-            # Gate TLS warning behind smtp backend — it is irrelevant (and
-            # noisy) when backend is console (Copilot PR #235 review).
             if email_cfg.tls_mode == "none":
                 logger.critical(
                     "EMAIL TLS IS DISABLED (email.tls_mode: 'none'). "

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -419,10 +419,10 @@ class Settings(BaseSettings):
     @model_validator(mode="after")
     def _validate_environment_security_requirements(self) -> "Settings":
         """Fail closed on environment-specific email and cookie settings."""
-        email_cfg = self.yaml.email
-        resolved_backend = self.EMAIL_BACKEND or email_cfg.backend
-
-        if self.environment == "production" and resolved_backend == "console":
+        if (
+            self.environment == "production"
+            and self.resolved_email_backend == "console"
+        ):
             raise ValueError(
                 "REFUSING TO START: email.backend is 'console' while "
                 "ENVIRONMENT=production. Configure SMTP delivery before "
@@ -458,8 +458,7 @@ class Settings(BaseSettings):
     def _validate_smtp_config(self) -> "Settings":
         """Fail fast if email backend is smtp but SMTP_HOST is missing."""
         email_cfg = self.yaml.email
-        resolved_backend = self.EMAIL_BACKEND or email_cfg.backend
-        if resolved_backend == "smtp":
+        if self.resolved_email_backend == "smtp":
             if not self.SMTP_HOST or self.SMTP_HOST.strip() == "":
                 raise ValueError(
                     "REFUSING TO START: email.backend is 'smtp' but SMTP_HOST "
@@ -535,6 +534,18 @@ class Settings(BaseSettings):
     def email(self) -> EmailConfig:
         """Access email configuration."""
         return self.yaml.email
+
+    @property
+    def resolved_email_backend(self) -> str:
+        """Return the effective email backend.
+
+        ``EMAIL_BACKEND`` (env override) wins over ``email.backend`` (YAML).
+        Both the Wave 5c fail-closed validators and the runtime
+        ``get_email_sender()`` factory must read this single source of
+        truth so that production deploys that pass validation also
+        actually send via the chosen backend.
+        """
+        return self.EMAIL_BACKEND or self.yaml.email.backend
 
     # === Legacy compatibility properties ===
     # These provide backward compatibility with code using old config names

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -92,7 +92,7 @@ security:
 # "smtp" sends real emails (requires SMTP_* env vars in .env).
 email:
   backend: "console"
-  from_address: "noreply@hnf1b-db.org"
+  from_address: "noreply@hnf1b.org"
   from_name: "HNF1B Database"
   tls_mode: "starttls"
   validate_certs: true

--- a/backend/scripts/create_admin_user.py
+++ b/backend/scripts/create_admin_user.py
@@ -49,6 +49,7 @@ async def create_admin_user() -> None:
                 existing_admin.locked_until = None
                 await db.commit()
                 print(f"✅ Admin user updated: {admin_username}")
+                print("   (password reset from $ADMIN_PASSWORD; not echoed)")
             else:
                 print("Creating new admin user...")
                 admin_user = User(
@@ -65,13 +66,13 @@ async def create_admin_user() -> None:
                 await db.refresh(admin_user)
                 print(f"✅ Admin user created: {admin_username} (ID: {admin_user.id})")
 
-            print("\n🔐 Login credentials:")
-            print(f"   Username: {admin_username}")
-            print(f"   Password: {admin_password}")
-            print(
-                "\n⚠️  SECURITY: Change the admin password immediately "
-                "after first login!\n"
-            )
+                print("\n🔐 Login credentials:")
+                print(f"   Username: {admin_username}")
+                print(f"   Password: {admin_password}")
+                print(
+                    "\n⚠️  SECURITY: Change the admin password immediately "
+                    "after first login!\n"
+                )
 
         except Exception as e:
             print(f"❌ Error creating admin user: {e}")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -320,7 +320,14 @@ async def test_refresh_rejects_signed_refresh_cookie_without_backing_session(
 
 @pytest.mark.asyncio
 async def test_refresh_missing_cookie_clears_auth_cookies(async_client: AsyncClient):
-    """Refresh failures still clear auth cookies when no refresh cookie is present."""
+    """Refresh failures still clear auth cookies when no refresh cookie is present.
+
+    Wave 5d / issue #288: the anonymous-bootstrap-probe path now returns
+    401 with detail "No active session" (was 403 "CSRF token missing"
+    before, which leaked the existence of the CSRF check on
+    unauthenticated requests). The response must still defensively clear
+    the stale csrf_token cookie so the client doesn't keep retrying.
+    """
     cookies = {settings.CSRF_COOKIE_NAME: "csrf-token"}
 
     response = await async_client.post(
@@ -329,7 +336,7 @@ async def test_refresh_missing_cookie_clears_auth_cookies(async_client: AsyncCli
     )
 
     assert response.status_code == 401
-    assert "missing" in response.json()["detail"].lower()
+    assert "no active session" in response.json()["detail"].lower()
     set_cookie_headers = response.headers.get_list("set-cookie")
     assert any(settings.REFRESH_COOKIE_NAME in header for header in set_cookie_headers)
     assert any(settings.CSRF_COOKIE_NAME in header for header in set_cookie_headers)

--- a/backend/tests/test_auth_csrf.py
+++ b/backend/tests/test_auth_csrf.py
@@ -7,7 +7,11 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from app.auth import dependencies as auth_dependencies
-from app.auth.dependencies import get_best_effort_user, require_csrf_token
+from app.auth.dependencies import (
+    get_best_effort_user,
+    require_csrf_token,
+    require_session_then_csrf,
+)
 from app.auth.session_cookies import clear_auth_cookies, set_auth_cookies
 from app.core.config import Settings, settings
 
@@ -155,3 +159,66 @@ def test_settings_expose_cookie_defaults():
     assert settings.AUTH_COOKIE_PATH == "/api/v2"
     assert settings.CSRF_COOKIE_PATH == "/"
     assert settings.AUTH_COOKIE_SAMESITE == "lax"
+
+
+# ----- require_session_then_csrf (issue #288) -----
+
+
+def _request_with_cookies(*, refresh: str | None, csrf_cookie: str | None, csrf_header: str | None) -> Request:
+    """Build a Starlette request with optional refresh cookie + CSRF pair."""
+    cookie_parts: list[str] = []
+    if refresh is not None:
+        cookie_parts.append(f"refresh_token={refresh}")
+    if csrf_cookie is not None:
+        cookie_parts.append(f"csrf_token={csrf_cookie}")
+
+    headers: list[tuple[bytes, bytes]] = []
+    if cookie_parts:
+        headers.append((b"cookie", "; ".join(cookie_parts).encode()))
+    if csrf_header is not None:
+        headers.append((b"x-csrf-token", csrf_header.encode()))
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v2/auth/refresh",
+        "headers": headers,
+    }
+    return Request(scope)
+
+
+async def test_require_session_then_csrf_returns_401_when_no_session_cookie():
+    """Anonymous bootstrap probe (no refresh cookie) returns 401, not 403."""
+    request = _request_with_cookies(refresh=None, csrf_cookie=None, csrf_header=None)
+
+    try:
+        await require_session_then_csrf(request)
+    except Exception as exc:  # noqa: BLE001
+        assert getattr(exc, "status_code", None) == 401
+        assert "no active session" in str(getattr(exc, "detail", "")).lower()
+    else:  # pragma: no cover - red phase guard
+        raise AssertionError("Expected 401 when refresh cookie is absent")
+
+
+async def test_require_session_then_csrf_returns_403_when_session_present_but_csrf_missing():
+    """With a refresh session cookie but no CSRF header, fall through to 403."""
+    request = _request_with_cookies(
+        refresh="rt-xyz", csrf_cookie="csrf-abc", csrf_header=None
+    )
+
+    try:
+        await require_session_then_csrf(request)
+    except Exception as exc:  # noqa: BLE001
+        assert getattr(exc, "status_code", None) == 403
+        assert "csrf" in str(getattr(exc, "detail", "")).lower()
+    else:  # pragma: no cover - red phase guard
+        raise AssertionError("Expected 403 when CSRF header is missing despite session cookie")
+
+
+async def test_require_session_then_csrf_accepts_full_session_with_matching_csrf():
+    """Refresh cookie + matching CSRF cookie/header pair is accepted (returns None)."""
+    request = _request_with_cookies(
+        refresh="rt-xyz", csrf_cookie="csrf-abc", csrf_header="csrf-abc"
+    )
+
+    assert await require_session_then_csrf(request) is None

--- a/backend/tests/test_auth_csrf.py
+++ b/backend/tests/test_auth_csrf.py
@@ -164,7 +164,9 @@ def test_settings_expose_cookie_defaults():
 # ----- require_session_then_csrf (issue #288) -----
 
 
-def _request_with_cookies(*, refresh: str | None, csrf_cookie: str | None, csrf_header: str | None) -> Request:
+def _request_with_cookies(
+    *, refresh: str | None, csrf_cookie: str | None, csrf_header: str | None
+) -> Request:
     """Build a Starlette request with optional refresh cookie + CSRF pair."""
     cookie_parts: list[str] = []
     if refresh is not None:
@@ -212,7 +214,9 @@ async def test_require_session_then_csrf_returns_403_when_session_present_but_cs
         assert getattr(exc, "status_code", None) == 403
         assert "csrf" in str(getattr(exc, "detail", "")).lower()
     else:  # pragma: no cover - red phase guard
-        raise AssertionError("Expected 403 when CSRF header is missing despite session cookie")
+        raise AssertionError(
+            "Expected 403 when CSRF header is missing despite session cookie"
+        )
 
 
 async def test_require_session_then_csrf_accepts_full_session_with_matching_csrf():

--- a/backend/tests/test_config_email_backend_override.py
+++ b/backend/tests/test_config_email_backend_override.py
@@ -89,3 +89,65 @@ def test_dev_keeps_yaml_console_default_with_no_env_override():
         env_override=None, yaml_backend="console", environment="development"
     )
     assert settings.EMAIL_BACKEND is None
+
+
+def test_resolved_email_backend_property_reflects_env_override():
+    """Settings.resolved_email_backend must agree with both validator and runtime."""
+    settings = _build_settings_with_stub_yaml(
+        env_override="smtp", yaml_backend="console", environment="production"
+    )
+    assert settings.resolved_email_backend == "smtp"
+
+
+def test_resolved_email_backend_property_falls_back_to_yaml():
+    """When no env override, the property reflects the YAML value."""
+    settings = _build_settings_with_stub_yaml(
+        env_override=None, yaml_backend="console", environment="development"
+    )
+    assert settings.resolved_email_backend == "console"
+
+
+def test_get_email_sender_honours_email_backend_env_override():
+    """Regression: get_email_sender() must use the resolved backend, not YAML alone.
+
+    Without this, a production deploy with EMAIL_BACKEND=smtp would pass
+    validators but actually send via console — defeating fail-closed
+    semantics (see PR #289 Copilot review).
+    """
+    from app.auth.email import (
+        ConsoleEmailSender,
+        SMTPEmailSender,
+        get_email_sender,
+    )
+    from app.core import config as config_module
+
+    settings = _build_settings_with_stub_yaml(
+        env_override="smtp", yaml_backend="console", environment="production"
+    )
+
+    with (
+        patch.object(config_module, "settings", settings),
+        patch("app.auth.email.settings", settings),
+    ):
+        sender = get_email_sender()
+
+    assert isinstance(sender, SMTPEmailSender)
+    assert not isinstance(sender, ConsoleEmailSender)
+
+
+def test_get_email_sender_uses_yaml_when_no_env_override():
+    """No env override → factory uses the YAML default (console in dev)."""
+    from app.auth.email import ConsoleEmailSender, get_email_sender
+    from app.core import config as config_module
+
+    settings = _build_settings_with_stub_yaml(
+        env_override=None, yaml_backend="console", environment="development"
+    )
+
+    with (
+        patch.object(config_module, "settings", settings),
+        patch("app.auth.email.settings", settings),
+    ):
+        sender = get_email_sender()
+
+    assert isinstance(sender, ConsoleEmailSender)

--- a/backend/tests/test_config_email_backend_override.py
+++ b/backend/tests/test_config_email_backend_override.py
@@ -1,0 +1,91 @@
+"""Tests for EMAIL_BACKEND env override semantics (Wave 5c follow-up)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.core.config import EmailConfig, Settings, YamlConfig
+
+
+def _build_settings_with_stub_yaml(
+    *,
+    env_override: str | None,
+    yaml_backend: str,
+    environment: str,
+) -> Settings:
+    """Build Settings with a stubbed YAML config (patched before construction).
+
+    Validators run during Settings(...) construction, so the YAML stub must be
+    in place via patching load_yaml_config before the call, not via post-hoc
+    mutation of _yaml_config. See PR review for issue #287.
+    """
+    yaml_cfg = YamlConfig(email=EmailConfig(backend=yaml_backend))
+    smtp_needed = (env_override or yaml_backend) == "smtp"
+
+    kwargs: dict[str, object] = {
+        "JWT_SECRET": "test-secret-key-abc123",
+        "ADMIN_PASSWORD": "TestAdminPass!2026",
+        "environment": environment,
+        "AUTH_COOKIE_SECURE": environment != "development",
+        "SMTP_HOST": "smtp.example.com" if smtp_needed else "",
+        "SMTP_USERNAME": "user" if smtp_needed else "",
+        "SMTP_PASSWORD": "pass" if smtp_needed else "",
+    }
+    if env_override is not None:
+        kwargs["EMAIL_BACKEND"] = env_override
+
+    with patch("app.core.config.load_yaml_config", return_value=yaml_cfg):
+        return Settings(**kwargs)
+
+
+def test_email_backend_env_overrides_yaml_console_in_production():
+    """EMAIL_BACKEND=smtp must override yaml backend='console' in production."""
+    settings = _build_settings_with_stub_yaml(
+        env_override="smtp", yaml_backend="console", environment="production"
+    )
+    assert settings.EMAIL_BACKEND == "smtp"
+
+
+def test_yaml_console_default_still_rejects_in_production_without_override():
+    """Without EMAIL_BACKEND set, yaml 'console' default must still fail-closed."""
+    with pytest.raises(ValueError, match="email.backend is 'console'"):
+        _build_settings_with_stub_yaml(
+            env_override=None, yaml_backend="console", environment="production"
+        )
+
+
+def test_yaml_smtp_default_without_smtp_host_also_fails_closed():
+    """Direct YAML 'smtp' with no SMTP_HOST must fail (proves stub really overrides yaml)."""
+    yaml_cfg = YamlConfig(email=EmailConfig(backend="smtp"))
+    with pytest.raises(ValueError, match="SMTP_HOST"):
+        with patch("app.core.config.load_yaml_config", return_value=yaml_cfg):
+            Settings(
+                JWT_SECRET="test-secret-key-abc123",
+                ADMIN_PASSWORD="TestAdminPass!2026",
+                environment="production",
+                AUTH_COOKIE_SECURE=True,
+                SMTP_HOST="",
+            )
+
+
+def test_email_backend_env_override_smtp_requires_smtp_host():
+    """EMAIL_BACKEND=smtp without SMTP_HOST must fail-closed (validator runs after override)."""
+    with pytest.raises(ValueError, match="SMTP_HOST"):
+        Settings(
+            JWT_SECRET="test-secret-key-abc123",
+            ADMIN_PASSWORD="TestAdminPass!2026",
+            environment="production",
+            AUTH_COOKIE_SECURE=True,
+            EMAIL_BACKEND="smtp",
+            SMTP_HOST="",
+        )
+
+
+def test_dev_keeps_yaml_console_default_with_no_env_override():
+    """Dev environment leaves yaml 'console' default in place; no override needed."""
+    settings = _build_settings_with_stub_yaml(
+        env_override=None, yaml_backend="console", environment="development"
+    )
+    assert settings.EMAIL_BACKEND is None

--- a/backend/tests/test_config_refuses_dev_auth_in_prod.py
+++ b/backend/tests/test_config_refuses_dev_auth_in_prod.py
@@ -57,14 +57,31 @@ def test_default_environment_is_production(monkeypatch):
     environment nor the on-disk ``backend/.env`` file can contaminate the
     assertion — this test is about the *class default*, not the runtime
     value on any particular developer's machine.
+
+    Since Wave 5c (bde6704) the production env path also runs the email
+    backend + AUTH_COOKIE_SECURE validators, so we satisfy them
+    explicitly so the construction can complete and we can assert on
+    the env default. The point of this test is the env *default*, not
+    the fail-closed posture (which has its own coverage in
+    ``test_config_email_backend_override.py`` and elsewhere).
     """
     monkeypatch.delenv("ENVIRONMENT", raising=False)
     monkeypatch.delenv("ENABLE_DEV_AUTH", raising=False)
+    monkeypatch.delenv("AUTH_COOKIE_SECURE", raising=False)
+    monkeypatch.delenv("EMAIL_BACKEND", raising=False)
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    monkeypatch.delenv("SMTP_USERNAME", raising=False)
+    monkeypatch.delenv("SMTP_PASSWORD", raising=False)
 
     s = Settings(
         _env_file=None,  # type: ignore[call-arg]
         JWT_SECRET="x" * 32,
         ADMIN_PASSWORD="A" * 20,
+        AUTH_COOKIE_SECURE=True,
+        EMAIL_BACKEND="smtp",
+        SMTP_HOST="smtp.example.com",
+        SMTP_USERNAME="u",
+        SMTP_PASSWORD="p",
     )
     assert s.environment == "production"
     assert s.enable_dev_auth is False

--- a/backend/tests/test_core_config.py
+++ b/backend/tests/test_core_config.py
@@ -9,9 +9,33 @@ import importlib
 import pytest
 from pydantic import ValidationError
 
+import app.core.config as _config_module
+
 BASE_ENV = {
     "DATABASE_URL": "postgresql+asyncpg://test:test@localhost:5433/test",
 }
+
+
+@pytest.fixture(autouse=True)
+def _preserve_settings_singleton_identity():
+    """Restore ``app.core.config.settings`` identity after each reload.
+
+    Tests in this module call ``importlib.reload(config_module)`` to get a
+    fresh ``Settings`` class for env-driven validator coverage. Reload
+    re-executes the module top-level, which constructs a NEW ``settings``
+    instance and rebinds ``app.core.config.settings`` to it. That breaks
+    the ``pkg_settings is core_settings`` invariant in
+    ``test_variant_validator_compat.py`` (the re-export was bound to the
+    original instance via ``from app.core.config import settings``).
+
+    Save the original object reference and restore it post-test so the
+    re-export identity check in subsequent test files still holds.
+    """
+    original_settings = _config_module.settings
+    try:
+        yield
+    finally:
+        _config_module.settings = original_settings
 
 
 def seed_safe_import_env(monkeypatch):

--- a/backend/tests/test_create_admin_user_no_password_leak.py
+++ b/backend/tests/test_create_admin_user_no_password_leak.py
@@ -1,0 +1,98 @@
+"""Regression test: admin script must not echo the password when the user already exists."""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import scripts.create_admin_user as admin_script
+
+
+class _StubResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+@pytest.mark.asyncio
+async def test_existing_admin_branch_does_not_print_password(monkeypatch):
+    """When the admin already exists the script must NOT echo the password."""
+    secret = "super-secret-rotation-value-9000"
+    monkeypatch.setattr(admin_script.settings, "ADMIN_USERNAME", "admin", raising=False)
+    monkeypatch.setattr(admin_script.settings, "ADMIN_EMAIL", "admin@example.com", raising=False)
+    monkeypatch.setattr(admin_script.settings, "ADMIN_PASSWORD", secret, raising=False)
+    monkeypatch.setattr(
+        admin_script.settings, "DATABASE_URL", "postgresql+asyncpg://x/y", raising=False
+    )
+
+    existing_admin = MagicMock()
+    existing_admin.id = 7
+
+    fake_session = MagicMock()
+    fake_session.execute = AsyncMock(return_value=_StubResult(existing_admin))
+    fake_session.commit = AsyncMock()
+    fake_session.rollback = AsyncMock()
+
+    fake_session_ctx = MagicMock()
+    fake_session_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    fake_sessionmaker = MagicMock(return_value=fake_session_ctx)
+
+    fake_engine = MagicMock()
+    fake_engine.dispose = AsyncMock()
+
+    with patch.object(admin_script, "create_async_engine", return_value=fake_engine), patch.object(
+        admin_script, "async_sessionmaker", return_value=fake_sessionmaker
+    ):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            await admin_script.create_admin_user()
+        output = buf.getvalue()
+
+    assert secret not in output, "ADMIN_PASSWORD must never be echoed on update path"
+    assert "Password:" not in output, "Plain 'Password:' label must not appear on update path"
+
+
+@pytest.mark.asyncio
+async def test_creation_branch_still_prints_credentials(monkeypatch):
+    """Brand-new admin path keeps printing the credential block (intentional)."""
+    secret = "fresh-install-password-9000"
+    monkeypatch.setattr(admin_script.settings, "ADMIN_USERNAME", "admin", raising=False)
+    monkeypatch.setattr(admin_script.settings, "ADMIN_EMAIL", "admin@example.com", raising=False)
+    monkeypatch.setattr(admin_script.settings, "ADMIN_PASSWORD", secret, raising=False)
+    monkeypatch.setattr(
+        admin_script.settings, "DATABASE_URL", "postgresql+asyncpg://x/y", raising=False
+    )
+
+    fake_session = MagicMock()
+    fake_session.execute = AsyncMock(return_value=_StubResult(None))
+    fake_session.commit = AsyncMock()
+    fake_session.refresh = AsyncMock()
+    fake_session.rollback = AsyncMock()
+    fake_session.add = MagicMock()
+
+    fake_session_ctx = MagicMock()
+    fake_session_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    fake_sessionmaker = MagicMock(return_value=fake_session_ctx)
+
+    fake_engine = MagicMock()
+    fake_engine.dispose = AsyncMock()
+
+    with patch.object(admin_script, "create_async_engine", return_value=fake_engine), patch.object(
+        admin_script, "async_sessionmaker", return_value=fake_sessionmaker
+    ):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            await admin_script.create_admin_user()
+        output = buf.getvalue()
+
+    assert secret in output, "Creation path is allowed to echo password once for first-run UX"
+    assert "Login credentials" in output

--- a/backend/tests/test_create_admin_user_no_password_leak.py
+++ b/backend/tests/test_create_admin_user_no_password_leak.py
@@ -24,7 +24,9 @@ async def test_existing_admin_branch_does_not_print_password(monkeypatch):
     """When the admin already exists the script must NOT echo the password."""
     secret = "super-secret-rotation-value-9000"
     monkeypatch.setattr(admin_script.settings, "ADMIN_USERNAME", "admin", raising=False)
-    monkeypatch.setattr(admin_script.settings, "ADMIN_EMAIL", "admin@example.com", raising=False)
+    monkeypatch.setattr(
+        admin_script.settings, "ADMIN_EMAIL", "admin@example.com", raising=False
+    )
     monkeypatch.setattr(admin_script.settings, "ADMIN_PASSWORD", secret, raising=False)
     monkeypatch.setattr(
         admin_script.settings, "DATABASE_URL", "postgresql+asyncpg://x/y", raising=False
@@ -47,8 +49,11 @@ async def test_existing_admin_branch_does_not_print_password(monkeypatch):
     fake_engine = MagicMock()
     fake_engine.dispose = AsyncMock()
 
-    with patch.object(admin_script, "create_async_engine", return_value=fake_engine), patch.object(
-        admin_script, "async_sessionmaker", return_value=fake_sessionmaker
+    with (
+        patch.object(admin_script, "create_async_engine", return_value=fake_engine),
+        patch.object(
+            admin_script, "async_sessionmaker", return_value=fake_sessionmaker
+        ),
     ):
         buf = io.StringIO()
         with redirect_stdout(buf):
@@ -56,7 +61,9 @@ async def test_existing_admin_branch_does_not_print_password(monkeypatch):
         output = buf.getvalue()
 
     assert secret not in output, "ADMIN_PASSWORD must never be echoed on update path"
-    assert "Password:" not in output, "Plain 'Password:' label must not appear on update path"
+    assert "Password:" not in output, (
+        "Plain 'Password:' label must not appear on update path"
+    )
 
 
 @pytest.mark.asyncio
@@ -64,7 +71,9 @@ async def test_creation_branch_still_prints_credentials(monkeypatch):
     """Brand-new admin path keeps printing the credential block (intentional)."""
     secret = "fresh-install-password-9000"
     monkeypatch.setattr(admin_script.settings, "ADMIN_USERNAME", "admin", raising=False)
-    monkeypatch.setattr(admin_script.settings, "ADMIN_EMAIL", "admin@example.com", raising=False)
+    monkeypatch.setattr(
+        admin_script.settings, "ADMIN_EMAIL", "admin@example.com", raising=False
+    )
     monkeypatch.setattr(admin_script.settings, "ADMIN_PASSWORD", secret, raising=False)
     monkeypatch.setattr(
         admin_script.settings, "DATABASE_URL", "postgresql+asyncpg://x/y", raising=False
@@ -86,13 +95,18 @@ async def test_creation_branch_still_prints_credentials(monkeypatch):
     fake_engine = MagicMock()
     fake_engine.dispose = AsyncMock()
 
-    with patch.object(admin_script, "create_async_engine", return_value=fake_engine), patch.object(
-        admin_script, "async_sessionmaker", return_value=fake_sessionmaker
+    with (
+        patch.object(admin_script, "create_async_engine", return_value=fake_engine),
+        patch.object(
+            admin_script, "async_sessionmaker", return_value=fake_sessionmaker
+        ),
     ):
         buf = io.StringIO()
         with redirect_stdout(buf):
             await admin_script.create_admin_user()
         output = buf.getvalue()
 
-    assert secret in output, "Creation path is allowed to echo password once for first-run UX"
+    assert secret in output, (
+        "Creation path is allowed to echo password once for first-run UX"
+    )
     assert "Login credentials" in output

--- a/backend/tests/test_health_endpoint.py
+++ b/backend/tests/test_health_endpoint.py
@@ -18,7 +18,9 @@ async def test_livez_reports_process_alive(async_client):
 
 
 @pytest.mark.asyncio
-async def test_health_reports_ready_when_dependencies_are_healthy(async_client, monkeypatch):
+async def test_health_reports_ready_when_dependencies_are_healthy(
+    async_client, monkeypatch
+):
     """Readiness should report healthy when DB and cache checks pass."""
     monkeypatch.setattr("app.main._database_ready", lambda: _resolved((True, None)))
     monkeypatch.setattr("app.main._cache_ready", lambda: _resolved((True, None)))
@@ -39,9 +41,13 @@ async def test_health_reports_ready_when_dependencies_are_healthy(async_client, 
 
 
 @pytest.mark.asyncio
-async def test_health_reports_not_ready_when_a_dependency_fails(async_client, monkeypatch):
+async def test_health_reports_not_ready_when_a_dependency_fails(
+    async_client, monkeypatch
+):
     """Readiness should return 503 with machine-readable dependency failures."""
-    monkeypatch.setattr("app.main._database_ready", lambda: _resolved((False, "db down")))
+    monkeypatch.setattr(
+        "app.main._database_ready", lambda: _resolved((False, "db down"))
+    )
     monkeypatch.setattr("app.main._cache_ready", lambda: _resolved((True, None)))
 
     response = await async_client.get("/health")

--- a/backend/tests/test_hpo_proxy_validate.py
+++ b/backend/tests/test_hpo_proxy_validate.py
@@ -27,9 +27,13 @@ async def test_validate_route_uses_async_term_lookup_for_slow_fetch(
         return mocked_term
 
     monkeypatch.setattr(ontology_service, "get_term", fail_sync_lookup)
-    monkeypatch.setattr(ontology_service, "get_term_async", fake_async_lookup, raising=False)
+    monkeypatch.setattr(
+        ontology_service, "get_term_async", fake_async_lookup, raising=False
+    )
 
-    response = await async_client.get("/api/v2/hpo/validate", params={"term_ids": term_id})
+    response = await async_client.get(
+        "/api/v2/hpo/validate", params={"term_ids": term_id}
+    )
 
     assert response.status_code == 200
     assert response.json()[term_id] == {
@@ -54,9 +58,13 @@ async def test_validate_route_marks_unknown_placeholder_invalid(
         assert requested_term_id == term_id
         return unknown_term
 
-    monkeypatch.setattr(ontology_service, "get_term_async", fake_async_lookup, raising=False)
+    monkeypatch.setattr(
+        ontology_service, "get_term_async", fake_async_lookup, raising=False
+    )
 
-    response = await async_client.get("/api/v2/hpo/validate", params={"term_ids": term_id})
+    response = await async_client.get(
+        "/api/v2/hpo/validate", params={"term_ids": term_id}
+    )
 
     assert response.status_code == 200
     assert response.json()[term_id] == {
@@ -80,9 +88,13 @@ async def test_validate_route_marks_obsolete_term_invalid(async_client, monkeypa
         assert requested_term_id == term_id
         return obsolete_term
 
-    monkeypatch.setattr(ontology_service, "get_term_async", fake_async_lookup, raising=False)
+    monkeypatch.setattr(
+        ontology_service, "get_term_async", fake_async_lookup, raising=False
+    )
 
-    response = await async_client.get("/api/v2/hpo/validate", params={"term_ids": term_id})
+    response = await async_client.get(
+        "/api/v2/hpo/validate", params={"term_ids": term_id}
+    )
 
     assert response.status_code == 200
     assert response.json()[term_id] == {

--- a/backend/tests/test_ontology_service.py
+++ b/backend/tests/test_ontology_service.py
@@ -96,7 +96,9 @@ async def test_get_term_async_checks_api_before_local_when_cache_misses(
     )
 
     monkeypatch.setattr(ontology_service.file_cache, "get", lambda _: None)
-    monkeypatch.setattr(ontology_service.local_provider, "get_term", lambda _: local_term)
+    monkeypatch.setattr(
+        ontology_service.local_provider, "get_term", lambda _: local_term
+    )
     monkeypatch.setattr(ontology_service, "_fetch_from_apis", lambda _: api_term)
 
     term = await ontology_service.get_term_async(term_id)

--- a/docker/docker-compose.npm.yml
+++ b/docker/docker-compose.npm.yml
@@ -88,6 +88,9 @@ services:
       args:
         BUILDKIT_INLINE_CACHE: 1
 
+    env_file:
+      - ../.env.docker
+
     # PRODUCTION: No exposed ports - NPM handles routing
     ports: []
 

--- a/docs/superpowers/plans/2026-05-10-issues-286-287-288.md
+++ b/docs/superpowers/plans/2026-05-10-issues-286-287-288.md
@@ -1,0 +1,1063 @@
+# Post-deploy hardening (#286, #287, #288) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land three independent fixes (vite chunking TDZ, production deployment plumbing, auth/refresh anonymous-probe semantics) on a single branch with one commit per issue.
+
+**Architecture:** No new abstractions. Three localised changes — frontend bundle config; backend env/config plumbing across Dockerfile, compose, settings, and entrypoint script; layered FastAPI dependency + frontend bootstrap gate. Each commit can be reverted independently.
+
+**Tech Stack:** Vite 6 (frontend bundling), Vue 3 + Vuetify 3 + Pinia, FastAPI + Pydantic Settings, Docker / Compose v2, pytest + Vitest.
+
+**Branch:** `fix/post-deploy-hardening-286-287-288` (already created; design spec already committed).
+
+**Spec reference:** `docs/superpowers/specs/2026-05-10-issues-286-287-288-design.md`.
+
+---
+
+## Conventions used in this plan
+
+- All paths are relative to repo root `C:\development\hnf1b-db\` unless otherwise noted.
+- Backend tests run via `cd backend && uv run pytest <path>` (or `make test` for everything).
+- Frontend tests run via `cd frontend && npm test -- <path>` (Vitest, run-once mode by default).
+- Frontend lint: `cd frontend && npm run lint:check`. Backend lint: `cd backend && uv run ruff check .`.
+- Each task ends with a focused commit. Commit messages must reference the issue number.
+- Never use `--no-verify`. If a hook fails, fix the underlying issue.
+
+---
+
+## Task 1: #286 — Consolidate Vue/Vuetify into a single `vue-stack` chunk
+
+**Files:**
+- Modify: `frontend/vite.config.js:114-148`
+
+**Why TDD doesn't apply here:** This is a build-config change. The verification is "the production build produces a single `vue-stack-*.js` instead of four separate Vue/Vuetify chunks, and the SPA boots without a TDZ error in preview mode." There is no unit-test seam for `manualChunks(id)` worth introducing.
+
+- [ ] **Step 1.1: Replace the `manualChunks(id)` body in `frontend/vite.config.js`**
+
+Open `frontend/vite.config.js`. Locate the `manualChunks(id) { ... }` function (currently lines 114-148). Replace its body with the consolidated form below. Leave the surrounding `rollupOptions` / `output` / `chunkSizeWarningLimit` / `target` / `minify` blocks unchanged.
+
+```js
+        manualChunks(id) {
+          // Heavy visualization libraries - lazy loaded on demand
+          if (id.includes('chart.js')) return 'charts';
+          if (id.includes('ngl')) return 'ngl-viewer';
+
+          // D3 modules - used for visualizations
+          if (id.includes('d3-') || id.includes('/d3/')) return 'd3-modules';
+
+          // Consolidated Vue stack — keeps any cycle intra-chunk.
+          // Splitting vue/@vue/vue-router/pinia/vuetify across chunks has
+          // produced TDZ "Cannot access 'b' before initialization" errors
+          // when a downstream dependency from the catch-all `vendor` bucket
+          // re-imports vue while @vue/reactivity is still mid-evaluation.
+          // See vitejs/vite#9686, #22122, #12209.
+          if (
+            id.includes('node_modules/vue/') ||
+            id.includes('node_modules/@vue/') ||
+            id.includes('node_modules/vue-router') ||
+            id.includes('node_modules/pinia') ||
+            id.includes('node_modules/vuetify') ||
+            id.includes('node_modules/@vuetify')
+          ) {
+            return 'vue-stack';
+          }
+
+          // Axios for API calls - frequently used
+          if (id.includes('axios')) return 'axios';
+
+          // Date utilities - split for better caching
+          if (id.includes('date-fns')) return 'date-utils';
+
+          // Form validation - only needed on edit pages
+          if (id.includes('yup')) return 'validation';
+
+          // File utilities - only needed for downloads
+          if (id.includes('file-saver')) return 'file-utils';
+
+          // Other node_modules
+          if (id.includes('node_modules')) return 'vendor';
+        },
+```
+
+- [ ] **Step 1.2: Run the production build**
+
+Run from repo root:
+
+```powershell
+cd frontend; npm run build
+```
+
+Expected: build succeeds with `✓ built in ...`. No "chunk size larger than 300 KB" warnings about `vue-stack` (it should land around 150 KB brotli, well under the limit).
+
+- [ ] **Step 1.3: Verify chunk shape**
+
+Run:
+
+```powershell
+ls frontend/dist/assets | Select-String -Pattern '^(vue-|vuetify-)'
+```
+
+Expected output: a single `vue-stack-<hash>.js` (and its `.br`/`.gz` siblings). There must be **no** `vue-vendor-`, `vuetify-core-`, `vuetify-data-`, or `vue-core-` chunks.
+
+- [ ] **Step 1.4: Smoke-test in preview**
+
+Run:
+
+```powershell
+cd frontend; npm run preview
+```
+
+Open the printed URL in a browser, hit the home page, and check the DevTools console. Expected: no `Cannot access 'b' before initialization` error; the Vue app mounts. Stop the preview server (Ctrl+C).
+
+- [ ] **Step 1.5: Lint the changed file**
+
+Run:
+
+```powershell
+cd frontend; npm run lint:check
+```
+
+Expected: no new errors.
+
+- [ ] **Step 1.6: Commit**
+
+```powershell
+git add frontend/vite.config.js
+git commit -m "fix(frontend): consolidate vue-stack chunk to avoid TDZ (#286)`n`nReplaces the four-rule split (vue-vendor / vue-core / vuetify-core /`nvuetify-data) with a single 'vue-stack' chunk so any circular import`namong vue, @vue, vue-router, pinia, vuetify, and @vuetify stays`nintra-chunk. The previous split tripped a TDZ ('Cannot access \`b\``nbefore initialization') on production cold loads after the dependency`ngraph picked up a new cycle. See vitejs/vite#9686, #22122, #12209.`n`nFixes #286."
+```
+
+(If you're on a non-PowerShell shell, use a `git commit -F -` heredoc instead — the message body matters, the shell escaping doesn't.)
+
+---
+
+## Task 2: #287 — Production deployment plumbing
+
+This task lands all five sub-fixes in one commit because they are coupled (the env override is meaningless without the example file update; the YAML typo and the env override touch the same area). Within the task, sub-tasks are TDD-ordered for the items that have a test seam (config validators, admin script).
+
+**Files:**
+- Modify: `backend/Dockerfile.prod` (add `COPY config.yaml`)
+- Modify: `docker/docker-compose.npm.yml` (add `env_file:` directive)
+- Modify: `backend/config.yaml` (fix `from_address` typo)
+- Modify: `backend/app/core/config.py` (add `EMAIL_BACKEND` env override + use it in two validators)
+- Modify: `.env.docker.example` (add Wave 5c production-runtime block)
+- Modify: `backend/scripts/create_admin_user.py` (move credentials echo into creation branch only)
+- Test: `backend/tests/test_config_email_backend_override.py` (new)
+- Test: `backend/tests/test_create_admin_user_no_password_leak.py` (new)
+
+### Sub-task 2A — `EMAIL_BACKEND` env override (TDD)
+
+- [ ] **Step 2A.1: Write the failing test**
+
+Create `backend/tests/test_config_email_backend_override.py`:
+
+```python
+"""Tests for EMAIL_BACKEND env override semantics (Wave 5c follow-up)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import Settings, YamlConfig
+from app.core.config import EmailConfig
+
+
+def _settings_with_yaml_email_backend(
+    *, env_override: str | None, yaml_backend: str, environment: str
+) -> Settings:
+    """Build a Settings instance with a stubbed YAML config."""
+    yaml_cfg = YamlConfig(email=EmailConfig(backend=yaml_backend))
+    kwargs: dict[str, object] = {
+        "JWT_SECRET": "test-secret-key-abc123",
+        "ADMIN_PASSWORD": "TestAdminPass!2026",
+        "environment": environment,
+        "AUTH_COOKIE_SECURE": environment != "development",
+        "SMTP_HOST": "smtp.example.com" if (env_override or yaml_backend) == "smtp" else "",
+        "SMTP_USERNAME": "user" if (env_override or yaml_backend) == "smtp" else "",
+        "SMTP_PASSWORD": "pass" if (env_override or yaml_backend) == "smtp" else "",
+    }
+    if env_override is not None:
+        kwargs["EMAIL_BACKEND"] = env_override
+
+    settings = Settings(**kwargs)
+    # Force-replace the lazy-loaded YAML config with our stub.
+    settings._yaml_config = yaml_cfg
+    # Re-run validators that read self.yaml.email.
+    return settings
+
+
+def test_email_backend_env_overrides_yaml_console_in_production():
+    """EMAIL_BACKEND=smtp must override yaml backend='console' in production."""
+    settings = _settings_with_yaml_email_backend(
+        env_override="smtp", yaml_backend="console", environment="production"
+    )
+    # If the override is honoured, we don't get the "REFUSING TO START" raise
+    # and SMTP_HOST presence makes _validate_smtp_config happy.
+    assert settings.EMAIL_BACKEND == "smtp"
+
+
+def test_yaml_console_default_still_rejects_in_production_without_override():
+    """Without EMAIL_BACKEND set, yaml 'console' default must still fail-closed."""
+    with pytest.raises(ValueError, match="email.backend is 'console'"):
+        _settings_with_yaml_email_backend(
+            env_override=None, yaml_backend="console", environment="production"
+        )
+
+
+def test_email_backend_env_override_smtp_requires_smtp_host():
+    """EMAIL_BACKEND=smtp without SMTP_HOST must fail-closed (validator runs after override)."""
+    with pytest.raises(ValueError, match="SMTP_HOST"):
+        Settings(
+            JWT_SECRET="test-secret-key-abc123",
+            ADMIN_PASSWORD="TestAdminPass!2026",
+            environment="production",
+            AUTH_COOKIE_SECURE=True,
+            EMAIL_BACKEND="smtp",
+            SMTP_HOST="",
+        )
+
+
+def test_dev_keeps_yaml_console_default_with_no_env_override():
+    """Dev environment leaves yaml 'console' default in place; no override needed."""
+    settings = _settings_with_yaml_email_backend(
+        env_override=None, yaml_backend="console", environment="development"
+    )
+    assert settings.EMAIL_BACKEND is None
+```
+
+- [ ] **Step 2A.2: Run the new tests and verify they fail**
+
+```powershell
+cd backend; uv run pytest tests/test_config_email_backend_override.py -v
+```
+
+Expected: all four tests fail (`Settings` has no `EMAIL_BACKEND` field yet, or validators do not consult it).
+
+- [ ] **Step 2A.3: Add the `EMAIL_BACKEND` field on `Settings`**
+
+In `backend/app/core/config.py`, locate the SMTP credentials block (currently lines 300-304):
+
+```python
+    # SMTP credentials (for email delivery)
+    SMTP_HOST: str = ""
+    SMTP_PORT: int = 587
+    SMTP_USERNAME: str = ""
+    SMTP_PASSWORD: str = ""
+```
+
+Insert the override field immediately after this block (before the `Admin credentials` comment on line 306):
+
+```python
+    # Email backend override — when set, takes precedence over YAML
+    # `email.backend`. Production must set EMAIL_BACKEND=smtp in .env.docker
+    # because the Wave 5c validator refuses to start with backend='console'.
+    EMAIL_BACKEND: Literal["console", "smtp"] | None = None
+```
+
+`Literal` is already imported at the top of this file — no new imports needed.
+
+- [ ] **Step 2A.4: Update validators to use the resolved value**
+
+In the same file, update `_validate_environment_security_requirements` (currently line 415). Replace its body (lines 416-435) with:
+
+```python
+        """Fail closed on environment-specific email and cookie settings."""
+        email_cfg = self.yaml.email
+        resolved_backend = self.EMAIL_BACKEND or email_cfg.backend
+
+        if self.environment == "production" and resolved_backend == "console":
+            raise ValueError(
+                "REFUSING TO START: email.backend is 'console' while "
+                "ENVIRONMENT=production. Configure SMTP delivery before "
+                "starting production."
+            )
+
+        if (
+            self.environment in {"staging", "production"}
+            and not self.AUTH_COOKIE_SECURE
+        ):
+            raise ValueError(
+                "REFUSING TO START: AUTH_COOKIE_SECURE must be true when "
+                f"ENVIRONMENT={self.environment}."
+            )
+
+        return self
+```
+
+Update `_validate_smtp_config` (currently line 452). Replace its body (lines 453-478) with:
+
+```python
+        """Fail fast if email backend is smtp but SMTP_HOST is missing."""
+        email_cfg = self.yaml.email
+        resolved_backend = self.EMAIL_BACKEND or email_cfg.backend
+        if resolved_backend == "smtp":
+            if not self.SMTP_HOST or self.SMTP_HOST.strip() == "":
+                raise ValueError(
+                    "REFUSING TO START: email.backend is 'smtp' but SMTP_HOST "
+                    "is empty. Set SMTP_HOST in .env or switch to "
+                    "email.backend: 'console' in config.yaml."
+                )
+            if email_cfg.use_credentials:
+                if not self.SMTP_USERNAME or not self.SMTP_PASSWORD:
+                    raise ValueError(
+                        "REFUSING TO START: email.backend is 'smtp' with "
+                        "use_credentials: true, but SMTP_USERNAME or "
+                        "SMTP_PASSWORD is empty. Set them in .env or set "
+                        "email.use_credentials: false in config.yaml."
+                    )
+            # Gate TLS warning behind smtp backend — it is irrelevant (and
+            # noisy) when backend is console (Copilot PR #235 review).
+            if email_cfg.tls_mode == "none":
+                logger.critical(
+                    "EMAIL TLS IS DISABLED (email.tls_mode: 'none'). "
+                    "Emails will be sent unencrypted. This is only safe "
+                    "for trusted internal relays."
+                )
+        return self
+```
+
+- [ ] **Step 2A.5: Run the tests and verify they pass**
+
+```powershell
+cd backend; uv run pytest tests/test_config_email_backend_override.py -v
+```
+
+Expected: all four tests pass.
+
+- [ ] **Step 2A.6: Run the full backend test suite to confirm no regressions**
+
+```powershell
+cd backend; uv run pytest -q
+```
+
+Expected: all tests pass. If any pre-existing test mocked `email_cfg.backend` directly and now needs to mock `EMAIL_BACKEND` too, fix it inline before moving on.
+
+### Sub-task 2B — Fix `from_address` typo in `backend/config.yaml`
+
+- [ ] **Step 2B.1: Fix the typo**
+
+In `backend/config.yaml`, line 95, change:
+
+```yaml
+  from_address: "noreply@hnf1b-db.org"
+```
+
+to:
+
+```yaml
+  from_address: "noreply@hnf1b.org"
+```
+
+No code change accompanies this; the value is read directly by the email backend at send time.
+
+### Sub-task 2C — `Dockerfile.prod` ships `config.yaml`
+
+- [ ] **Step 2C.1: Add the COPY directive**
+
+In `backend/Dockerfile.prod`, locate line 86 (`COPY --chown=hnf1b:hnf1b ./scripts ./scripts`). Add the following line directly after it (so it sits between `./scripts` and the entrypoint copy on line 89):
+
+```dockerfile
+COPY --chown=hnf1b:hnf1b ./config.yaml ./
+```
+
+- [ ] **Step 2C.2: Build the image to confirm the COPY resolves**
+
+```powershell
+docker build -f backend/Dockerfile.prod -t hnf1b-api:plan-test backend
+```
+
+Expected: build succeeds. If the COPY line cannot resolve `config.yaml`, the build fails with `not found in build context`.
+
+- [ ] **Step 2C.3: Verify the file landed inside the image**
+
+```powershell
+docker run --rm --entrypoint sh hnf1b-api:plan-test -c "ls -la /app/config.yaml && head -5 /app/config.yaml"
+```
+
+Expected: `/app/config.yaml` exists, owned by `hnf1b:hnf1b`, with the YAML header visible.
+
+### Sub-task 2D — Compose api service reads `.env.docker`
+
+- [ ] **Step 2D.1: Add `env_file:` to the api service**
+
+In `docker/docker-compose.npm.yml`, locate the `hnf1b_api:` service block at line 84. Insert an `env_file:` directive after the `build:` block and before `# PRODUCTION: No exposed ports` (around line 91):
+
+```yaml
+    env_file:
+      - ../.env.docker
+
+```
+
+The full beginning of the api service should now read:
+
+```yaml
+  hnf1b_api:
+    build:
+      context: ../backend
+      dockerfile: Dockerfile.prod
+      args:
+        BUILDKIT_INLINE_CACHE: 1
+
+    env_file:
+      - ../.env.docker
+
+    # PRODUCTION: No exposed ports - NPM handles routing
+    ports: []
+```
+
+- [ ] **Step 2D.2: Validate the compose file syntax**
+
+```powershell
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.npm.yml --env-file .env.docker.example config
+```
+
+Expected: compose prints the merged config without errors and the `hnf1b_api` service shows the resolved env vars.
+
+(Use `.env.docker.example` here because the secret-bearing `.env.docker` is not in version control on a fresh checkout.)
+
+### Sub-task 2E — `.env.docker.example` adds Wave 5c production-runtime block
+
+- [ ] **Step 2E.1: Insert the production-runtime block**
+
+Open `.env.docker.example`. Locate the section header `# Admin Credentials (for initial setup)` (around line 49). Immediately above that section, insert:
+
+```dotenv
+# ============================================
+# Production runtime (REQUIRED for production)
+# ============================================
+# These are read by Wave 5c fail-closed validators in app/core/config.py.
+
+ENVIRONMENT=production
+AUTH_COOKIE_SECURE=true
+
+# Email delivery — must be 'smtp' in production (validator refuses 'console').
+# See backend/.env.example for SendGrid / Mailgun / AWS SES samples.
+EMAIL_BACKEND=smtp
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+
+```
+
+(Leave the rest of the file untouched.)
+
+### Sub-task 2F — `create_admin_user.py` no longer leaks the password on every restart (TDD)
+
+- [ ] **Step 2F.1: Write the failing test**
+
+Create `backend/tests/test_create_admin_user_no_password_leak.py`:
+
+```python
+"""Regression test: admin script must not echo the password when the user already exists."""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import scripts.create_admin_user as admin_script
+
+
+class _StubResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+@pytest.mark.asyncio
+async def test_existing_admin_branch_does_not_print_password(monkeypatch):
+    """When the admin already exists the script must NOT echo the password."""
+    secret = "super-secret-rotation-value-9000"
+    monkeypatch.setattr(admin_script.settings, "ADMIN_USERNAME", "admin", raising=False)
+    monkeypatch.setattr(admin_script.settings, "ADMIN_EMAIL", "admin@example.com", raising=False)
+    monkeypatch.setattr(admin_script.settings, "ADMIN_PASSWORD", secret, raising=False)
+    monkeypatch.setattr(
+        admin_script.settings, "DATABASE_URL", "postgresql+asyncpg://x/y", raising=False
+    )
+
+    existing_admin = MagicMock()
+    existing_admin.id = 7
+
+    fake_session = MagicMock()
+    fake_session.execute = AsyncMock(return_value=_StubResult(existing_admin))
+    fake_session.commit = AsyncMock()
+    fake_session.rollback = AsyncMock()
+
+    fake_session_ctx = MagicMock()
+    fake_session_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    fake_sessionmaker = MagicMock(return_value=fake_session_ctx)
+
+    fake_engine = MagicMock()
+    fake_engine.dispose = AsyncMock()
+
+    with patch.object(admin_script, "create_async_engine", return_value=fake_engine), patch.object(
+        admin_script, "async_sessionmaker", return_value=fake_sessionmaker
+    ):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            await admin_script.create_admin_user()
+        output = buf.getvalue()
+
+    assert secret not in output, "ADMIN_PASSWORD must never be echoed on update path"
+    assert "Password:" not in output, "Plain 'Password:' label must not appear on update path"
+
+
+@pytest.mark.asyncio
+async def test_creation_branch_still_prints_credentials(monkeypatch):
+    """Brand-new admin path keeps printing the credential block (intentional)."""
+    secret = "fresh-install-password-9000"
+    monkeypatch.setattr(admin_script.settings, "ADMIN_USERNAME", "admin", raising=False)
+    monkeypatch.setattr(admin_script.settings, "ADMIN_EMAIL", "admin@example.com", raising=False)
+    monkeypatch.setattr(admin_script.settings, "ADMIN_PASSWORD", secret, raising=False)
+    monkeypatch.setattr(
+        admin_script.settings, "DATABASE_URL", "postgresql+asyncpg://x/y", raising=False
+    )
+
+    fake_session = MagicMock()
+    fake_session.execute = AsyncMock(return_value=_StubResult(None))
+    fake_session.commit = AsyncMock()
+    fake_session.refresh = AsyncMock()
+    fake_session.rollback = AsyncMock()
+    fake_session.add = MagicMock()
+
+    fake_session_ctx = MagicMock()
+    fake_session_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    fake_sessionmaker = MagicMock(return_value=fake_session_ctx)
+
+    fake_engine = MagicMock()
+    fake_engine.dispose = AsyncMock()
+
+    with patch.object(admin_script, "create_async_engine", return_value=fake_engine), patch.object(
+        admin_script, "async_sessionmaker", return_value=fake_sessionmaker
+    ):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            await admin_script.create_admin_user()
+        output = buf.getvalue()
+
+    assert secret in output, "Creation path is allowed to echo password once for first-run UX"
+    assert "Login credentials" in output
+```
+
+- [ ] **Step 2F.2: Run the test and verify it fails on the existing-admin path**
+
+```powershell
+cd backend; uv run pytest tests/test_create_admin_user_no_password_leak.py -v
+```
+
+Expected: `test_existing_admin_branch_does_not_print_password` fails (current code prints the password unconditionally). The creation test should pass.
+
+- [ ] **Step 2F.3: Move the credentials block into the creation branch**
+
+In `backend/scripts/create_admin_user.py`, replace lines 42-74 (the `if existing_admin: ... else: ...` block plus the trailing credential print) with:
+
+```python
+            if existing_admin:
+                print(f"Admin user exists (ID: {existing_admin.id}), updating...")
+                existing_admin.hashed_password = get_password_hash(admin_password)
+                existing_admin.role = "admin"
+                existing_admin.is_active = True
+                existing_admin.is_verified = True
+                existing_admin.failed_login_attempts = 0
+                existing_admin.locked_until = None
+                await db.commit()
+                print(f"✅ Admin user updated: {admin_username}")
+                print("   (password reset from $ADMIN_PASSWORD; not echoed)")
+            else:
+                print("Creating new admin user...")
+                admin_user = User(
+                    email=admin_email,
+                    username=admin_username,
+                    hashed_password=get_password_hash(admin_password),
+                    full_name="Administrator",
+                    role="admin",
+                    is_active=True,
+                    is_verified=True,
+                )
+                db.add(admin_user)
+                await db.commit()
+                await db.refresh(admin_user)
+                print(f"✅ Admin user created: {admin_username} (ID: {admin_user.id})")
+
+                print("\n🔐 Login credentials:")
+                print(f"   Username: {admin_username}")
+                print(f"   Password: {admin_password}")
+                print(
+                    "\n⚠️  SECURITY: Change the admin password immediately "
+                    "after first login!\n"
+                )
+```
+
+- [ ] **Step 2F.4: Run the tests and verify both pass**
+
+```powershell
+cd backend; uv run pytest tests/test_create_admin_user_no_password_leak.py -v
+```
+
+Expected: both tests pass.
+
+### Sub-task 2G — Final test sweep + commit for issue #287
+
+- [ ] **Step 2G.1: Run backend lint + full test suite**
+
+```powershell
+cd backend; uv run ruff check .
+cd backend; uv run pytest -q
+```
+
+Expected: no lint errors, all tests pass.
+
+- [ ] **Step 2G.2: Commit**
+
+```powershell
+git add backend/Dockerfile.prod docker/docker-compose.npm.yml backend/config.yaml backend/app/core/config.py .env.docker.example backend/scripts/create_admin_user.py backend/tests/test_config_email_backend_override.py backend/tests/test_create_admin_user_no_password_leak.py
+git commit -m "fix(deploy): close production deployment gaps (#287)`n`nFive sub-fixes that together restore a clean 'git pull && make rebuild'`nupgrade path for production after the Wave 5c fail-closed validators`nlanded in bde6704:`n`n  1. Dockerfile.prod now COPY-s config.yaml so the YAML loader actually`n     finds it in the production image.`n  2. docker-compose.npm.yml adds env_file: ../.env.docker on hnf1b_api`n     so SMTP_* and AUTH_COOKIE_SECURE reach the container process.`n  3. New EMAIL_BACKEND env override on Settings; production sets it to`n     'smtp' in .env.docker without forcing dev users to edit YAML.`n     config.yaml keeps backend: 'console' as the dev-friendly default.`n  4. .env.docker.example documents the production-runtime block`n     (ENVIRONMENT, AUTH_COOKIE_SECURE, EMAIL_BACKEND, SMTP_*).`n  5. create_admin_user.py no longer echoes the admin password on the`n     existing-admin branch — only on first creation.`n`nAlso fixes the from_address typo (hnf1b-db.org -> hnf1b.org).`n`nFixes #287."
+```
+
+---
+
+## Task 3: #288 — `auth/refresh` returns 401 on anonymous probe + SPA skips probe
+
+**Files:**
+- Modify: `backend/app/auth/dependencies.py:210` (add `require_session_then_csrf` next to `require_csrf_token`)
+- Modify: `backend/app/api/auth_endpoints.py:26,339` (import + dependency swap on `/auth/refresh`)
+- Modify: `frontend/src/stores/authStore.js:10,215` (import `getCsrfToken`, gate the bootstrap probe)
+- Test: `backend/tests/test_auth_csrf.py` (extend with three new cases)
+- Test: `frontend/tests/unit/stores/authStore.spec.js` (extend with two new cases)
+
+### Sub-task 3A — Backend dependency + endpoint swap (TDD)
+
+- [ ] **Step 3A.1: Append three failing tests to `backend/tests/test_auth_csrf.py`**
+
+Append to the bottom of `backend/tests/test_auth_csrf.py`:
+
+```python
+
+
+# ----- require_session_then_csrf (issue #288) -----
+
+
+from app.auth.dependencies import require_session_then_csrf
+
+
+def _request_with_cookies(*, refresh: str | None, csrf_cookie: str | None, csrf_header: str | None) -> Request:
+    """Build a Starlette request with optional refresh cookie + CSRF pair."""
+    cookie_parts: list[str] = []
+    if refresh is not None:
+        cookie_parts.append(f"refresh_token={refresh}")
+    if csrf_cookie is not None:
+        cookie_parts.append(f"csrf_token={csrf_cookie}")
+
+    headers: list[tuple[bytes, bytes]] = []
+    if cookie_parts:
+        headers.append((b"cookie", "; ".join(cookie_parts).encode()))
+    if csrf_header is not None:
+        headers.append((b"x-csrf-token", csrf_header.encode()))
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v2/auth/refresh",
+        "headers": headers,
+    }
+    return Request(scope)
+
+
+async def test_require_session_then_csrf_returns_401_when_no_session_cookie():
+    """Anonymous bootstrap probe (no refresh cookie) returns 401, not 403."""
+    request = _request_with_cookies(refresh=None, csrf_cookie=None, csrf_header=None)
+
+    try:
+        await require_session_then_csrf(request)
+    except Exception as exc:  # noqa: BLE001
+        assert getattr(exc, "status_code", None) == 401
+        assert "no active session" in str(getattr(exc, "detail", "")).lower()
+    else:  # pragma: no cover - red phase guard
+        raise AssertionError("Expected 401 when refresh cookie is absent")
+
+
+async def test_require_session_then_csrf_returns_403_when_session_present_but_csrf_missing():
+    """With a refresh session cookie but no CSRF header, fall through to 403."""
+    request = _request_with_cookies(
+        refresh="rt-xyz", csrf_cookie="csrf-abc", csrf_header=None
+    )
+
+    try:
+        await require_session_then_csrf(request)
+    except Exception as exc:  # noqa: BLE001
+        assert getattr(exc, "status_code", None) == 403
+        assert "csrf" in str(getattr(exc, "detail", "")).lower()
+    else:  # pragma: no cover - red phase guard
+        raise AssertionError("Expected 403 when CSRF header is missing despite session cookie")
+
+
+async def test_require_session_then_csrf_accepts_full_session_with_matching_csrf():
+    """Refresh cookie + matching CSRF cookie/header pair is accepted (returns None)."""
+    request = _request_with_cookies(
+        refresh="rt-xyz", csrf_cookie="csrf-abc", csrf_header="csrf-abc"
+    )
+
+    assert await require_session_then_csrf(request) is None
+```
+
+- [ ] **Step 3A.2: Run the new tests and verify they fail at import time**
+
+```powershell
+cd backend; uv run pytest tests/test_auth_csrf.py -v
+```
+
+Expected: collection error or `ImportError: cannot import name 'require_session_then_csrf' from 'app.auth.dependencies'`.
+
+- [ ] **Step 3A.3: Add `require_session_then_csrf` in `backend/app/auth/dependencies.py`**
+
+Append to the end of `backend/app/auth/dependencies.py` (after `require_csrf_token` ending at line 219):
+
+```python
+
+
+async def require_session_then_csrf(request: Request) -> None:
+    """Layered guard for cookie-auth endpoints invoked from anonymous SPAs.
+
+    Returns 401 when there is no refresh-session cookie at all (an anonymous
+    bootstrap probe), and only runs the CSRF check when a session is actually
+    claimed. This keeps 403 reserved for genuine CSRF rejections and gives
+    the frontend the more-correct status to discriminate on.
+
+    Used on /auth/refresh; logout keeps plain require_csrf_token.
+    """
+    if not request.cookies.get(settings.REFRESH_COOKIE_NAME):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="No active session",
+        )
+    await require_csrf_token(request)
+```
+
+`settings`, `status`, `Request`, and `HTTPException` are already imported at the top of this file.
+
+(Note: the field is `settings.REFRESH_COOKIE_NAME` — verify by grepping `REFRESH_COOKIE_NAME` if the original file's auth-cookie field name has been renamed since this plan was written; `settings.AUTH_COOKIE_NAME` is **not** the live name.)
+
+- [ ] **Step 3A.4: Wire the new dependency into `/auth/refresh`**
+
+In `backend/app/api/auth_endpoints.py`:
+
+1. Update line 26 to import the new dependency:
+
+```python
+from app.auth.dependencies import (
+    get_best_effort_user,
+    require_csrf_token,
+    require_session_then_csrf,
+)
+```
+
+(If the existing import is still a single-line form, replace it with this multi-line block.)
+
+2. On line 339, change:
+
+```python
+    _: None = Depends(require_csrf_token),
+```
+
+to:
+
+```python
+    _: None = Depends(require_session_then_csrf),
+```
+
+Leave the `/auth/logout` endpoint at line 419 unchanged — it stays on `require_csrf_token`.
+
+- [ ] **Step 3A.5: Run the new and existing CSRF tests**
+
+```powershell
+cd backend; uv run pytest tests/test_auth_csrf.py -v
+```
+
+Expected: all tests in this file pass.
+
+- [ ] **Step 3A.6: Run the full backend suite to confirm no regressions**
+
+```powershell
+cd backend; uv run pytest -q
+```
+
+Expected: all tests pass.
+
+### Sub-task 3B — Frontend bootstrap probe gate (TDD)
+
+- [ ] **Step 3B.1: Append failing tests to `frontend/tests/unit/stores/authStore.spec.js`**
+
+Inside the existing `describe('Auth Store', ...)` block (after the existing `describe('Initial State', ...)` block), append a new `describe('initialize() bootstrap probe gate (#288)', ...)` block. Insert before the closing `});` of `describe('Auth Store', ...)`:
+
+```js
+  describe('initialize() bootstrap probe gate (#288)', () => {
+    let originalCookieDescriptor;
+
+    beforeEach(() => {
+      originalCookieDescriptor = Object.getOwnPropertyDescriptor(document, 'cookie');
+    });
+
+    afterEach(() => {
+      if (originalCookieDescriptor) {
+        Object.defineProperty(document, 'cookie', originalCookieDescriptor);
+      }
+    });
+
+    function setCookie(value) {
+      Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get: () => value,
+      });
+    }
+
+    it('skips /auth/refresh when no csrf_token cookie is present', async () => {
+      setCookie('');
+      const authStore = useAuthStore();
+
+      await authStore.initialize();
+
+      expect(apiClient.post).not.toHaveBeenCalledWith(
+        '/auth/refresh',
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(authStore.hasInitialized).toBe(true);
+    });
+
+    it('calls /auth/refresh when csrf_token cookie is present', async () => {
+      setCookie('csrf_token=abc123');
+      apiClient.post.mockResolvedValueOnce({ data: { access_token: 'new-token' } });
+      apiClient.get.mockResolvedValueOnce({ data: { username: 'alice', role: 'curator' } });
+
+      const authStore = useAuthStore();
+      await authStore.initialize();
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/auth/refresh',
+        null,
+        expect.objectContaining({ withCredentials: true }),
+      );
+      expect(authStore.accessToken).toBe('new-token');
+    });
+  });
+```
+
+- [ ] **Step 3B.2: Run the new tests and verify they fail**
+
+```powershell
+cd frontend; npm test -- tests/unit/stores/authStore.spec.js
+```
+
+Expected: the "skips /auth/refresh when no csrf_token cookie is present" test fails (the current code calls refresh unconditionally when no in-memory access token is present).
+
+- [ ] **Step 3B.3: Add `getCsrfToken` to the existing import on line 10**
+
+In `frontend/src/stores/authStore.js`, change line 10:
+
+```js
+import { clearTokens, getAccessToken, persistTokens } from '@/api/session';
+```
+
+to:
+
+```js
+import {
+  clearTokens,
+  getAccessToken,
+  getCsrfToken,
+  persistTokens,
+} from '@/api/session';
+```
+
+- [ ] **Step 3B.4: Gate the bootstrap probe in `initialize()`**
+
+In `frontend/src/stores/authStore.js`, replace the `initialize` function (currently lines 215-251) with:
+
+```js
+  // Initialize: Load user if token exists
+  async function initialize() {
+    if (initializationPromise) {
+      return initializationPromise;
+    }
+
+    initializationPromise = (async () => {
+      if (accessToken.value) {
+        try {
+          await fetchCurrentUser();
+        } catch (err) {
+          // Token might be expired, will be handled by interceptor
+          const level = user.value ? 'warn' : 'debug';
+          window.logService[level]('Failed to initialize user session', {
+            error: err.message,
+          });
+        }
+        return;
+      }
+
+      // No csrf_token cookie → no refresh session is possible (cookies are
+      // set together at /auth/login). Skip the probe to avoid an unnecessary
+      // round trip — and the misleading 403 — on every anonymous page load.
+      // See issue #288.
+      if (!getCsrfToken()) {
+        return;
+      }
+
+      try {
+        await refreshAccessToken();
+        await fetchCurrentUser();
+      } catch (err) {
+        // Anonymous visitor — refresh rejection is expected.
+        window.logService.debug('Anonymous session bootstrap skipped', {
+          error: err.message,
+        });
+      }
+    })();
+
+    try {
+      await initializationPromise;
+    } finally {
+      hasInitialized.value = true;
+      initializationPromise = null;
+    }
+  }
+```
+
+- [ ] **Step 3B.5: Run the new and surrounding tests**
+
+```powershell
+cd frontend; npm test -- tests/unit/stores/authStore.spec.js
+```
+
+Expected: all tests in this file pass.
+
+- [ ] **Step 3B.6: Run the full frontend test suite**
+
+```powershell
+cd frontend; npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3B.7: Lint frontend**
+
+```powershell
+cd frontend; npm run lint:check
+```
+
+Expected: no new lint errors.
+
+### Sub-task 3C — Commit issue #288
+
+- [ ] **Step 3C.1: Commit**
+
+```powershell
+git add backend/app/auth/dependencies.py backend/app/api/auth_endpoints.py backend/tests/test_auth_csrf.py frontend/src/stores/authStore.js frontend/tests/unit/stores/authStore.spec.js
+git commit -m "fix(auth): return 401 for anonymous /auth/refresh probes (#288)`n`nBackend: introduce require_session_then_csrf — a layered FastAPI dep`nthat checks for the refresh-session cookie first and only runs the CSRF`ncheck when the cookie is present. /auth/refresh now uses this dep, so`nan anonymous bootstrap probe gets a correct 401 instead of a misleading`n403 and 403 stays reserved for genuine CSRF rejections. /auth/logout`nkeeps the plain require_csrf_token dep — its semantics are unchanged.`n`nFrontend: authStore.initialize() now reads the JS-readable csrf_token`ncookie and skips the /auth/refresh round trip entirely when the cookie`nis absent. The cookie is set atomically with refresh_token at login,`nso its absence proves no session can be refreshed. Eliminates the`nconsole 403 noise and one unconditional HTTP request per anonymous`npage load.`n`nFixes #288."
+```
+
+---
+
+## Final verification (whole branch)
+
+- [ ] **Step F.1: Run all backend tests**
+
+```powershell
+cd backend; uv run pytest -q
+```
+
+Expected: green.
+
+- [ ] **Step F.2: Run all frontend tests**
+
+```powershell
+cd frontend; npm test
+```
+
+Expected: green.
+
+- [ ] **Step F.3: Build the frontend**
+
+```powershell
+cd frontend; npm run build
+```
+
+Expected: green; `vue-stack-*.js` present in `dist/assets/`.
+
+- [ ] **Step F.4: Confirm git log**
+
+```powershell
+git log --oneline main..HEAD
+```
+
+Expected (4 commits including the spec):
+
+```
+<sha> fix(auth): return 401 for anonymous /auth/refresh probes (#288)
+<sha> fix(deploy): close production deployment gaps (#287)
+<sha> fix(frontend): consolidate vue-stack chunk to avoid TDZ (#286)
+<sha> docs(spec): post-deploy hardening for #286, #287, #288
+```
+
+- [ ] **Step F.5: Push and open the PR**
+
+```powershell
+git push -u origin fix/post-deploy-hardening-286-287-288
+gh pr create --title "fix: post-deploy hardening (#286, #287, #288)" --body "$(@'
+## Summary
+
+Three independent regressions surfaced by the 09789ff production deploy:
+
+- #286 — Frontend SPA TDZ (Cannot access 'b' before initialization) caused by Vite chunking the Vue ecosystem across cyclic chunks. Fixed by consolidating vue/@vue/vue-router/pinia/vuetify into a single `vue-stack` chunk.
+- #287 — Wave 5c fail-closed validators trip on five pre-existing deployment-plumbing gaps. Fixed: Dockerfile.prod now copies config.yaml; compose api service reads .env.docker; new EMAIL_BACKEND env override keeps dev on console while letting prod fail-closed; .env.docker.example documents Wave 5c vars; admin-create script no longer echoes password on every restart.
+- #288 — /auth/refresh returns 403 (CSRF) for the anonymous bootstrap probe instead of 401, and the SPA makes the probe call unconditionally. Fixed with a layered backend dependency and a frontend csrf-cookie gate.
+
+Spec: docs/superpowers/specs/2026-05-10-issues-286-287-288-design.md
+Plan: docs/superpowers/plans/2026-05-10-issues-286-287-288.md
+
+Three commits, one per issue, so reverts stay granular.
+
+## Test plan
+
+- [ ] Backend `uv run pytest` passes locally
+- [ ] Frontend `npm test` passes locally
+- [ ] Frontend `npm run build` produces `vue-stack-*.js` and no `vue-vendor-*` / `vuetify-core-*` chunks
+- [ ] Manual smoke: incognito production load shows no 403 on /auth/refresh and no console TDZ error
+- [ ] CI green on GitHub Actions
+
+Closes #286
+Closes #287
+Closes #288
+'@)"
+```
+
+(Watch the PR's Actions run — do not call this complete until CI is green.)
+
+---
+
+## Self-review checklist (run by author after writing this plan)
+
+- **Spec coverage:**
+  - #286 vite consolidation → Task 1 ✓
+  - #287 sub-fix 1 (Dockerfile COPY) → Sub-task 2C ✓
+  - #287 sub-fix 2 (compose env_file) → Sub-task 2D ✓
+  - #287 sub-fix 3 (config.yaml typo + EMAIL_BACKEND override) → Sub-tasks 2A + 2B ✓
+  - #287 sub-fix 4 (.env.docker.example sync) → Sub-task 2E ✓
+  - #287 sub-fix 5 (admin password leak) → Sub-task 2F ✓
+  - #288 backend dependency swap → Sub-task 3A ✓
+  - #288 frontend bootstrap gate → Sub-task 3B ✓
+  - Commit boundaries match spec's commit plan ✓
+- **Placeholder scan:** none.
+- **Type/name consistency:**
+  - `EMAIL_BACKEND` field name consistent across config.py, tests, .env.docker.example ✓
+  - `require_session_then_csrf` name consistent across dependencies.py, auth_endpoints.py, tests ✓
+  - `vue-stack` chunk name consistent across vite.config.js and verification command ✓
+  - `settings.REFRESH_COOKIE_NAME` used (not the spec's stale `AUTH_COOKIE_NAME`) — flagged in Step 3A.3 ✓

--- a/docs/superpowers/specs/2026-05-10-issues-286-287-288-design.md
+++ b/docs/superpowers/specs/2026-05-10-issues-286-287-288-design.md
@@ -1,0 +1,292 @@
+# Post-deploy hardening — issues #286, #287, #288
+
+**Date:** 2026-05-10
+**Status:** Approved (design)
+**Branch (planned):** `fix/post-deploy-hardening-286-287-288`
+**Issues:** [#286](https://github.com/berntpopp/hnf1b-db/issues/286), [#287](https://github.com/berntpopp/hnf1b-db/issues/287), [#288](https://github.com/berntpopp/hnf1b-db/issues/288)
+
+## Context
+
+The `09789ff` deploy to production exposed three independent regressions, all reported with reproductions and proposed remedies by `@berntpopp`:
+
+1. **#286** — Production SPA fails to boot with a TDZ `Cannot access 'b' before initialization` error caused by Rollup chunking the Vue ecosystem across cyclic chunks.
+2. **#287** — Wave 5c fail-closed validators (commit `bde6704`) trip on five pre-existing deployment-plumbing gaps that the upgrade didn't account for; the validators are correct, the deploy surface is incomplete.
+3. **#288** — `POST /auth/refresh` returns 403 (CSRF) for the anonymous bootstrap probe instead of 401 (no session); the SPA also makes the probe call unnecessarily on every anonymous page load.
+
+All three are reproducible from `main` (`09789ff`). Production hotfixes are in place for #286 and #287 and will be overwritten by the next `git pull` until upstream lands these fixes.
+
+## Goals
+
+- Restore a clean `git pull && make rebuild` upgrade path on the production VPS.
+- Eliminate the SPA boot-time TDZ error and make the manual-chunk strategy resilient against new circular imports.
+- Return correct HTTP semantics for anonymous refresh probes (401, not 403) and stop the SPA from making the probe call when it provably can't succeed.
+- Keep the Wave 5c fail-closed posture intact — every validator must continue to refuse to start when its precondition is unmet.
+
+## Non-goals
+
+- Rewriting the chunking strategy from scratch (Option B in #286 is rejected — losing the explicit lazy-load boundaries for `chart.js`/`d3`/`ngl` would regress observed performance).
+- Replacing the YAML+env config split with a config-per-environment scheme (out of scope; tracked separately if ever).
+- Touching `/auth/logout`'s CSRF dependency. The bug report is scoped to `/auth/refresh`'s anonymous-probe path.
+
+## Approach (decided)
+
+- **Branch strategy:** single branch, single PR, three commits — one per issue. Bundled because the user prefers a single review/CI cycle for related post-deploy hardening; per-issue commits keep `git revert` granular.
+- **#286:** consolidated `vue-stack` chunk (Option A from the issue). Adds a code-comment pointer to the upstream Vite issues (#9686, #22122).
+- **#287:** five sub-fixes implementing the reporter's recommendations, with one upgrade — instead of flipping `email.backend` default to `"smtp"` in `config.yaml` (which would break dev), introduce an `EMAIL_BACKEND` env override that production sets via `.env.docker`. Dev continues to use the YAML's `"console"` default with no setup.
+- **#288:** layered backend dependency (`require_session_then_csrf`) on `/auth/refresh` only, plus a frontend gate that skips the probe when `csrf_token` cookie is absent.
+
+## Detailed design
+
+### #286 — `frontend/vite.config.js`
+
+Replace the four-rule split (`vuetify-data`, `vuetify-core`, `vue-core`, `vue-vendor`) with a single `vue-stack` chunk:
+
+```js
+manualChunks(id) {
+  if (id.includes('chart.js')) return 'charts';
+  if (id.includes('ngl')) return 'ngl-viewer';
+  if (id.includes('d3-') || id.includes('/d3/')) return 'd3-modules';
+
+  // Consolidated Vue stack — keeps any cycle intra-chunk.
+  // Splitting vue/@vue/vue-router/pinia/vuetify across chunks has produced
+  // TDZ "Cannot access 'b' before initialization" errors when a downstream
+  // dependency from the catch-all `vendor` bucket re-imports vue while
+  // @vue/reactivity is mid-evaluation. See vitejs/vite#9686, #22122, #12209.
+  if (
+    id.includes('node_modules/vue/') ||
+    id.includes('node_modules/@vue/') ||
+    id.includes('node_modules/vue-router') ||
+    id.includes('node_modules/pinia') ||
+    id.includes('node_modules/vuetify') ||
+    id.includes('node_modules/@vuetify')
+  ) {
+    return 'vue-stack';
+  }
+
+  if (id.includes('axios')) return 'axios';
+  if (id.includes('date-fns')) return 'date-utils';
+  if (id.includes('yup')) return 'validation';
+  if (id.includes('file-saver')) return 'file-utils';
+  if (id.includes('node_modules')) return 'vendor';
+}
+```
+
+The `vue-stack` chunk is ~150KB brotli — under the existing `chunkSizeWarningLimit: 300`, so the warning threshold is unchanged.
+
+**Verification:** `npm run build` succeeds; `dist/assets/` contains `vue-stack-*.js` and no separate `vue-vendor`/`vuetify-core`/`vue-core` chunks; `dist/bundle-analysis.html` confirms the chunk size; `npm run preview` followed by a manual page load shows no TDZ error in the browser console.
+
+### #287 — Production deployment plumbing
+
+#### 2.1 `backend/Dockerfile.prod`
+
+Add after line 86 (`COPY --chown=hnf1b:hnf1b ./scripts ./scripts`):
+
+```dockerfile
+COPY --chown=hnf1b:hnf1b ./config.yaml ./
+```
+
+The YAML loader (`backend/app/core/config.py:252`) searches `/app/config.yaml` first and silently returns defaults if missing — so the COPY is what makes the production-tuned values take effect.
+
+#### 2.2 `docker/docker-compose.npm.yml`
+
+Add to the `hnf1b_api:` service block (between `build:` and `ports:`):
+
+```yaml
+env_file:
+  - ../.env.docker
+```
+
+`docker compose --env-file .env.docker` only feeds variable interpolation in the compose file; service-level `env_file:` is what passes variables into the container process. The existing enumerated `environment:` block stays — `environment:` takes precedence over `env_file:` in Docker Compose, so explicit values still win.
+
+#### 2.3 Email backend — config + override
+
+**`backend/config.yaml`:** keep `backend: "console"` as the default. Fix the `from_address` typo:
+
+```yaml
+email:
+  backend: "console"
+  from_address: "noreply@hnf1b.org"  # was hnf1b-db.org
+```
+
+**`backend/app/core/config.py`:** add an env-only override field. Place near the existing SMTP settings:
+
+```python
+EMAIL_BACKEND: Literal["console", "smtp"] | None = None
+```
+
+Then update the two existing email-related validators (`_validate_environment_security_requirements` at line 415 and `_validate_smtp_config` at line 452) to read the resolved value rather than `email_cfg.backend` directly:
+
+```python
+resolved_backend = self.EMAIL_BACKEND or email_cfg.backend
+```
+
+Use `resolved_backend` in every comparison that today reads `email_cfg.backend`. The YAML's `email.backend` field stays as a documented default; production overrides it via `EMAIL_BACKEND=smtp` in `.env.docker`. Dev users need no env var.
+
+#### 2.4 `.env.docker.example`
+
+Add a "Production runtime" section before the existing "Admin Credentials" block:
+
+```dotenv
+# ============================================
+# Production runtime (REQUIRED for production)
+# ============================================
+ENVIRONMENT=production
+AUTH_COOKIE_SECURE=true
+
+# Email delivery — must be 'smtp' in production (validator fails closed).
+# See backend/.env.example for SendGrid/Mailgun/AWS SES samples.
+EMAIL_BACKEND=smtp
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+```
+
+#### 2.5 `backend/scripts/create_admin_user.py`
+
+Move the credentials block into the creation branch only. Existing-admin branch prints a non-secret notice:
+
+```python
+if existing_admin:
+    print(f"Admin user exists (ID: {existing_admin.id}), updating...")
+    existing_admin.hashed_password = get_password_hash(admin_password)
+    # ...unchanged...
+    await db.commit()
+    print(f"✅ Admin user updated: {admin_username}")
+    print(f"   (password reset from $ADMIN_PASSWORD; not echoed)")
+else:
+    print("Creating new admin user...")
+    # ...unchanged through db.refresh(admin_user)...
+    print(f"✅ Admin user created: {admin_username} (ID: {admin_user.id})")
+    print("\n🔐 Login credentials:")
+    print(f"   Username: {admin_username}")
+    print(f"   Password: {admin_password}")
+    print(
+        "\n⚠️  SECURITY: Change the admin password immediately "
+        "after first login!\n"
+    )
+```
+
+**Verification:** rebuild image → `docker exec hnf1b_api_npm cat /app/config.yaml` shows the file; container boots with `EMAIL_BACKEND=smtp` in `.env.docker`; backend test confirms `EMAIL_BACKEND` env overrides YAML; backend test confirms the existing-admin branch does not emit a `Password:` line; restart loop in dev does not echo passwords after the first creation.
+
+### #288 — `auth/refresh` semantics
+
+#### 3.1 `backend/app/auth/dependencies.py`
+
+Add next to `require_csrf_token`:
+
+```python
+async def require_session_then_csrf(request: Request) -> None:
+    """Layered guard for cookie-auth endpoints invoked from anonymous SPAs.
+
+    Returns 401 when no refresh-session cookie is present (an anonymous
+    bootstrap probe), and only runs the CSRF check when a session is
+    actually claimed. This keeps 403 reserved for genuine CSRF rejection.
+    """
+    if not request.cookies.get(settings.AUTH_COOKIE_NAME):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="No active session",
+        )
+    await require_csrf_token(request)
+```
+
+Uses `settings.AUTH_COOKIE_NAME` to follow the existing config pattern (the value resolves to `"refresh_token"`).
+
+#### 3.2 `backend/app/api/auth_endpoints.py`
+
+Swap the dependency on `/auth/refresh` (line 339):
+
+```python
+_: None = Depends(require_session_then_csrf),
+```
+
+`/auth/logout` (line 419) keeps `require_csrf_token`. Logout from a stale tab without a session cookie is not the anonymous-probe scenario this guard exists to fix, and existing tests cover the current contract.
+
+Update `from app.auth.dependencies import ...` on line 26 to also import `require_session_then_csrf`.
+
+#### 3.3 `frontend/src/stores/authStore.js`
+
+Modify `initialize()` (around line 215). Add `getCsrfToken` to the existing import on line 10. Gate the bootstrap refresh:
+
+```js
+async function initialize() {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = (async () => {
+    if (accessToken.value) {
+      try {
+        await fetchCurrentUser();
+      } catch (err) {
+        const level = user.value ? 'warn' : 'debug';
+        window.logService[level]('Failed to initialize user session', {
+          error: err.message,
+        });
+      }
+      return;
+    }
+
+    // No csrf_token cookie → no refresh session is possible (cookies are
+    // set together at login). Skip the probe to avoid an unnecessary
+    // round trip on every anonymous page load.
+    if (!getCsrfToken()) {
+      return;
+    }
+
+    try {
+      await refreshAccessToken();
+      await fetchCurrentUser();
+    } catch (err) {
+      window.logService.debug('Anonymous session bootstrap skipped', {
+        error: err.message,
+      });
+    }
+  })();
+
+  try {
+    await initializationPromise;
+  } finally {
+    hasInitialized.value = true;
+    initializationPromise = null;
+  }
+}
+```
+
+The `csrf_token` cookie is JS-readable (`Path=/`, not HttpOnly) and is set together with the HttpOnly `refresh_token` cookie by `/auth/login`. Its absence proves no session exists. If a user clears cookies mid-session both cookies disappear together, so the gate cannot strand a real session.
+
+**Verification:**
+
+- New backend test (extend `test_auth_csrf.py` or new `test_auth_refresh_anonymous.py`):
+  - Anonymous `POST /auth/refresh` (no cookies) → 401 with `"No active session"`.
+  - Request with `refresh_token` cookie but missing/invalid `X-CSRF-Token` → 403 (existing CSRF behaviour preserved).
+- `test_auth_tokens.py` continues to pass (happy-path refresh unchanged).
+- Frontend Vitest: stub `document.cookie`; assert `apiClient.post('/auth/refresh', …)` is **not** called when cookie is empty; assert it **is** called when `csrf_token=…` is present.
+- Manual: load production in an incognito window, console shows no 403 on `/auth/refresh` and the network tab shows no request to it.
+
+## Architecture & isolation
+
+- Each issue's changes touch independent files; no shared state across the three.
+- `require_session_then_csrf` is a single-purpose function that composes with `require_csrf_token`. Tested in isolation; explicit caller change-out at the endpoint boundary.
+- `EMAIL_BACKEND` env field follows the same pattern as `JWT_SECRET`/`DATABASE_URL` — an env-only value that overrides YAML for environment-specific deploys. No new config-loading machinery required.
+- `vue-stack` consolidation removes a cross-chunk dependency surface; the comment block in `vite.config.js` documents the constraint for future maintainers.
+
+## Commit plan
+
+1. `fix(frontend): consolidate vue-stack chunk to avoid TDZ (#286)` — `frontend/vite.config.js`.
+2. `fix(deploy): close production deployment gaps (#287)` — `backend/Dockerfile.prod`, `docker/docker-compose.npm.yml`, `backend/config.yaml`, `backend/app/core/config.py`, `.env.docker.example`, `backend/scripts/create_admin_user.py`, plus tests.
+3. `fix(auth): return 401 for anonymous refresh probes (#288)` — `backend/app/auth/dependencies.py`, `backend/app/api/auth_endpoints.py`, `frontend/src/stores/authStore.js`, plus backend and frontend tests.
+
+PR title: `fix: post-deploy hardening (#286, #287, #288)`. PR body lists each commit's scope and links the three issues.
+
+## Risk register
+
+- **#286 chunk consolidation** could mask a future genuine cyclic-import bug by hiding it inside `vue-stack`. Mitigation: the inline comment names the failure mode; bundle analyzer remains in the build for size regressions.
+- **#287 `EMAIL_BACKEND` override** changes the precedence story for one config field. Mitigation: validator tests cover both YAML-only and env-override paths; the env override is documented in `.env.docker.example`.
+- **#288 frontend gate** assumes the `csrf_token` cookie is reliable proof of a session. Mitigation: the cookies are set atomically by `/auth/login` and cleared atomically by `/auth/logout`; if a future change ever splits them, the gate degrades to a single 401 round trip — same behaviour we have today, just one request later.
+
+## Out-of-scope follow-ups (not in this PR)
+
+- Document the production deploy upgrade path in `docs/deployment/` once these fixes land (separate docs PR).
+- Consider extracting an integration test that runs the production compose stack and asserts a clean boot — would have caught #287 pre-merge.

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -7,7 +7,7 @@ import {
   getDevQuickLoginDisabledMessage,
   isDevQuickLoginEnabled,
 } from '@/config/devAuth';
-import { clearTokens, getAccessToken, persistTokens } from '@/api/session';
+import { clearTokens, getAccessToken, getCsrfToken, persistTokens } from '@/api/session';
 
 export const useAuthStore = defineStore('auth', () => {
   // State
@@ -228,6 +228,14 @@ export const useAuthStore = defineStore('auth', () => {
             error: err.message,
           });
         }
+        return;
+      }
+
+      // No csrf_token cookie → no refresh session is possible (cookies are
+      // set together at /auth/login). Skip the probe to avoid an unnecessary
+      // round trip — and the misleading 403 — on every anonymous page load.
+      // See issue #288.
+      if (!getCsrfToken()) {
         return;
       }
 

--- a/frontend/tests/unit/components/common/ExternalLink.spec.js
+++ b/frontend/tests/unit/components/common/ExternalLink.spec.js
@@ -22,8 +22,11 @@ describe('ExternalLink', () => {
     });
     const icon = wrapper.find('[data-testid="external-link-icon"]');
     expect(icon.exists()).toBe(true);
-    // Vuetify VIcon maps slot content to a CSS class on the rendered <i>
-    expect(icon.classes()).toContain('mdi-open-in-new');
+    // Vuetify is not registered in this unit-test mount, so VIcon does
+    // not render to an <i class="mdi mdi-open-in-new">. Assert on the
+    // slot content passed to <v-icon> instead — that's what the
+    // Vuetify renderer will turn into the mdi class at runtime.
+    expect(icon.text()).toContain('mdi-open-in-new');
   });
 
   it('suppresses the icon when showIcon=false', () => {

--- a/frontend/tests/unit/stores/authStore.spec.js
+++ b/frontend/tests/unit/stores/authStore.spec.js
@@ -28,7 +28,14 @@ globalThis.window.logService = {
 describe('Auth Store', () => {
   const originalDev = import.meta.env.DEV;
   const originalFlag = import.meta.env.VITE_ENABLE_DEV_AUTH;
-  let _originalCookieDescriptor;
+  // `document.cookie` lives on Document.prototype, NOT the instance, so
+  // Object.getOwnPropertyDescriptor(document, 'cookie') returns undefined
+  // before any stub is installed. We capture *whether* an own descriptor
+  // existed so afterEach can either restore it or delete the stub we
+  // installed (which falls back to the prototype getter again).
+  // See PR #289 Copilot review.
+  let _hadOwnCookieDescriptor;
+  let _originalOwnCookieDescriptor;
 
   function setCookie(value) {
     Object.defineProperty(document, 'cookie', {
@@ -38,7 +45,8 @@ describe('Auth Store', () => {
   }
 
   beforeEach(() => {
-    _originalCookieDescriptor = Object.getOwnPropertyDescriptor(document, 'cookie');
+    _originalOwnCookieDescriptor = Object.getOwnPropertyDescriptor(document, 'cookie');
+    _hadOwnCookieDescriptor = _originalOwnCookieDescriptor !== undefined;
     setActivePinia(createPinia());
     clearTokens();
     vi.clearAllMocks();
@@ -49,8 +57,12 @@ describe('Auth Store', () => {
   });
 
   afterEach(() => {
-    if (_originalCookieDescriptor) {
-      Object.defineProperty(document, 'cookie', _originalCookieDescriptor);
+    if (_hadOwnCookieDescriptor) {
+      Object.defineProperty(document, 'cookie', _originalOwnCookieDescriptor);
+    } else {
+      // No own descriptor existed before — delete our stub so the
+      // prototype getter (Document.prototype.cookie) takes over again.
+      delete document.cookie;
     }
     clearTokens();
     vi.restoreAllMocks();

--- a/frontend/tests/unit/stores/authStore.spec.js
+++ b/frontend/tests/unit/stores/authStore.spec.js
@@ -28,8 +28,17 @@ globalThis.window.logService = {
 describe('Auth Store', () => {
   const originalDev = import.meta.env.DEV;
   const originalFlag = import.meta.env.VITE_ENABLE_DEV_AUTH;
+  let _originalCookieDescriptor;
+
+  function setCookie(value) {
+    Object.defineProperty(document, 'cookie', {
+      configurable: true,
+      get: () => value,
+    });
+  }
 
   beforeEach(() => {
+    _originalCookieDescriptor = Object.getOwnPropertyDescriptor(document, 'cookie');
     setActivePinia(createPinia());
     clearTokens();
     vi.clearAllMocks();
@@ -40,6 +49,9 @@ describe('Auth Store', () => {
   });
 
   afterEach(() => {
+    if (_originalCookieDescriptor) {
+      Object.defineProperty(document, 'cookie', _originalCookieDescriptor);
+    }
     clearTokens();
     vi.restoreAllMocks();
     import.meta.env.DEV = originalDev;
@@ -282,6 +294,9 @@ describe('Auth Store', () => {
     });
 
     it('attempts one refresh bootstrap before loading the current user', async () => {
+      // Simulate a returning user who has the csrf_token cookie set.
+      setCookie('csrf_token=bootstrap-csrf');
+
       const authStore = useAuthStore();
 
       apiClient.post.mockResolvedValueOnce({
@@ -306,6 +321,9 @@ describe('Auth Store', () => {
     });
 
     it('stays anonymous when refresh bootstrap fails', async () => {
+      // Simulate a user with a stale/expired session (csrf_token cookie present).
+      setCookie('csrf_token=stale-csrf');
+
       const authStore = useAuthStore();
 
       apiClient.post.mockRejectedValueOnce(new Error('Refresh failed'));
@@ -363,15 +381,51 @@ describe('Auth Store', () => {
     });
 
     it('initialize() logs anonymous bootstrap skip at debug', async () => {
+      // Need csrf_token cookie so the probe runs and we can observe the debug log.
+      setCookie('csrf_token=stale-csrf');
+
       apiClient.post.mockRejectedValueOnce(new Error('401 Unauthorized'));
       const store = useAuthStore();
       await store.initialize();
+
       // The "Failed to initialize user session" warn must not fire for anons.
       expect(logSpy.warn).not.toHaveBeenCalledWith(
         'Failed to initialize user session',
         expect.anything()
       );
       expect(logSpy.debug).toHaveBeenCalled();
+    });
+  });
+
+  describe('initialize() bootstrap probe gate (#288)', () => {
+    it('skips /auth/refresh when no csrf_token cookie is present', async () => {
+      setCookie('');
+      const authStore = useAuthStore();
+
+      await authStore.initialize();
+
+      expect(apiClient.post).not.toHaveBeenCalledWith(
+        '/auth/refresh',
+        expect.anything(),
+        expect.anything()
+      );
+      expect(authStore.hasInitialized).toBe(true);
+    });
+
+    it('calls /auth/refresh when csrf_token cookie is present', async () => {
+      setCookie('csrf_token=abc123');
+      apiClient.post.mockResolvedValueOnce({ data: { access_token: 'new-token' } });
+      apiClient.get.mockResolvedValueOnce({ data: { username: 'alice', role: 'curator' } });
+
+      const authStore = useAuthStore();
+      await authStore.initialize();
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/auth/refresh',
+        null,
+        expect.objectContaining({ withCredentials: true })
+      );
+      expect(authStore.accessToken).toBe('new-token');
     });
   });
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -119,17 +119,22 @@ export default defineConfig({
           // D3 modules - used for visualizations
           if (id.includes('d3-') || id.includes('/d3/')) return 'd3-modules';
 
-          // Vuetify data table components (heavy, often lazy loaded)
-          if (id.includes('vuetify/lib/components/VDataTable')) {
-            return 'vuetify-data';
+          // Consolidated Vue stack — keeps any cycle intra-chunk.
+          // Splitting vue/@vue/vue-router/pinia/vuetify across chunks has
+          // produced TDZ "Cannot access 'b' before initialization" errors
+          // when a downstream dependency from the catch-all `vendor` bucket
+          // re-imports vue while @vue/reactivity is still mid-evaluation.
+          // See vitejs/vite#9686, #22122, #12209.
+          if (
+            id.includes('node_modules/vue/') ||
+            id.includes('node_modules/@vue/') ||
+            id.includes('node_modules/vue-router') ||
+            id.includes('node_modules/pinia') ||
+            id.includes('node_modules/vuetify') ||
+            id.includes('node_modules/@vuetify')
+          ) {
+            return 'vue-stack';
           }
-          if (id.includes('vuetify')) return 'vuetify-core';
-
-          // Vue ecosystem - core framework
-          if (id.includes('vue-router') || id.includes('pinia')) {
-            return 'vue-core';
-          }
-          if (id.includes('/vue/') || id.includes('@vue/')) return 'vue-vendor';
 
           // Axios for API calls - frequently used
           if (id.includes('axios')) return 'axios';


### PR DESCRIPTION
## Summary

Three independent regressions surfaced by the `09789ff` production deploy. Five commits — one docs-spec, one docs-plan, three fix commits (one per issue), one chore lint fix.

- **#286** — Frontend SPA TDZ (`Cannot access 'b' before initialization`) caused by Rollup chunking the Vue ecosystem across cyclic chunks. Fixed by consolidating `vue / @vue / vue-router / pinia / vuetify / @vuetify` into a single `vue-stack` chunk in `frontend/vite.config.js`. Lazy-loaded `charts`, `ngl-viewer`, `d3-modules` chunks preserved.
- **#287** — Wave 5c fail-closed validators (commit `bde6704`) trip on five pre-existing deployment-plumbing gaps. Fixed: `Dockerfile.prod` now `COPY`s `config.yaml`; `docker/docker-compose.npm.yml` adds `env_file: ../.env.docker` on the api service; new `EMAIL_BACKEND` env override on `Settings` (keeps dev YAML default `console`, lets prod set `smtp` via `.env.docker`); `.env.docker.example` documents Wave 5c vars; `create_admin_user.py` no longer echoes the password on the existing-admin branch; `from_address` typo fixed.
- **#288** — `POST /auth/refresh` returns 403 (CSRF) for the anonymous bootstrap probe instead of 401, and the SPA makes the probe call unconditionally. Fixed with a layered backend dependency (`require_session_then_csrf`, used only on `/auth/refresh`) and a frontend `csrf_token`-cookie gate in `authStore.initialize()`. `/auth/logout` keeps the plain `require_csrf_token`.

Spec: `docs/superpowers/specs/2026-05-10-issues-286-287-288-design.md`
Plan: `docs/superpowers/plans/2026-05-10-issues-286-287-288.md`

Closes #286
Closes #287
Closes #288

## Test plan

- [ ] `cd backend && uv run pytest -q` — full backend suite passes (3 pre-existing failures on this Windows dev box: `test_no_mutations_against_comment_edits` cp1252 UnicodeDecodeError, `test_default_environment_is_production`, `test_settings_re_export_shares_identity_with_app_core_config`; verified present on `dc05865` parent)
- [ ] `cd backend && uv run pytest tests/test_auth_csrf.py tests/test_config_email_backend_override.py tests/test_create_admin_user_no_password_leak.py -v` — 18 new/extended tests pass
- [ ] `cd backend && uv run ruff check .` — clean
- [ ] `cd frontend && npm test` — pass (1 pre-existing unrelated failure in `ExternalLink` spec verified present on parent)
- [ ] `cd frontend && npm run lint:check` — 0 errors (24 pre-existing warnings)
- [ ] `cd frontend && npm run build` — `vue-stack-*.js` present, no `vue-vendor-*` / `vuetify-core-*` / `vuetify-data-*` / `vue-core-*` chunks
- [ ] Smoke-test in `npm run preview`: anonymous home-page load shows no `Cannot access 'b' before initialization` console error and no 403 on `/auth/refresh`
- [ ] After deploy: `git pull && make rebuild` boots cleanly on the production VPS without manual hotfix conflicts; production restart no longer prints admin password to logs on existing-admin path

## Out-of-scope follow-ups

- `docs/deployment/docker.md` should be updated to list `ENVIRONMENT`, `AUTH_COOKIE_SECURE`, `EMAIL_BACKEND`, `SMTP_*` as required production env vars (currently only documents `LOG_LEVEL_API` / `CORS_ORIGINS`). Separate docs PR.