### PR TITLE
fix(security): allow Swagger/ReDoc CDN assets in CSP

### DIFF
--- a/backend/app/core/security_headers.py
+++ b/backend/app/core/security_headers.py
@@ -11,10 +11,16 @@ from starlette.responses import Response
 # CSP is intentionally permissive for now because the frontend uses
 # inline scripts and connects to multiple origins. Tighten this in a
 # future hardening pass (out of Wave 2 scope).
+#
+# https://cdn.jsdelivr.net is allowed in script-src/style-src because the
+# Swagger UI (/api/v2/docs) and ReDoc (/api/v2/redoc) pages FastAPI serves
+# load their JS/CSS bundles from that CDN. Without it the docs page renders
+# blank (the swagger-ui div never hydrates). The favicon is served from
+# https://fastapi.tiangolo.com and is already covered by img-src https:.
 DEFAULT_CSP = (
     "default-src 'self'; "
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
-    "style-src 'self' 'unsafe-inline'; "
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; "
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
     "img-src 'self' data: https:; "
     "connect-src 'self' https://rest.ensembl.org https://eutils.ncbi.nlm.nih.gov "
     "https://hpo.jax.org https://www.ebi.ac.uk; "


### PR DESCRIPTION
## Problem

`https://api.hnf1b.org/api/v2/docs` rendered as a **blank page**. DNS, the Strato subdomain, NPM proxy, and the API itself were all working fine (endpoint returns HTTP 200, `openapi.json` returns 200).

The real cause was the API's own **Content-Security-Policy**. FastAPI's Swagger UI (`/api/v2/docs`) and ReDoc (`/api/v2/redoc`) load their JS/CSS bundles from `https://cdn.jsdelivr.net`, but the CSP only allowed `'self'` for `script-src`/`style-src`:

```
script-src 'self' 'unsafe-inline' 'unsafe-eval';
style-src  'self' 'unsafe-inline';
```

The browser blocked `swagger-ui-bundle.js` and `swagger-ui.css`, so `<div id="swagger-ui">` never hydrated.

## Fix

Add `https://cdn.jsdelivr.net` to `script-src` and `style-src` in `backend/app/core/security_headers.py`. All other directives are unchanged. The docs favicon (`fastapi.tiangolo.com`) is already covered by `img-src https:`.

## Verification

Exercised the middleware end-to-end via `TestClient`: the emitted CSP now includes the CDN in both directives, with all existing directives (default-src, connect-src allowlist, frame-ancestors, etc.) intact.

## Note

This trusts jsdelivr to serve scripts (FastAPI's default docs behavior). A stricter alternative is to self-host the swagger-ui-dist assets and point `swagger_js_url`/`swagger_css_url` at `'self'` — happy to switch to that approach if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)