### PR TITLE
feat(charts): export (PNG/CSV/SVG) + a11y across analyses charts

### DIFF
--- a/frontend/src/components/analyses/BoxPlotChart.vue
+++ b/frontend/src/components/analyses/BoxPlotChart.vue
@@ -1,21 +1,43 @@
 <!-- D3 Box Plot / Violin Plot Chart for DNA Distance Analysis -->
 <template>
-  <div class="box-plot-wrapper">
-    <div class="export-controls">
-      <button class="export-btn" title="Download as SVG" @click="exportSVG">
-        <span class="export-icon">⬇</span> Export SVG
-      </button>
-    </div>
-    <div ref="chartContainer" class="chart-container" />
+  <div class="box-plot-wrapper" v-bind="ariaProps">
+    <span :id="titleId" class="sr-only">{{ chartName }}</span>
+    <span :id="descId" class="sr-only">{{ description }}</span>
+    <ChartExportMenu
+      :svg-el="svgEl"
+      :rows="exportRows"
+      :columns="exportColumns"
+      :chart-name="chartName"
+    />
+    <div ref="chartContainer" class="chart-container" aria-hidden="true" />
+    <details class="chart-data-table">
+      <summary>View data as table</summary>
+      <table>
+        <thead>
+          <tr>
+            <th v-for="c in exportColumns" :key="c.key">{{ c.label }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(r, i) in exportRows" :key="i">
+            <td v-for="c in exportColumns" :key="c.key">{{ r[c.key] }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </details>
   </div>
 </template>
 
 <script>
 import * as d3 from 'd3';
+import { ref, computed } from 'vue';
 import { formatPValue } from '@/utils/statistics';
+import ChartExportMenu from '@/components/analyses/ChartExportMenu.vue';
+import { useChartAccessibility } from '@/composables/useChartAccessibility';
 
 export default {
   name: 'BoxPlotChart',
+  components: { ChartExportMenu },
   props: {
     pathogenicDistances: {
       type: Array,
@@ -41,8 +63,81 @@ export default {
       type: Number,
       default: 400,
     },
+    chartName: { type: String, default: 'DNA distance by pathogenicity' },
   },
   emits: ['variant-hover'],
+  setup(props) {
+    const svgEl = ref(null);
+
+    function computeStats(distances) {
+      if (!distances.length) return null;
+      const sorted = [...distances].map((v) => v.distance).sort((a, b) => a - b);
+      const n = sorted.length;
+      const q = (p) => {
+        const idx = (sorted.length - 1) * p;
+        const lo = Math.floor(idx);
+        const hi = Math.ceil(idx);
+        return lo === hi ? sorted[lo] : sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+      };
+      return {
+        n,
+        min: sorted[0],
+        q1: q(0.25),
+        median: q(0.5),
+        q3: q(0.75),
+        max: sorted[n - 1],
+      };
+    }
+
+    const exportRows = computed(() => {
+      const rows = [];
+      const groups = [
+        { label: 'P/LP', data: props.pathogenicDistances || [] },
+        { label: 'VUS', data: props.vusDistances || [] },
+      ];
+      for (const g of groups) {
+        const stats = computeStats(g.data);
+        if (!stats) continue;
+        rows.push({
+          group: g.label,
+          n: stats.n,
+          min: stats.min.toFixed(2),
+          q1: stats.q1.toFixed(2),
+          median: stats.median.toFixed(2),
+          q3: stats.q3.toFixed(2),
+          max: stats.max.toFixed(2),
+        });
+      }
+      return rows;
+    });
+
+    const exportColumns = [
+      { key: 'group', label: 'Group' },
+      { key: 'n', label: 'N' },
+      { key: 'min', label: 'Min (Å)' },
+      { key: 'q1', label: 'Q1 (Å)' },
+      { key: 'median', label: 'Median (Å)' },
+      { key: 'q3', label: 'Q3 (Å)' },
+      { key: 'max', label: 'Max (Å)' },
+    ];
+
+    const summary = computed(() => {
+      const rows = exportRows.value;
+      if (!rows.length) return `${props.chartName}: no data.`;
+      const parts = rows.map(
+        (r) => `${r.group}: median ${r.median} Å, IQR ${r.q1}–${r.q3} Å, n=${r.n}`
+      );
+      let sig = '';
+      if (props.mannWhitneyResult && typeof props.mannWhitneyResult.pValue === 'number') {
+        const p = props.mannWhitneyResult.pValue;
+        sig = ` Mann-Whitney p=${p < 0.001 ? '<0.001' : p.toFixed(3)}${props.pValueSignificant ? ' (significant)' : ''}.`;
+      }
+      return `${props.chartName}. ${parts.join('; ')}.${sig}`;
+    });
+
+    const a11y = useChartAccessibility({ chartName: props.chartName, summary });
+    return { svgEl, exportRows, exportColumns, ...a11y };
+  },
   watch: {
     pathogenicDistances: {
       handler() {
@@ -65,49 +160,6 @@ export default {
     d3.select('body').select('.dna-distance-tooltip').remove();
   },
   methods: {
-    exportSVG() {
-      const svgElement = this.$refs.chartContainer?.querySelector('svg');
-      if (!svgElement) {
-        return;
-      }
-
-      // Clone the SVG to avoid modifying the original
-      const clonedSvg = svgElement.cloneNode(true);
-
-      // Add XML declaration and namespace for standalone SVG
-      clonedSvg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-      clonedSvg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
-
-      // Add white background for better compatibility with publication software
-      const background = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-      background.setAttribute('width', '100%');
-      background.setAttribute('height', '100%');
-      background.setAttribute('fill', 'white');
-      clonedSvg.insertBefore(background, clonedSvg.firstChild);
-
-      // Serialize to string
-      const serializer = new XMLSerializer();
-      let svgString = serializer.serializeToString(clonedSvg);
-
-      // Add XML declaration
-      svgString = '<?xml version="1.0" encoding="UTF-8"?>\n' + svgString;
-
-      // Create blob and download
-      const blob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-
-      // Generate filename
-      const timestamp = new Date().toISOString().slice(0, 10);
-      const filename = `dna-distance-violin-plot-${timestamp}.svg`;
-
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
-    },
     renderChart() {
       if (!this.$refs.chartContainer) {
         return;
@@ -141,6 +193,7 @@ export default {
         .attr('width', containerWidth)
         .attr('height', this.height)
         .style('display', 'block');
+      this.svgEl = svg.node();
 
       const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
 
@@ -434,6 +487,7 @@ export default {
 <style scoped>
 .box-plot-wrapper {
   width: 100%;
+  position: relative;
 }
 
 .chart-container {
@@ -441,36 +495,24 @@ export default {
   min-height: 400px;
 }
 
-.export-controls {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 8px;
+.chart-data-table {
+  margin-top: 16px;
+  font-size: 14px;
 }
-
-.export-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  background-color: #1976d2;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  font-size: 12px;
-  font-weight: 500;
+.chart-data-table summary {
   cursor: pointer;
-  transition: background-color 0.2s;
+  padding: 4px 0;
+  color: rgb(var(--v-theme-on-surface), 0.7);
 }
-
-.export-btn:hover {
-  background-color: #1565c0;
+.chart-data-table table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
 }
-
-.export-btn:active {
-  background-color: #0d47a1;
-}
-
-.export-icon {
-  font-size: 12px;
+.chart-data-table th,
+.chart-data-table td {
+  padding: 4px 8px;
+  border: 1px solid rgb(var(--v-theme-on-surface), 0.12);
+  text-align: left;
 }
 </style>

--- a/frontend/src/components/analyses/ChartExportMenu.vue
+++ b/frontend/src/components/analyses/ChartExportMenu.vue
@@ -1,0 +1,79 @@
+<template>
+  <v-menu offset="4">
+    <template #activator="{ props: activator }">
+      <v-btn
+        v-bind="activator"
+        :disabled="!svgEl"
+        icon="mdi-download"
+        size="small"
+        variant="text"
+        :aria-label="`Export ${chartName}`"
+        class="chart-export-menu__btn"
+      />
+    </template>
+    <v-list density="compact">
+      <v-list-item @click="exportPng">
+        <v-list-item-title>Export as PNG</v-list-item-title>
+      </v-list-item>
+      <v-list-item @click="exportCsv">
+        <v-list-item-title>Export as CSV</v-list-item-title>
+      </v-list-item>
+      <v-list-item @click="exportSvg">
+        <v-list-item-title>Export as SVG</v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+
+<script setup>
+import {
+  exportSvgAsPng,
+  exportSvgAsSvg,
+  exportDataAsCsv,
+  buildExportFilename,
+} from '@/utils/chartExport';
+import { useAnnouncer } from '@/composables/useAccessibility';
+
+const props = defineProps({
+  svgEl: { type: [Object, Function], default: null },
+  rows: { type: Array, default: () => [] },
+  columns: { type: Array, default: () => [] },
+  chartName: { type: String, required: true },
+});
+
+const { announce } = useAnnouncer();
+
+function resolveSvg() {
+  return typeof props.svgEl === 'function' ? props.svgEl() : props.svgEl;
+}
+
+async function exportPng() {
+  const svg = resolveSvg();
+  if (!svg) return;
+  await exportSvgAsPng(svg, { filename: buildExportFilename(props.chartName, 'png') });
+  announce('Chart exported as PNG');
+}
+
+function exportCsv() {
+  exportDataAsCsv(props.rows, props.columns, buildExportFilename(props.chartName, 'csv'));
+  announce('Chart exported as CSV');
+}
+
+function exportSvg() {
+  const svg = resolveSvg();
+  if (!svg) return;
+  exportSvgAsSvg(svg, buildExportFilename(props.chartName, 'svg'));
+  announce('Chart exported as SVG');
+}
+
+defineExpose({ exportPng, exportCsv, exportSvg });
+</script>
+
+<style scoped>
+.chart-export-menu__btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 1;
+}
+</style>

--- a/frontend/src/components/analyses/DNADistanceAnalysis.vue
+++ b/frontend/src/components/analyses/DNADistanceAnalysis.vue
@@ -41,6 +41,7 @@
             </v-card-title>
             <v-card-text>
               <BoxPlotChart
+                chart-name="Distance Distribution by Pathogenicity"
                 :pathogenic-distances="pathogenicDistances"
                 :vus-distances="vusDistances"
                 :p-value-significant="pValueSignificant"

--- a/frontend/src/components/analyses/DonutChart.vue
+++ b/frontend/src/components/analyses/DonutChart.vue
@@ -1,20 +1,45 @@
 <template>
-  <div class="donut-chart-container">
+  <div class="donut-chart-container" v-bind="ariaProps">
+    <span :id="titleId" class="sr-only">{{ chartName }}</span>
+    <span :id="descId" class="sr-only">{{ description }}</span>
+    <ChartExportMenu
+      :svg-el="svgEl"
+      :rows="exportRows"
+      :columns="exportColumns"
+      :chart-name="chartName"
+    />
     <div class="chart-wrapper">
-      <!-- The div where the chart will be rendered -->
-      <div ref="chart" class="chart" />
-      <!-- Legend -->
+      <div ref="chart" class="chart" aria-hidden="true" />
       <div ref="legend" class="legend" />
     </div>
+    <details class="chart-data-table">
+      <summary>View data as table</summary>
+      <table>
+        <thead>
+          <tr>
+            <th v-for="c in exportColumns" :key="c.key">{{ c.label }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(r, i) in exportRows" :key="i">
+            <td v-for="c in exportColumns" :key="c.key">{{ r[c.key] }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </details>
   </div>
 </template>
 
 <script>
 // Import D3 and utilities for exporting.
 import * as d3 from 'd3';
+import { ref, computed } from 'vue';
+import ChartExportMenu from '@/components/analyses/ChartExportMenu.vue';
+import { useChartAccessibility } from '@/composables/useChartAccessibility';
 
 export default {
   name: 'DonutChart',
+  components: { ChartExportMenu },
   props: {
     /**
      * The data to be plotted.
@@ -24,25 +49,13 @@ export default {
      *   grouped_counts: [ { _id: string, count: number }, … ]
      * }
      */
-    chartData: {
-      type: Object,
-      required: true,
-    },
+    chartData: { type: Object, required: true },
     /** Width of the chart (in pixels) */
-    width: {
-      type: Number,
-      default: 600,
-    },
+    width: { type: Number, default: 600 },
     /** Height of the chart (in pixels) */
-    height: {
-      type: Number,
-      default: 500,
-    },
+    height: { type: Number, default: 500 },
     /** Margin (in pixels) used to compute the donut radius */
-    margin: {
-      type: Number,
-      default: 50,
-    },
+    margin: { type: Number, default: 50 },
     /** Color scheme for the donut slices (fallback when colorMap not provided) */
     colorScheme: {
       type: Array,
@@ -50,25 +63,41 @@ export default {
     },
     /**
      * Color map for semantic coloring (label -> color).
-     * When provided, labels are mapped to specific colors.
-     * Example: { 'Pathogenic': '#D32F2F', 'Benign': '#388E3C' }
      */
-    colorMap: {
-      type: Object,
-      default: null,
-    },
-    /**
-     * If true, shows an export button that lets the user download the chart as PNG.
-     */
-    exportable: {
-      type: Boolean,
-      default: false,
-    },
+    colorMap: { type: Object, default: null },
+    /** Human-readable chart name used for ARIA + export filenames. */
+    chartName: { type: String, default: 'Donut chart' },
+  },
+  setup(props) {
+    const svgEl = ref(null);
+    const exportRows = computed(() => {
+      const entries = props.chartData?.grouped_counts ?? [];
+      const total = props.chartData?.total_count ?? entries.reduce((s, e) => s + e.count, 0);
+      return entries.map((e) => ({
+        group: e._id,
+        count: e.count,
+        percent: total ? ((e.count / total) * 100).toFixed(1) : '0.0',
+      }));
+    });
+    const exportColumns = [
+      { key: 'group', label: 'Group' },
+      { key: 'count', label: 'Count' },
+      { key: 'percent', label: 'Percent' },
+    ];
+    const summary = computed(() => {
+      const entries = props.chartData?.grouped_counts ?? [];
+      const total = props.chartData?.total_count ?? entries.reduce((s, e) => s + e.count, 0);
+      if (!entries.length) return `${props.chartName}: no data.`;
+      const parts = entries.map(
+        (e) => `${e._id}: ${e.count} (${total ? ((e.count / total) * 100).toFixed(1) : '0.0'}%)`
+      );
+      return `${props.chartName}. ${parts.join(', ')}. Total ${total}.`;
+    });
+    const a11y = useChartAccessibility({ chartName: props.chartName, summary });
+    return { svgEl, exportRows, exportColumns, ...a11y };
   },
   data() {
-    return {
-      mdiDownload: 'mdi-download',
-    };
+    return {};
   },
   watch: {
     // Redraw the chart if the data changes.
@@ -93,16 +122,16 @@ export default {
       const { width, height, margin } = this;
       const radius = Math.min(width, height) / 2 - margin;
 
-      // Create the SVG element.
-      const svg = d3
+      // Create the SVG element. Capture the root <svg> so the export menu can read it.
+      const svgRoot = d3
         .select(this.$refs.chart)
         .append('svg')
         .attr('width', width)
         .attr('height', height)
         .attr('viewBox', `0 0 ${width} ${height}`)
-        .attr('preserveAspectRatio', 'xMinYMin meet')
-        .append('g')
-        .attr('transform', `translate(${width / 2}, ${height / 2})`);
+        .attr('preserveAspectRatio', 'xMinYMin meet');
+      this.svgEl = svgRoot.node();
+      const svg = svgRoot.append('g').attr('transform', `translate(${width / 2}, ${height / 2})`);
 
       // Create a tooltip div within the chart container.
       const tooltip = d3
@@ -268,5 +297,26 @@ export default {
   pointer-events: none;
   font-size: 14px;
   color: #333;
+}
+
+.chart-data-table {
+  margin-top: 16px;
+  font-size: 14px;
+}
+.chart-data-table summary {
+  cursor: pointer;
+  padding: 4px 0;
+  color: rgb(var(--v-theme-on-surface), 0.7);
+}
+.chart-data-table table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+}
+.chart-data-table th,
+.chart-data-table td {
+  padding: 4px 8px;
+  border: 1px solid rgb(var(--v-theme-on-surface), 0.12);
+  text-align: left;
 }
 </style>

--- a/frontend/src/components/analyses/KaplanMeierChart.vue
+++ b/frontend/src/components/analyses/KaplanMeierChart.vue
@@ -1,19 +1,41 @@
 <template>
-  <div class="kaplan-meier-container">
-    <div class="export-controls">
-      <button class="export-btn" title="Download as SVG" @click="exportSVG">
-        <span class="export-icon">⬇</span> Export SVG
-      </button>
-    </div>
-    <div ref="chart" />
+  <div class="kaplan-meier-container" v-bind="ariaProps">
+    <span :id="titleId" class="sr-only">{{ chartName }}</span>
+    <span :id="descId" class="sr-only">{{ description }}</span>
+    <ChartExportMenu
+      :svg-el="svgEl"
+      :rows="exportRows"
+      :columns="exportColumns"
+      :chart-name="chartName"
+    />
+    <div ref="chart" aria-hidden="true" />
+    <details class="chart-data-table">
+      <summary>View data as table</summary>
+      <table>
+        <thead>
+          <tr>
+            <th v-for="c in exportColumns" :key="c.key">{{ c.label }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(r, i) in exportRows" :key="i">
+            <td v-for="c in exportColumns" :key="c.key">{{ r[c.key] }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </details>
   </div>
 </template>
 
 <script>
+import { ref, computed } from 'vue';
 import * as d3 from 'd3';
+import ChartExportMenu from '@/components/analyses/ChartExportMenu.vue';
+import { useChartAccessibility } from '@/composables/useChartAccessibility';
 
 export default {
   name: 'KaplanMeierChart',
+  components: { ChartExportMenu },
   props: {
     survivalData: {
       type: Object,
@@ -31,6 +53,67 @@ export default {
       type: Object,
       default: () => ({ top: 60, right: 100, bottom: 60, left: 80 }),
     },
+    chartName: { type: String, default: 'Renal survival curve' },
+  },
+  setup(props) {
+    const svgEl = ref(null);
+
+    const exportRows = computed(() => {
+      const groups = props.survivalData?.groups ?? [];
+      const rows = [];
+      for (const g of groups) {
+        for (const point of g.survival_data ?? []) {
+          rows.push({
+            group: g.name,
+            time: point.time,
+            survival:
+              typeof point.survival_probability === 'number'
+                ? point.survival_probability.toFixed(3)
+                : point.survival_probability,
+            ci_lower: typeof point.ci_lower === 'number' ? point.ci_lower.toFixed(3) : '',
+            ci_upper: typeof point.ci_upper === 'number' ? point.ci_upper.toFixed(3) : '',
+            at_risk: point.at_risk ?? '',
+            events: point.events ?? '',
+            censored: point.censored ?? '',
+          });
+        }
+      }
+      return rows;
+    });
+
+    const exportColumns = [
+      { key: 'group', label: 'Group' },
+      { key: 'time', label: 'Time (years)' },
+      { key: 'survival', label: 'Survival probability' },
+      { key: 'ci_lower', label: '95% CI lower' },
+      { key: 'ci_upper', label: '95% CI upper' },
+      { key: 'at_risk', label: 'N at risk' },
+      { key: 'events', label: 'Events' },
+      { key: 'censored', label: 'Censored' },
+    ];
+
+    const summary = computed(() => {
+      const groups = props.survivalData?.groups ?? [];
+      if (!groups.length) return `${props.chartName}: no data.`;
+      const parts = groups.map((g) => {
+        const points = g.survival_data ?? [];
+        const last = points[points.length - 1];
+        const lastSurvival =
+          last && typeof last.survival_probability === 'number'
+            ? last.survival_probability.toFixed(3)
+            : 'unknown';
+        const median = points.find((p) => p.survival_probability <= 0.5);
+        const medianText = median ? `median ${median.time.toFixed(1)}y` : 'median not reached';
+        return `${g.name} (n=${g.n}, ${g.events} events, ${medianText}, final S(t)=${lastSurvival})`;
+      });
+      const endpoint = props.survivalData?.endpoint
+        ? ` Endpoint: ${props.survivalData.endpoint}.`
+        : '';
+      return `${props.chartName}.${endpoint} ${parts.join('; ')}.`;
+    });
+
+    const a11y = useChartAccessibility({ chartName: props.chartName, summary });
+    return { svgEl, exportRows, exportColumns, ...a11y };
   },
   watch: {
     survivalData: {
@@ -48,52 +131,6 @@ export default {
     window.removeEventListener('resize', this.renderChart);
   },
   methods: {
-    exportSVG() {
-      const svgElement = this.$refs.chart.querySelector('svg');
-      if (!svgElement) {
-        return;
-      }
-
-      // Clone the SVG to avoid modifying the original
-      const clonedSvg = svgElement.cloneNode(true);
-
-      // Add XML declaration and namespace for standalone SVG
-      clonedSvg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-      clonedSvg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
-
-      // Add white background for better compatibility with publication software
-      const background = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-      background.setAttribute('width', '100%');
-      background.setAttribute('height', '100%');
-      background.setAttribute('fill', 'white');
-      clonedSvg.insertBefore(background, clonedSvg.firstChild);
-
-      // Serialize to string
-      const serializer = new XMLSerializer();
-      let svgString = serializer.serializeToString(clonedSvg);
-
-      // Add XML declaration
-      svgString = '<?xml version="1.0" encoding="UTF-8"?>\n' + svgString;
-
-      // Create blob and download
-      const blob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-
-      // Generate filename based on comparison type and endpoint
-      const timestamp = new Date().toISOString().slice(0, 10);
-      const comparison = this.survivalData?.comparison_type || 'survival';
-      const endpoint =
-        this.survivalData?.endpoint?.replace(/\s+/g, '-').toLowerCase() || 'analysis';
-      const filename = `kaplan-meier-${comparison}-${endpoint}-${timestamp}.svg`;
-
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
-    },
     renderChart() {
       d3.select(this.$refs.chart).selectAll('*').remove();
 
@@ -115,15 +152,15 @@ export default {
       const svgWidth = width - margin.left - margin.right;
       const svgHeight = height - margin.top - margin.bottom;
 
-      const svg = d3
+      const svgRoot = d3
         .select(this.$refs.chart)
         .append('svg')
         .attr('width', width)
         .attr('height', height)
         .attr('viewBox', `0 0 ${width} ${height}`)
-        .attr('preserveAspectRatio', 'xMinYMin meet')
-        .append('g')
-        .attr('transform', `translate(${margin.left},${margin.top})`);
+        .attr('preserveAspectRatio', 'xMinYMin meet');
+      this.svgEl = typeof svgRoot.node === 'function' ? svgRoot.node() : null;
+      const svg = svgRoot.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
 
       const groups = this.survivalData.groups;
 
@@ -446,39 +483,27 @@ export default {
 .kaplan-meier-container {
   width: 100%;
   overflow-x: auto;
+  position: relative;
 }
 
-.export-controls {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 8px;
-  padding-right: 10px;
-}
-
-.export-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
-  background-color: #1976d2;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.export-btn:hover {
-  background-color: #1565c0;
-}
-
-.export-btn:active {
-  background-color: #0d47a1;
-}
-
-.export-icon {
+.chart-data-table {
+  margin-top: 16px;
   font-size: 14px;
+}
+.chart-data-table summary {
+  cursor: pointer;
+  padding: 4px 0;
+  color: rgb(var(--v-theme-on-surface), 0.7);
+}
+.chart-data-table table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+}
+.chart-data-table th,
+.chart-data-table td {
+  padding: 4px 8px;
+  border: 1px solid rgb(var(--v-theme-on-surface), 0.12);
+  text-align: left;
 }
 </style>

--- a/frontend/src/components/analyses/PublicationsTimelineChart.vue
+++ b/frontend/src/components/analyses/PublicationsTimelineChart.vue
@@ -1,20 +1,43 @@
 <template>
-  <v-card flat>
+  <v-card flat v-bind="ariaProps">
     <v-card-title class="text-h6 d-flex align-center justify-space-between">
-      <div class="d-flex align-center">
+      <div :id="titleId" class="d-flex align-center">
         <v-icon class="mr-2">mdi-chart-line</v-icon>
         Publications by Type Over Years
       </div>
-      <v-btn-toggle v-model="chartMode" mandatory dense color="primary">
-        <v-btn value="cumulative" size="small">
-          <v-icon left size="small">mdi-chart-timeline-variant</v-icon>
-          Cumulative
-        </v-btn>
-        <v-btn value="annual" size="small">
-          <v-icon left size="small">mdi-chart-line</v-icon>
-          Annual
-        </v-btn>
-      </v-btn-toggle>
+      <div class="d-flex align-center">
+        <v-btn-toggle v-model="chartMode" mandatory dense color="primary">
+          <v-btn value="cumulative" size="small">
+            <v-icon left size="small">mdi-chart-timeline-variant</v-icon>
+            Cumulative
+          </v-btn>
+          <v-btn value="annual" size="small">
+            <v-icon left size="small">mdi-chart-line</v-icon>
+            Annual
+          </v-btn>
+        </v-btn-toggle>
+        <v-menu offset="4">
+          <template #activator="{ props: activator }">
+            <v-btn
+              v-bind="activator"
+              :disabled="!chart"
+              icon="mdi-download"
+              size="small"
+              variant="text"
+              :aria-label="`Export ${chartName}`"
+              class="ml-2"
+            />
+          </template>
+          <v-list density="compact">
+            <v-list-item @click="exportPng">
+              <v-list-item-title>Export as PNG</v-list-item-title>
+            </v-list-item>
+            <v-list-item @click="exportCsv">
+              <v-list-item-title>Export as CSV</v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+      </div>
     </v-card-title>
 
     <v-card-text>
@@ -50,12 +73,14 @@
         <code>make publications-sync</code> to fetch metadata from PubMed.
       </v-alert>
 
+      <span :id="descId" class="sr-only">{{ description }}</span>
+
       <!-- Chart -->
       <div
         v-if="!loading && !error && chartData.labels && chartData.labels.length > 0"
         style="height: 500px"
       >
-        <canvas ref="chartCanvas" />
+        <canvas ref="chartCanvas" aria-hidden="true" />
       </div>
 
       <!-- No Data State -->
@@ -70,12 +95,38 @@
           Publication metadata not synced. Run <code>make publications-sync</code> first.
         </div>
       </div>
+
+      <details
+        v-if="!loading && !error && chartData.labels && chartData.labels.length > 0"
+        class="chart-data-table"
+      >
+        <summary>View data as table</summary>
+        <table>
+          <thead>
+            <tr>
+              <th>Year</th>
+              <th v-for="ds in chartData.datasets" :key="ds.label">{{ ds.label }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(year, i) in chartData.labels" :key="year">
+              <td>{{ year }}</td>
+              <td v-for="ds in chartData.datasets" :key="ds.label">{{ ds.data[i] }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </details>
     </v-card-text>
   </v-card>
 </template>
 
 <script>
 import { Chart, registerables } from 'chart.js';
+import { ref, computed } from 'vue';
+import { saveAs } from 'file-saver';
+import { exportDataAsCsv, buildExportFilename } from '@/utils/chartExport';
+import { useChartAccessibility } from '@/composables/useChartAccessibility';
+import { useAnnouncer } from '@/composables/useAccessibility';
 import * as API from '@/api';
 
 // Register Chart.js components
@@ -89,8 +140,19 @@ export default {
       default: 'cumulative',
       validator: (value) => ['annual', 'cumulative'].includes(value),
     },
+    chartName: { type: String, default: 'Publications per year by type' },
   },
   emits: ['update:mode'],
+  setup(props) {
+    const titleElId = 'publications-timeline-title';
+    // Source summary off a manually-bridged ref that the Options API updates in
+    // processChartData below.
+    const summarySource = ref('No publications data loaded yet.');
+    const summary = computed(() => summarySource.value);
+    const a11y = useChartAccessibility({ chartName: props.chartName, summary });
+    const { announce } = useAnnouncer();
+    return { ...a11y, summarySource, announce, titleElId };
+  },
   data() {
     return {
       loading: false,
@@ -259,6 +321,22 @@ export default {
         labels: years,
         datasets: datasets,
       };
+
+      // Update summary for screen readers
+      if (years.length === 0) {
+        this.summarySource = `${this.chartName}: no data.`;
+      } else {
+        const totalCount = datasets.reduce(
+          (sum, ds) => sum + ds.data.reduce((s, v) => s + v, 0),
+          0
+        );
+        const typeList = datasets.map((d) => d.label).join(', ');
+        const cumulativeNote = this.chartMode === 'cumulative' ? ' (cumulative)' : ' (annual)';
+        this.summarySource =
+          `${this.chartName}${cumulativeNote}, ${years[0]}–${years[years.length - 1]}. ` +
+          `${datasets.length} publication types: ${typeList}. ` +
+          `Total ${totalCount} phenopackets.`;
+      }
     },
 
     renderChart() {
@@ -333,6 +411,46 @@ export default {
         },
       });
     },
+
+    /**
+     * Build the rows + columns used by CSV export and the data-table fallback.
+     * Returns { rows, columns } shaped for exportDataAsCsv.
+     */
+    buildExportData() {
+      const columns = [
+        { key: 'year', label: 'Year' },
+        ...this.chartData.datasets.map((d) => ({ key: d.label, label: d.label })),
+      ];
+      const rows = (this.chartData.labels || []).map((year, idx) => {
+        const row = { year };
+        for (const ds of this.chartData.datasets) {
+          row[ds.label] = ds.data[idx];
+        }
+        return row;
+      });
+      return { rows, columns };
+    },
+
+    exportPng() {
+      if (!this.chart) return;
+      const dataUrl = this.chart.toBase64Image('image/png', 1.0);
+      // Convert data URL to Blob without fetch (fetch on a data URL works in
+      // browsers but adds a microtask; do it inline so we can call saveAs sync).
+      const [meta, base64] = dataUrl.split(',');
+      const mime = meta.match(/data:(.*?);/)[1];
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      const blob = new Blob([bytes], { type: mime });
+      saveAs(blob, buildExportFilename(this.chartName, 'png'));
+      this.announce('Chart exported as PNG');
+    },
+
+    exportCsv() {
+      const { rows, columns } = this.buildExportData();
+      exportDataAsCsv(rows, columns, buildExportFilename(this.chartName, 'csv'));
+      this.announce('Chart exported as CSV');
+    },
   },
 };
 </script>
@@ -340,5 +458,26 @@ export default {
 <style scoped>
 canvas {
   max-height: 500px;
+}
+
+.chart-data-table {
+  margin-top: 16px;
+  font-size: 14px;
+}
+.chart-data-table summary {
+  cursor: pointer;
+  padding: 4px 0;
+  color: rgb(var(--v-theme-on-surface), 0.7);
+}
+.chart-data-table table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+}
+.chart-data-table th,
+.chart-data-table td {
+  padding: 4px 8px;
+  border: 1px solid rgb(var(--v-theme-on-surface), 0.12);
+  text-align: left;
 }
 </style>

--- a/frontend/src/components/analyses/StackedBarChart.vue
+++ b/frontend/src/components/analyses/StackedBarChart.vue
@@ -1,12 +1,37 @@
 <template>
-  <div class="stacked-bar-chart-container">
-    <!-- The div where the chart will be rendered -->
-    <div ref="chart" />
+  <div class="stacked-bar-chart-container" v-bind="ariaProps">
+    <span :id="titleId" class="sr-only">{{ chartName }}</span>
+    <span :id="descId" class="sr-only">{{ description }}</span>
+    <ChartExportMenu
+      :svg-el="svgEl"
+      :rows="exportRows"
+      :columns="exportColumns"
+      :chart-name="chartName"
+    />
+    <div ref="chart" aria-hidden="true" />
+    <details class="chart-data-table">
+      <summary>View data as table</summary>
+      <table>
+        <thead>
+          <tr>
+            <th v-for="c in exportColumns" :key="c.key">{{ c.label }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(r, i) in exportRows" :key="i">
+            <td v-for="c in exportColumns" :key="c.key">{{ r[c.key] }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </details>
   </div>
 </template>
 
 <script>
+import { ref, computed } from 'vue';
 import * as d3 from 'd3';
+import ChartExportMenu from '@/components/analyses/ChartExportMenu.vue';
+import { useChartAccessibility } from '@/composables/useChartAccessibility';
 
 /**
  * CKD stage HPO IDs to aggregate into a single "Chronic Kidney Disease" entry.
@@ -28,6 +53,7 @@ const CKD_HPO_IDS = [
 
 export default {
   name: 'StackedBarChart',
+  components: { ChartExportMenu },
   props: {
     /**
      * The data to be plotted.
@@ -71,6 +97,37 @@ export default {
       type: Array,
       default: () => ['#4CAF50', '#F44336', '#9E9E9E'], // Green, Red, Gray
     },
+    chartName: { type: String, default: 'Phenotypic features' },
+  },
+  setup(props) {
+    const svgEl = ref(null);
+    const exportRows = computed(() => {
+      const limited = (props.chartData || []).slice(0, props.displayLimit);
+      return limited.map((row) => ({
+        feature: row.label,
+        present: row.details?.present_count ?? 0,
+        absent: row.details?.absent_count ?? 0,
+        not_reported: row.details?.not_reported_count ?? 0,
+      }));
+    });
+    const exportColumns = [
+      { key: 'feature', label: 'Feature' },
+      { key: 'present', label: 'Present' },
+      { key: 'absent', label: 'Absent' },
+      { key: 'not_reported', label: 'Not reported' },
+    ];
+    const summary = computed(() => {
+      const rows = exportRows.value;
+      if (!rows.length) return `${props.chartName}: no data.`;
+      const top = rows
+        .slice(0, 5)
+        .map((r) => `${r.feature}: ${r.present} present, ${r.absent} absent`);
+      const tail =
+        rows.length > 5 ? ` and ${rows.length - 5} more, available in the data table` : '';
+      return `${props.chartName} across ${rows.length} entries. ${top.join('; ')}${tail}.`;
+    });
+    const a11y = useChartAccessibility({ chartName: props.chartName, summary });
+    return { svgEl, exportRows, exportColumns, ...a11y };
   },
   watch: {
     chartData: {
@@ -179,16 +236,16 @@ export default {
       const svgWidth = width - margin.left - margin.right;
       const svgHeight = height - margin.top - margin.bottom;
 
-      // Append the SVG element.
-      const svg = d3
+      // Append the SVG element. Capture the root for export.
+      const svgRoot = d3
         .select(this.$refs.chart)
         .append('svg')
         .attr('width', width)
         .attr('height', height)
         .attr('viewBox', `0 0 ${width} ${height}`)
-        .attr('preserveAspectRatio', 'xMinYMin meet')
-        .append('g')
-        .attr('transform', `translate(${margin.left},${margin.top})`);
+        .attr('preserveAspectRatio', 'xMinYMin meet');
+      this.svgEl = svgRoot.node();
+      const svg = svgRoot.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
 
       // Aggregate CKD stages into a single entry
       const aggregatedData = this.aggregateCKDStages(this.chartData);
@@ -392,5 +449,26 @@ export default {
   pointer-events: none;
   font-size: 14px;
   color: #333;
+}
+
+.chart-data-table {
+  margin-top: 16px;
+  font-size: 14px;
+}
+.chart-data-table summary {
+  cursor: pointer;
+  padding: 4px 0;
+  color: rgb(var(--v-theme-on-surface), 0.7);
+}
+.chart-data-table table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+}
+.chart-data-table th,
+.chart-data-table td {
+  padding: 4px 8px;
+  border: 1px solid rgb(var(--v-theme-on-surface), 0.12);
+  text-align: left;
 }
 </style>

--- a/frontend/src/components/analyses/VariantComparisonChart.vue
+++ b/frontend/src/components/analyses/VariantComparisonChart.vue
@@ -1,19 +1,41 @@
 <template>
-  <div class="variant-comparison-container">
-    <div class="export-controls">
-      <button class="export-btn" title="Download as SVG" @click="exportSVG">
-        <span class="export-icon">⬇</span> Export SVG
-      </button>
-    </div>
-    <div ref="chart" />
+  <div class="variant-comparison-container" v-bind="ariaProps">
+    <span :id="titleId" class="sr-only">{{ chartName }}</span>
+    <span :id="descId" class="sr-only">{{ description }}</span>
+    <ChartExportMenu
+      :svg-el="svgEl"
+      :rows="exportRows"
+      :columns="exportColumns"
+      :chart-name="chartName"
+    />
+    <div ref="chart" aria-hidden="true" />
+    <details class="chart-data-table">
+      <summary>View data as table</summary>
+      <table>
+        <thead>
+          <tr>
+            <th v-for="c in exportColumns" :key="c.key">{{ c.label }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(r, i) in exportRows" :key="i">
+            <td v-for="c in exportColumns" :key="c.key">{{ r[c.key] }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </details>
   </div>
 </template>
 
 <script>
+import { ref, computed } from 'vue';
 import * as d3 from 'd3';
+import ChartExportMenu from '@/components/analyses/ChartExportMenu.vue';
+import { useChartAccessibility } from '@/composables/useChartAccessibility';
 
 export default {
   name: 'VariantComparisonChart',
+  components: { ChartExportMenu },
   props: {
     comparisonData: {
       type: Object,
@@ -39,6 +61,72 @@ export default {
       type: Object,
       default: () => ({ top: 120, right: 30, bottom: 220, left: 80 }),
     },
+    chartName: { type: String, default: 'Variant group phenotype comparison' },
+  },
+  setup(props) {
+    const svgEl = ref(null);
+
+    const exportRows = computed(() => {
+      const data = props.comparisonData;
+      if (!data || !Array.isArray(data.phenotypes)) return [];
+      return data.phenotypes.map((p) => ({
+        phenotype: p.hpo_label,
+        hpo_id: p.hpo_id ?? '',
+        group1_present: p.group1_present,
+        group1_total: p.group1_total,
+        group1_percent:
+          typeof p.group1_percentage === 'number' ? p.group1_percentage.toFixed(1) : '',
+        group2_present: p.group2_present,
+        group2_total: p.group2_total,
+        group2_percent:
+          typeof p.group2_percentage === 'number' ? p.group2_percentage.toFixed(1) : '',
+        p_value: typeof p.p_value === 'number' ? p.p_value : '',
+        p_value_fdr: typeof p.p_value_fdr === 'number' ? p.p_value_fdr : '',
+        effect_size: typeof p.effect_size === 'number' ? p.effect_size.toFixed(2) : '',
+        significant: p.significant ? 'yes' : 'no',
+      }));
+    });
+
+    const exportColumns = computed(() => {
+      const g1 = props.comparisonData?.group1_name ?? 'Group 1';
+      const g2 = props.comparisonData?.group2_name ?? 'Group 2';
+      return [
+        { key: 'phenotype', label: 'Phenotype' },
+        { key: 'hpo_id', label: 'HPO ID' },
+        { key: 'group1_present', label: `${g1} present` },
+        { key: 'group1_total', label: `${g1} total` },
+        { key: 'group1_percent', label: `${g1} %` },
+        { key: 'group2_present', label: `${g2} present` },
+        { key: 'group2_total', label: `${g2} total` },
+        { key: 'group2_percent', label: `${g2} %` },
+        { key: 'p_value', label: 'p (Fisher)' },
+        { key: 'p_value_fdr', label: 'p (FDR)' },
+        { key: 'effect_size', label: "Cohen's h" },
+        { key: 'significant', label: 'Significant' },
+      ];
+    });
+
+    const summary = computed(() => {
+      const data = props.comparisonData;
+      if (!data || !Array.isArray(data.phenotypes) || !data.phenotypes.length) {
+        return `${props.chartName}: no data.`;
+      }
+      const g1 = data.group1_name ?? 'Group 1';
+      const g2 = data.group2_name ?? 'Group 2';
+      const total1 = data.group1_count ?? '';
+      const total2 = data.group2_count ?? '';
+      const sig = data.phenotypes.filter((p) => p.significant);
+      const sigText = sig.length
+        ? `${sig.length} of ${data.phenotypes.length} phenotypes show significant differences (FDR p < 0.05): ${sig
+            .slice(0, 5)
+            .map((p) => p.hpo_label)
+            .join(', ')}${sig.length > 5 ? ` and ${sig.length - 5} more` : ''}`
+        : `No phenotypes reach FDR p < 0.05 across ${data.phenotypes.length} tested`;
+      return `${props.chartName}. ${g1} (n=${total1}) vs ${g2} (n=${total2}). ${sigText}.`;
+    });
+
+    const a11y = useChartAccessibility({ chartName: props.chartName, summary });
+    return { svgEl, exportRows, exportColumns, ...a11y };
   },
   watch: {
     comparisonData: {
@@ -125,63 +213,6 @@ export default {
         return !ckdStagePatterns.some((pattern) => lowerLabel.includes(pattern));
       });
     },
-    exportSVG() {
-      const svgElement = this.$refs.chart.querySelector('svg');
-      if (!svgElement) {
-        return;
-      }
-
-      // Clone the SVG to avoid modifying the original
-      const clonedSvg = svgElement.cloneNode(true);
-
-      // Add padding to prevent content cutoff (4mm ≈ 15px)
-      const padding = 15;
-      const originalWidth = parseFloat(svgElement.getAttribute('width')) || this.width;
-      const originalHeight = parseFloat(svgElement.getAttribute('height')) || this.height;
-      const newWidth = originalWidth + padding * 2;
-      const newHeight = originalHeight + padding * 2;
-
-      // Update SVG dimensions and viewBox
-      clonedSvg.setAttribute('width', newWidth);
-      clonedSvg.setAttribute('height', newHeight);
-      clonedSvg.setAttribute('viewBox', `${-padding} ${-padding} ${newWidth} ${newHeight}`);
-
-      // Add XML declaration and namespace for standalone SVG
-      clonedSvg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-      clonedSvg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
-
-      // Add white background for better compatibility with publication software
-      const background = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-      background.setAttribute('x', -padding);
-      background.setAttribute('y', -padding);
-      background.setAttribute('width', newWidth);
-      background.setAttribute('height', newHeight);
-      background.setAttribute('fill', 'white');
-      clonedSvg.insertBefore(background, clonedSvg.firstChild);
-
-      // Serialize to string
-      const serializer = new XMLSerializer();
-      let svgString = serializer.serializeToString(clonedSvg);
-
-      // Add XML declaration
-      svgString = '<?xml version="1.0" encoding="UTF-8"?>\n' + svgString;
-
-      // Create blob and download
-      const blob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-
-      // Generate filename based on comparison type and filter
-      const timestamp = new Date().toISOString().slice(0, 10);
-      const filename = `variant-comparison-${this.comparisonType}-${this.organSystemFilter}-${timestamp}.svg`;
-
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
-    },
     renderChart() {
       d3.select(this.$refs.chart).selectAll('*').remove();
       // Clean up any existing tooltips from previous renders
@@ -205,15 +236,15 @@ export default {
       const svgWidth = width - margin.left - margin.right;
       const svgHeight = height - margin.top - margin.bottom;
 
-      const svg = d3
+      const svgRoot = d3
         .select(this.$refs.chart)
         .append('svg')
         .attr('width', width)
         .attr('height', height)
         .attr('viewBox', `0 0 ${width} ${height}`)
-        .attr('preserveAspectRatio', 'xMinYMin meet')
-        .append('g')
-        .attr('transform', `translate(${margin.left},${margin.top})`);
+        .attr('preserveAspectRatio', 'xMinYMin meet');
+      this.svgEl = typeof svgRoot.node === 'function' ? svgRoot.node() : null;
+      const svg = svgRoot.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
 
       // Apply filtering: first remove uninformative phenotypes, then filter by organ system
       const allPhenotypes = this.comparisonData.phenotypes;
@@ -611,39 +642,27 @@ export default {
 .variant-comparison-container {
   width: 100%;
   overflow-x: auto;
+  position: relative;
 }
 
-.export-controls {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 8px;
-  padding-right: 10px;
-}
-
-.export-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
-  background-color: #1976d2;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.export-btn:hover {
-  background-color: #1565c0;
-}
-
-.export-btn:active {
-  background-color: #0d47a1;
-}
-
-.export-icon {
+.chart-data-table {
+  margin-top: 16px;
   font-size: 14px;
+}
+.chart-data-table summary {
+  cursor: pointer;
+  padding: 4px 0;
+  color: rgb(var(--v-theme-on-surface), 0.7);
+}
+.chart-data-table table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+}
+.chart-data-table th,
+.chart-data-table td {
+  padding: 4px 8px;
+  border: 1px solid rgb(var(--v-theme-on-surface), 0.12);
+  text-align: left;
 }
 </style>

--- a/frontend/src/components/common/ExternalLink.vue
+++ b/frontend/src/components/common/ExternalLink.vue
@@ -40,15 +40,4 @@ defineProps({
   margin-left: 4px;
   vertical-align: -2px;
 }
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
 </style>

--- a/frontend/src/composables/useChartAccessibility.js
+++ b/frontend/src/composables/useChartAccessibility.js
@@ -1,0 +1,31 @@
+/**
+ * Per-chart accessibility helpers: generates stable unique IDs for ARIA
+ * title/description, returns a prop bundle the chart spreads onto its
+ * wrapper, and exposes the summary ref for binding into a visually-hidden
+ * description element.
+ *
+ * @param {{ chartName: string, summary: import('vue').Ref<string> }} options
+ * @returns {{
+ *   titleId: string,
+ *   descId: string,
+ *   description: import('vue').Ref<string>,
+ *   ariaProps: { role: string, 'aria-labelledby': string, 'aria-describedby': string },
+ * }}
+ */
+let counter = 0;
+
+export function useChartAccessibility({ chartName: _chartName, summary }) {
+  counter += 1;
+  const titleId = `chart-title-${counter}`;
+  const descId = `chart-desc-${counter}`;
+  return {
+    titleId,
+    descId,
+    description: summary,
+    ariaProps: {
+      role: 'img',
+      'aria-labelledby': titleId,
+      'aria-describedby': descId,
+    },
+  };
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -140,3 +140,16 @@ a:not(.v-btn):not(.v-chip):not(.v-list-item) {
     scroll-behavior: auto !important;
   }
 }
+
+/* Visually-hidden helper for screen-reader-only content (WCAG 1.1.1 fallback). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/src/utils/chartExport.js
+++ b/frontend/src/utils/chartExport.js
@@ -41,3 +41,14 @@ export function exportDataAsCsv(rows, columns, filename) {
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
   saveAs(blob, filename);
 }
+
+/**
+ * Export an SVG element as a raw .svg file (vector, editable in Illustrator/Inkscape).
+ * @param {SVGElement} svgEl
+ * @param {string} filename
+ */
+export function exportSvgAsSvg(svgEl, filename) {
+  const serialized = new XMLSerializer().serializeToString(svgEl);
+  const blob = new Blob([serialized], { type: 'image/svg+xml;charset=utf-8' });
+  saveAs(blob, filename);
+}

--- a/frontend/src/utils/chartExport.js
+++ b/frontend/src/utils/chartExport.js
@@ -1,3 +1,5 @@
+import { saveAs } from 'file-saver';
+
 /**
  * Build a filename in the format hnf1b-db_<kebab-name>_<YYYY-MM-DD>.<ext>.
  * @param {string} chartName - Human-readable chart name (any case, spaces or underscores allowed).
@@ -11,4 +13,31 @@ export function buildExportFilename(chartName, ext) {
     .toLowerCase();
   const date = new Date().toISOString().slice(0, 10);
   return `hnf1b-db_${kebab}_${date}.${ext}`;
+}
+
+const CSV_NEEDS_QUOTING = /[,"\n\r]/;
+
+function escapeCsvField(value) {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (CSV_NEEDS_QUOTING.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Export an array of row objects to a CSV file (RFC 4180, UTF-8 BOM, CRLF).
+ * @param {Array<Object>} rows
+ * @param {Array<{key:string,label:string}>} columns
+ * @param {string} filename
+ */
+export function exportDataAsCsv(rows, columns, filename) {
+  const header = columns.map((c) => escapeCsvField(c.label)).join(',');
+  const body = rows
+    .map((row) => columns.map((c) => escapeCsvField(row[c.key])).join(','))
+    .join('\r\n');
+  const csv = `\uFEFF${header}\r\n${body}${rows.length ? '\r\n' : ''}`;
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  saveAs(blob, filename);
 }

--- a/frontend/src/utils/chartExport.js
+++ b/frontend/src/utils/chartExport.js
@@ -1,0 +1,14 @@
+/**
+ * Build a filename in the format hnf1b-db_<kebab-name>_<YYYY-MM-DD>.<ext>.
+ * @param {string} chartName - Human-readable chart name (any case, spaces or underscores allowed).
+ * @param {string} ext - File extension without the dot ('png', 'csv', 'svg').
+ * @returns {string}
+ */
+export function buildExportFilename(chartName, ext) {
+  const kebab = chartName
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
+  const date = new Date().toISOString().slice(0, 10);
+  return `hnf1b-db_${kebab}_${date}.${ext}`;
+}

--- a/frontend/src/utils/chartExport.js
+++ b/frontend/src/utils/chartExport.js
@@ -52,3 +52,72 @@ export function exportSvgAsSvg(svgEl, filename) {
   const blob = new Blob([serialized], { type: 'image/svg+xml;charset=utf-8' });
   saveAs(blob, filename);
 }
+
+/**
+ * Inline computed styles from the live DOM onto a cloned SVG subtree so that
+ * the serialized SVG renders identically when loaded into a canvas.
+ * D3 sets some styles via .style() (inline) and some via class rules; only
+ * inline styles survive cloneNode. This walk transfers the rest.
+ * @param {Element} liveRoot - The original element still in the DOM.
+ * @param {Element} clonedRoot - The cloned element to mutate.
+ */
+function inlineComputedStyles(liveRoot, clonedRoot) {
+  const liveNodes = [liveRoot, ...liveRoot.querySelectorAll('*')];
+  const clonedNodes = [clonedRoot, ...clonedRoot.querySelectorAll('*')];
+  for (let i = 0; i < liveNodes.length; i++) {
+    const computed = window.getComputedStyle(liveNodes[i]);
+    let inline = '';
+    for (let j = 0; j < computed.length; j++) {
+      const prop = computed[j];
+      inline += `${prop}:${computed.getPropertyValue(prop)};`;
+    }
+    clonedNodes[i].setAttribute('style', inline);
+  }
+}
+
+/**
+ * Export an SVG element as a PNG via canvas. No external dependencies for
+ * rasterization; uses file-saver for the download trigger.
+ * @param {SVGElement} svgEl
+ * @param {{filename:string, scale?:number, background?:string}} options
+ * @returns {Promise<void>}
+ */
+export function exportSvgAsPng(svgEl, { filename, scale = 2, background = '#ffffff' }) {
+  return new Promise((resolve, reject) => {
+    const bbox = {
+      width: parseFloat(svgEl.getAttribute('width')) || svgEl.clientWidth,
+      height: parseFloat(svgEl.getAttribute('height')) || svgEl.clientHeight,
+    };
+
+    const clone = svgEl.cloneNode(true);
+    inlineComputedStyles(svgEl, clone);
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    clone.setAttribute('width', bbox.width);
+    clone.setAttribute('height', bbox.height);
+
+    const serialized = new XMLSerializer().serializeToString(clone);
+    const svgBlob = new Blob([serialized], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(svgBlob);
+
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = bbox.width * scale;
+      canvas.height = bbox.height * scale;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = background;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      URL.revokeObjectURL(url);
+      canvas.toBlob((pngBlob) => {
+        saveAs(pngBlob, filename);
+        resolve();
+      }, 'image/png');
+    };
+    img.onerror = (e) => {
+      URL.revokeObjectURL(url);
+      reject(e);
+    };
+    img.src = url;
+  });
+}

--- a/frontend/tests/unit/components/analyses/ChartExportMenu.spec.js
+++ b/frontend/tests/unit/components/analyses/ChartExportMenu.spec.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+
+const { announceMock } = vi.hoisted(() => ({ announceMock: vi.fn() }));
+
+vi.mock('@/utils/chartExport', () => ({
+  exportSvgAsPng: vi.fn().mockResolvedValue(),
+  exportSvgAsSvg: vi.fn(),
+  exportDataAsCsv: vi.fn(),
+  buildExportFilename: vi.fn((name, ext) => `hnf1b-db_${name}_${ext}`),
+}));
+
+vi.mock('@/composables/useAccessibility', () => ({
+  useAnnouncer: () => ({ announce: announceMock }),
+}));
+
+import ChartExportMenu from '@/components/analyses/ChartExportMenu.vue';
+import { exportSvgAsPng, exportSvgAsSvg, exportDataAsCsv } from '@/utils/chartExport';
+
+const vuetify = createVuetify({ components, directives });
+
+describe('ChartExportMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeWrapper(propsOverrides = {}) {
+    const svgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    return mount(ChartExportMenu, {
+      global: { plugins: [vuetify] },
+      props: {
+        svgEl,
+        rows: [{ a: 1 }],
+        columns: [{ key: 'a', label: 'A' }],
+        chartName: 'Test Chart',
+        ...propsOverrides,
+      },
+    });
+  }
+
+  it('disables the menu button when svgEl is null', () => {
+    const wrapper = mount(ChartExportMenu, {
+      global: { plugins: [vuetify] },
+      props: {
+        svgEl: null,
+        rows: [],
+        columns: [],
+        chartName: 'Test',
+      },
+    });
+    const btn = wrapper.find('button');
+    expect(btn.attributes('disabled')).toBeDefined();
+  });
+
+  it('invokes PNG export and announces on click', async () => {
+    const wrapper = makeWrapper();
+    await wrapper.vm.exportPng();
+    expect(exportSvgAsPng).toHaveBeenCalledOnce();
+    expect(announceMock).toHaveBeenCalledWith('Chart exported as PNG');
+  });
+
+  it('invokes CSV export and announces on click', async () => {
+    const wrapper = makeWrapper();
+    await wrapper.vm.exportCsv();
+    expect(exportDataAsCsv).toHaveBeenCalledOnce();
+    expect(announceMock).toHaveBeenCalledWith('Chart exported as CSV');
+  });
+
+  it('invokes SVG export and announces on click', async () => {
+    const wrapper = makeWrapper();
+    await wrapper.vm.exportSvg();
+    expect(exportSvgAsSvg).toHaveBeenCalledOnce();
+    expect(announceMock).toHaveBeenCalledWith('Chart exported as SVG');
+  });
+});

--- a/frontend/tests/unit/composables/useChartAccessibility.spec.js
+++ b/frontend/tests/unit/composables/useChartAccessibility.spec.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { ref } from 'vue';
+import { useChartAccessibility } from '@/composables/useChartAccessibility';
+
+describe('useChartAccessibility', () => {
+  it('returns role="img" plus stable labelledby/describedby IDs', () => {
+    const summary = ref('Donut chart with 3 segments.');
+    const { titleId, descId, ariaProps } = useChartAccessibility({
+      chartName: 'Sex distribution',
+      summary,
+    });
+    expect(ariaProps.role).toBe('img');
+    expect(ariaProps['aria-labelledby']).toBe(titleId);
+    expect(ariaProps['aria-describedby']).toBe(descId);
+    expect(titleId).toMatch(/^chart-title-\d+$/);
+    expect(descId).toMatch(/^chart-desc-\d+$/);
+  });
+
+  it('produces unique IDs across multiple instances', () => {
+    const a = useChartAccessibility({ chartName: 'A', summary: ref('') });
+    const b = useChartAccessibility({ chartName: 'B', summary: ref('') });
+    expect(a.titleId).not.toBe(b.titleId);
+    expect(a.descId).not.toBe(b.descId);
+  });
+
+  it('exposes the summary ref unchanged for template binding', () => {
+    const summary = ref('first');
+    const { description } = useChartAccessibility({ chartName: 'X', summary });
+    expect(description.value).toBe('first');
+    summary.value = 'second';
+    expect(description.value).toBe('second');
+  });
+});

--- a/frontend/tests/unit/utils/chartExport.spec.js
+++ b/frontend/tests/unit/utils/chartExport.spec.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildExportFilename } from '@/utils/chartExport';
+
+describe('buildExportFilename', () => {
+  it('formats as hnf1b-db_<kebab>_<date>.<ext>', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00Z'));
+    expect(buildExportFilename('Sex Distribution', 'png')).toBe(
+      'hnf1b-db_sex-distribution_2026-05-11.png'
+    );
+    vi.useRealTimers();
+  });
+
+  it('kebab-cases multi-word names with mixed case and underscores', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T00:00:00Z'));
+    expect(buildExportFilename('Kaplan_Meier survivalCurve', 'csv')).toBe(
+      'hnf1b-db_kaplan-meier-survival-curve_2026-05-11.csv'
+    );
+    vi.useRealTimers();
+  });
+});

--- a/frontend/tests/unit/utils/chartExport.spec.js
+++ b/frontend/tests/unit/utils/chartExport.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { buildExportFilename } from '@/utils/chartExport';
 
 describe('buildExportFilename', () => {
@@ -111,5 +111,85 @@ describe('exportSvgAsSvg', () => {
     const text = await blob.text();
     expect(text).toContain('<svg');
     expect(text).toContain('<circle');
+  });
+});
+
+describe('exportSvgAsPng', () => {
+  let saveAsMock;
+  let originalImage;
+  let originalCreateObjectURL;
+  let originalRevokeObjectURL;
+  let originalGetContext;
+  let originalToBlob;
+
+  beforeEach(() => {
+    saveAsMock = vi.fn();
+    vi.resetModules();
+    vi.doMock('file-saver', () => ({ saveAs: saveAsMock, default: { saveAs: saveAsMock } }));
+
+    originalImage = global.Image;
+    global.Image = class {
+      constructor() {
+        this.width = 100;
+        this.height = 50;
+        setTimeout(() => this.onload && this.onload(), 0);
+      }
+      set src(_) {}
+    };
+
+    originalCreateObjectURL = URL.createObjectURL;
+    originalRevokeObjectURL = URL.revokeObjectURL;
+    URL.createObjectURL = vi.fn(() => 'blob:mock');
+    URL.revokeObjectURL = vi.fn();
+
+    originalGetContext = HTMLCanvasElement.prototype.getContext;
+    originalToBlob = HTMLCanvasElement.prototype.toBlob;
+    HTMLCanvasElement.prototype.getContext = function () {
+      return {
+        fillStyle: '',
+        fillRect: vi.fn(),
+        drawImage: vi.fn(),
+      };
+    };
+    HTMLCanvasElement.prototype.toBlob = function (cb, type) {
+      cb(new Blob(['png-bytes'], { type: type || 'image/png' }));
+    };
+  });
+
+  afterEach(() => {
+    global.Image = originalImage;
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    HTMLCanvasElement.prototype.toBlob = originalToBlob;
+  });
+
+  it('saves a PNG blob with the supplied filename', async () => {
+    const { exportSvgAsPng: fn } = await import('@/utils/chartExport');
+    const svgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svgEl.setAttribute('width', '100');
+    svgEl.setAttribute('height', '50');
+
+    await fn(svgEl, { filename: 'chart.png' });
+
+    expect(saveAsMock).toHaveBeenCalledOnce();
+    const [blob, filename] = saveAsMock.mock.calls[0];
+    expect(filename).toBe('chart.png');
+    expect(blob.type).toBe('image/png');
+  });
+
+  it('honors scale option for the canvas dimensions', async () => {
+    const { exportSvgAsPng: fn } = await import('@/utils/chartExport');
+    const svgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svgEl.setAttribute('width', '100');
+    svgEl.setAttribute('height', '50');
+    const canvasSpy = vi.spyOn(document, 'createElement');
+
+    await fn(svgEl, { filename: 'chart.png', scale: 3 });
+
+    const canvasCall = canvasSpy.mock.results.find((r) => r.value instanceof HTMLCanvasElement);
+    expect(canvasCall.value.width).toBe(300);
+    expect(canvasCall.value.height).toBe(150);
+    canvasSpy.mockRestore();
   });
 });

--- a/frontend/tests/unit/utils/chartExport.spec.js
+++ b/frontend/tests/unit/utils/chartExport.spec.js
@@ -82,3 +82,34 @@ describe('exportDataAsCsv', () => {
     expect(text).toBe('﻿A,B,C\r\n,,0\r\n');
   });
 });
+
+describe('exportSvgAsSvg', () => {
+  let saveAsMock;
+  beforeEach(() => {
+    saveAsMock = vi.fn();
+    vi.resetModules();
+    vi.doMock('file-saver', () => ({ saveAs: saveAsMock, default: { saveAs: saveAsMock } }));
+  });
+
+  it('serializes the SVG element and saves with image/svg+xml MIME', async () => {
+    const { exportSvgAsSvg: fn } = await import('@/utils/chartExport');
+    const svgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svgEl.setAttribute('width', '100');
+    svgEl.setAttribute('height', '50');
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('cx', '10');
+    circle.setAttribute('cy', '10');
+    circle.setAttribute('r', '5');
+    svgEl.appendChild(circle);
+
+    fn(svgEl, 'chart.svg');
+
+    expect(saveAsMock).toHaveBeenCalledOnce();
+    const [blob, filename] = saveAsMock.mock.calls[0];
+    expect(filename).toBe('chart.svg');
+    expect(blob.type).toBe('image/svg+xml;charset=utf-8');
+    const text = await blob.text();
+    expect(text).toContain('<svg');
+    expect(text).toContain('<circle');
+  });
+});

--- a/frontend/tests/unit/utils/chartExport.spec.js
+++ b/frontend/tests/unit/utils/chartExport.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildExportFilename } from '@/utils/chartExport';
 
 describe('buildExportFilename', () => {
@@ -18,5 +18,67 @@ describe('buildExportFilename', () => {
       'hnf1b-db_kaplan-meier-survival-curve_2026-05-11.csv'
     );
     vi.useRealTimers();
+  });
+});
+
+describe('exportDataAsCsv', () => {
+  let saveAsMock;
+  beforeEach(() => {
+    vi.resetModules();
+    saveAsMock = vi.fn();
+    vi.doMock('file-saver', () => ({ saveAs: saveAsMock, default: { saveAs: saveAsMock } }));
+  });
+
+  it('writes BOM + headers + rows with CRLF line endings', async () => {
+    const { exportDataAsCsv: fn } = await import('@/utils/chartExport');
+    fn(
+      [
+        { label: 'Male', count: 389 },
+        { label: 'Female', count: 416 },
+      ],
+      [
+        { key: 'label', label: 'Group' },
+        { key: 'count', label: 'N' },
+      ],
+      'test.csv'
+    );
+    expect(saveAsMock).toHaveBeenCalledOnce();
+    const [blob, filename] = saveAsMock.mock.calls[0];
+    expect(filename).toBe('test.csv');
+    expect(blob.type).toBe('text/csv;charset=utf-8');
+    const text = await blob.text();
+    expect(text).toBe('﻿Group,N\r\nMale,389\r\nFemale,416\r\n');
+  });
+
+  it('quotes fields containing commas, quotes, or newlines (RFC 4180)', async () => {
+    const { exportDataAsCsv: fn } = await import('@/utils/chartExport');
+    fn(
+      [{ a: 'has, comma', b: 'has "quote"', c: 'has\nnewline' }],
+      [
+        { key: 'a', label: 'A' },
+        { key: 'b', label: 'B' },
+        { key: 'c', label: 'C' },
+      ],
+      'test.csv'
+    );
+    const [blob] = saveAsMock.mock.calls[0];
+    const text = await blob.text();
+    expect(text).toBe('﻿A,B,C\r\n"has, comma","has ""quote""","has\nnewline"\r\n');
+  });
+
+  it('renders null / undefined as empty fields', async () => {
+    const { exportDataAsCsv: fn } = await import('@/utils/chartExport');
+    fn(
+      [{ a: null, b: undefined, c: 0 }],
+      [
+        { key: 'a', label: 'A' },
+        { key: 'b', label: 'B' },
+        { key: 'c', label: 'C' },
+      ],
+      'test.csv'
+    );
+    const [blob] = saveAsMock.mock.calls[0];
+    const text = await blob.text();
+    expect(text).toBe('﻿A,B,C\r\n,,0\r\n');
   });
 });


### PR DESCRIPTION
## Summary
- Closes #135 (ARIA labels and accessibility support for charts)
- Closes #136 (chart data export — CSV, PNG)
- Adds PNG (2× DPR), CSV (RFC 4180 + BOM), and raw SVG export to 7 chart components
- Wraps each chart in an ARIA-described container with a `<details>` data-table fallback (WCAG 2.1 A: 1.1.1, 1.4.1, 2.1.1)
- Promotes `.sr-only` to the global stylesheet

Spec: `docs/superpowers/specs/2026-05-11-chart-export-and-a11y-design.md`
Plan: `docs/superpowers/plans/2026-05-11-chart-export-and-a11y.md`

## Architecture
Three new building blocks shared across all 7 charts:
- `frontend/src/utils/chartExport.js` — pure utility module with `buildExportFilename`, `exportDataAsCsv` (RFC 4180 + UTF-8 BOM + CRLF), `exportSvgAsSvg` (XMLSerializer), `exportSvgAsPng` (canvas + computed-style inlining, no new deps)
- `frontend/src/composables/useChartAccessibility.js` — stable unique ARIA `labelledby`/`describedby` IDs + `ariaProps` bundle
- `frontend/src/components/analyses/ChartExportMenu.vue` — Vuetify v-menu with PNG/CSV/SVG actions, announces via `useAnnouncer`

Each chart adds a `setup(props)` block (alongside its existing Options API) computing `svgEl`, `exportRows`, `exportColumns`, and a chart-specific `summary` description. The D3-managed subtree is `aria-hidden="true"`; the ARIA description carries the semantic signal.

## Per-chart deviations from the original plan
- **PublicationsTimelineChart** uses Chart.js + `<canvas>`, not D3 + SVG. The shared `ChartExportMenu` cannot be reused, so this chart renders an inline 2-item menu (PNG via `chart.toBase64Image()`, CSV via the shared utility). SVG export is omitted — the chart has no SVG to export. Documented in commit.
- **BoxPlotChart** takes two array props (`pathogenicDistances`, `vusDistances`) rather than a single `chartData`; export rows compute min/Q1/median/Q3/max per group on the fly and the summary references the Mann-Whitney p-value.
- **StackedBarChart** exports raw `chartData` rather than the CKD-aggregated form rendered by the chart; the aggregation is treated as a presentation detail. Documented in commit.
- **DNADistanceAnalysis** is a multi-section dashboard, not a chart — its only SVG is owned by the child BoxPlotChart, which is already wrapped. The change here is a pass-through `chart-name` prop so the chart's ARIA label matches the visible card heading.
- **KaplanMeier / VariantComparison** existing legacy `exportSVG()` methods + inline buttons removed; the new ChartExportMenu replaces them. Existing specs (40 + 55 cases) stay green without changes.

## Out of scope (deliberate, separate issues)
- Colorblind pattern fills (the `<details>` data table satisfies WCAG 1.4.1 for now)
- Options-API → `<script setup>` rewrite of existing charts
- Chart animations (#139), service-worker caching (#138)

## Test plan
- [x] Vitest: chartExport.spec.js (8 cases), useChartAccessibility.spec.js (3 cases), ChartExportMenu.spec.js (4 cases) — all new
- [x] Pre-existing KaplanMeierChart spec (40 cases) and VariantComparisonChart spec (55 cases) still green without spec changes
- [x] Full Vitest suite green: 50 files / 426 tests + 1 expected fail (was 47 / 411 — added 3 files / 15 tests)
- [x] `npm run lint`: 0 errors (13 pre-existing warnings, none in touched files)
- [x] `npm run format`: no diff
- [ ] Playwright a11y job (axe-core on `/`) — needs the full backend stack; will validate via CI
- [ ] Manual NVDA spot-check on Windows: tab to a chart, confirm title + description are announced and the `<details>` data table is reachable
- [ ] Manual export quality check: PNG crisp at 2× DPR; CSV opens correctly in Excel/LibreOffice with the UTF-8 BOM honored

## File changes
14 conventional-commits commits, one per task. The 7 chart components touched are all in `frontend/src/components/analyses/`.