### PR TITLE
feat(mcp): serve streamable HTTP at root path

### DIFF
--- a/mcp/src/hnf1b_mcp/server.py
+++ b/mcp/src/hnf1b_mcp/server.py
@@ -225,6 +225,11 @@ def build_http_app(settings: Settings | None = None) -> Starlette:
     settings = settings or get_settings()
     mcp = build_app(settings)
     app = mcp.http_app(
+        # Mount the streamable-HTTP endpoint at the root so clients connect to
+        # the bare subdomain (https://mcp.hnf1b.org) instead of the redundant
+        # ".../mcp" suffix. The ``/health`` custom route still resolves because
+        # FastMCP registers custom routes ahead of the transport mount.
+        path="/",
         stateless_http=True,
         json_response=True,
         middleware=[
@@ -245,6 +250,9 @@ def main() -> None:
         transport="http",
         host=settings.host,
         port=settings.port,
+        # Serve the MCP endpoint at the root path (see build_http_app). This is
+        # the production entrypoint (console script ``hnf1b-mcp``).
+        path="/",
         stateless_http=True,
         json_response=True,
         middleware=[


### PR DESCRIPTION
## What

Mount the FastMCP streamable-HTTP endpoint at `/` instead of the default `/mcp`, so the Claude connector URL is the bare subdomain:

- before: `https://mcp.hnf1b.org/mcp`
- after: `https://mcp.hnf1b.org`

Changes `build_http_app()` (`http_app(path="/")`) and `main()` (`mcp.run(path="/")`, the prod `hnf1b-mcp` entrypoint).

## Safety

- `/health` still resolves — FastMCP registers custom routes ahead of the transport mount. Verified: `GET /health` → 200 **and** `POST /` (MCP initialize) → 200.
- Full MCP suite: **281 passed**.

## Follow-up (ops, not in this PR)

NPM proxy host for mcp.hnf1b.org will move the streaming directives (`proxy_buffering off`, long timeouts) from the `/mcp` location to the server level so they apply to `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)