### PR TITLE
feat(mcp): filter transparency + sort discoverability for search_variants

### DIFF
--- a/mcp/src/hnf1b_mcp/services/capabilities.py
+++ b/mcp/src/hnf1b_mcp/services/capabilities.py
@@ -15,6 +15,7 @@ from hnf1b_mcp.services.dataclass import DataClass
 from hnf1b_mcp.services.errors import ERROR_CODES
 from hnf1b_mcp.services.statistics import _VALID_METRICS
 from hnf1b_mcp.services.terms import _VALID_VOCABULARIES
+from hnf1b_mcp.services.variants import VARIANT_SORT_FIELDS
 
 _TOOLS: list[dict[str, str]] = [
     {
@@ -248,6 +249,17 @@ def _filterable_fields() -> dict[str, Any]:
             "query": {
                 "type": "string",
                 "hint": "free-text HGVS / coords / id",
+            },
+            "sort": {
+                # Derived from the tool's own sort map so the advertised
+                # vocabulary can never drift from what is actually honored.
+                "values": list(VARIANT_SORT_FIELDS),
+                "hint": (
+                    "prefix with '-' for descending; default '-carrier_count' "
+                    "(most common first), so the first row IS the top variant by "
+                    "carrier count. Echoed as applied_sort; carrier_count is on "
+                    "every row, so ties are visible without an extra call."
+                ),
             },
         },
         "hnf1b_resolve_terms": {

--- a/mcp/src/hnf1b_mcp/services/variants.py
+++ b/mcp/src/hnf1b_mcp/services/variants.py
@@ -34,16 +34,27 @@ _GENE_SYMBOL = "HNF1B"
 # backend does not support (e.g. ``label``, ``consequence``) are reported as
 # ignored in meta rather than silently dropped — an unknown sort key otherwise
 # falls back to the default order, looking like a no-op.
-_SORT_FIELD_TRANSLATION: dict[str, str] = {
+# Canonical, agent-facing sortable fields for variant search: the MCP-friendly
+# name -> the backend ORDER BY token it maps to. This is the single source of
+# truth; capabilities advertises exactly these keys (see capabilities.py) so the
+# documented sort vocabulary can never drift from what the tool actually honors.
+VARIANT_SORT_FIELDS: dict[str, str] = {
     "carrier_count": "individualCount",
     "classification": "classificationVerdict",
     "structural_type": "variant_type",
     "variant_id": "variant_id",
+    "simple_id": "simple_id",
     "transcript": "transcript",
     "protein": "protein",
     "hg38": "hg38",
-    "simple_id": "simple_id",
-    # accept backend tokens verbatim too
+}
+
+# The accepted translation set is the canonical fields plus the raw backend
+# tokens accepted verbatim (defensive: a caller that read a backend token
+# elsewhere still gets a correct sort). Built from VARIANT_SORT_FIELDS so the two
+# stay in lockstep.
+_SORT_FIELD_TRANSLATION: dict[str, str] = {
+    **VARIANT_SORT_FIELDS,
     "individualCount": "individualCount",
     "classificationVerdict": "classificationVerdict",
     "variant_type": "variant_type",
@@ -225,6 +236,12 @@ async def search_variants(
     this function forwards the filter and trusts the server's data and totals.
     When *consequence* is set, ``filtered_count`` (== ``total``) is included.
 
+    When any filter is active, the result's ``_meta`` carries a machine-readable
+    ``applied_filters`` dict (the exact predicates honored) and
+    ``filter_mode == "server"`` so a caller can programmatically confirm the
+    filter was applied server-side against the honest cross-page total — without
+    parsing prose. These fields surface in the wrapped ``meta`` block.
+
     Args:
         client: Authenticated :class:`ApiClient` instance.
         query: Free-text search query forwarded to the API.
@@ -331,21 +348,46 @@ async def search_variants(
         if symbols and symbols <= {_GENE_SYMBOL}:
             result["gene_symbol_all"] = _GENE_SYMBOL
 
-    # Make sort handling visible: echo the sort actually applied server-side and
-    # name any parameter that was requested but could not be honored. An LLM
-    # cannot self-correct on a silently-dropped argument.
+    # Make the server's filtering and sorting machine-readable so an agent never
+    # has to parse prose to learn what was applied. Every filter listed below is
+    # a real server-side query predicate evaluated against an honest
+    # meta.page.totalRecords (the consequence filter is applied pre-pagination by
+    # the all-variants endpoint), so filter_mode is "server": pagination totals
+    # and has_more stay trustworthy across pages. These two keys are emitted only
+    # when at least one filter is active — an unfiltered browse needs neither.
+    extra_meta: dict[str, Any] = {}
+    applied_filters: dict[str, Any] = {}
+    if query is not None:
+        applied_filters["query"] = query
+    if variant_type is not None:
+        applied_filters["variant_type"] = variant_type
+    if classification is not None:
+        applied_filters["classification"] = classification
+    if gene is not None:
+        applied_filters["gene"] = gene
+    if consequence is not None:
+        applied_filters["consequence"] = consequence
+    if domain is not None:
+        applied_filters["domain"] = domain
+    if applied_filters:
+        extra_meta["applied_filters"] = applied_filters
+        extra_meta["filter_mode"] = "server"
+
+    # Echo the sort actually applied server-side and name any parameter that was
+    # requested but could not be honored. An LLM cannot self-correct on a
+    # silently-dropped argument.
     if sort is not None:
-        sort_meta: dict[str, Any] = {
-            "applied_sort": backend_sort,
-            "ignored_params": ignored_sort,
-        }
+        extra_meta["applied_sort"] = backend_sort
+        extra_meta["ignored_params"] = ignored_sort
         if ignored_sort:
-            sort_meta["sort_note"] = (
+            extra_meta["sort_note"] = (
                 f"sort={sort!r} is not sortable server-side; default order"
                 " (carrier_count desc) was used. Sortable fields: "
                 f"{sorted(_SORT_FIELD_TRANSLATION)}"
             )
-        result["_meta"] = sort_meta
+
+    if extra_meta:
+        result["_meta"] = extra_meta
 
     return result
 

--- a/mcp/tests/test_capabilities.py
+++ b/mcp/tests/test_capabilities.py
@@ -41,7 +41,7 @@ def test_capabilities_filterable_fields_present():
     }
 
     sv = ff["hnf1b_search_variants"]
-    # Exactly the real filter params — no invented hgvs_c / acmg_class.
+    # Exactly the real filter/sort params — no invented hgvs_c / acmg_class.
     assert set(sv) == {
         "classification",
         "consequence",
@@ -49,7 +49,10 @@ def test_capabilities_filterable_fields_present():
         "domain",
         "gene",
         "query",
+        "sort",
     }
+    # sort defaults to most-common-first so "top variant" needs no extra call.
+    assert "carrier_count" in sv["sort"]["values"]
     assert sv["classification"]["values"] == list(VARIANT_CLASSIFICATION_VALUES)
     assert sv["consequence"]["values"] == list(MOLECULAR_CONSEQUENCE_VALUES)
     assert sv["variant_type"]["values"] == list(VARIANT_TYPE_VALUES)

--- a/mcp/tests/test_variants.py
+++ b/mcp/tests/test_variants.py
@@ -212,6 +212,54 @@ async def test_search_variants_passes_filters():
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_search_variants_echoes_applied_filters_and_server_mode():
+    """Active filters are echoed in _meta with filter_mode == 'server'.
+
+    An agent can then programmatically confirm which predicates were honored and
+    that they were applied server-side against an honest cross-page total — the
+    machine-readable replacement for parsing a prose filter note.
+    """
+    respx.get(f"{BASE}/phenopackets/aggregate/all-variants").mock(
+        return_value=httpx.Response(
+            200, json={"data": [], "meta": {"page": {"totalRecords": 88}}}
+        )
+    )
+    client = ApiClient(base_url=BASE)
+    result = await search_variants(
+        client,
+        consequence="Missense",
+        classification="PATHOGENIC",
+    )
+    await client.aclose()
+
+    assert result["_meta"]["filter_mode"] == "server"
+    assert result["_meta"]["applied_filters"] == {
+        "consequence": "Missense",
+        "classification": "PATHOGENIC",
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_variants_no_filter_omits_filter_meta():
+    """An unfiltered browse emits neither applied_filters nor filter_mode."""
+    respx.get(f"{BASE}/phenopackets/aggregate/all-variants").mock(
+        return_value=httpx.Response(
+            200, json={"data": [], "meta": {"page": {"totalRecords": 0}}}
+        )
+    )
+    client = ApiClient(base_url=BASE)
+    result = await search_variants(client)
+    await client.aclose()
+
+    # No filters and no sort -> no _meta channel at all.
+    meta = result.get("_meta", {})
+    assert "applied_filters" not in meta
+    assert "filter_mode" not in meta
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_search_variants_translates_and_echoes_sort():
     """A row-name sort key is translated to the backend token and echoed."""
     route = respx.get(f"{BASE}/phenopackets/aggregate/all-variants").mock(


### PR DESCRIPTION
## Context

An LLM consuming the HNF1B-db MCP scored `hnf1b_search_variants` 8/10, docking *correctness/trust* to 5 over four findings. Verifying against the **live branch code** (not the stale hosted server the reviewer actually hit) showed **3 of 4 already shipped in #319**:

| Finding | Status in current code |
|---|---|
| P0 — consequence filter server-side, honest total | **Done.** `consequence=Missense&page[size]=3` → `totalRecords: 88` (cross-page-honest), 3 Missense rows. The `consequence_filter_note` prose the reviewer quoted no longer exists. |
| P1 — sort by carrier_count | **Done.** `sort=-carrier_count` works and is the default order; `carrier_count` on every row; `applied_sort` echoed. |
| P2 — ties visible | **Mitigated.** carrier_count on every row + echoed order ⇒ ties are directly observable. |
| P3 — machine-readable applied-filter echo | **This PR.** |

## Changes

- **`search_variants` filter transparency:** when any filter is active, `_meta` now carries `applied_filters` (the exact predicates honored) and `filter_mode: "server"`. Agents can programmatically confirm filtering happened server-side against the honest total — the deterministic replacement for parsing a prose note. Omitted on unfiltered browses.
- **Sort discoverability:** `get_capabilities` now advertises the `sort` field for `search_variants` (default `-carrier_count`, most-common-first). The reviewer didn't know sort existed because capabilities never listed it.
- **Single source of truth:** sort vocabulary factored into `VARIANT_SORT_FIELDS`; capabilities derives its advertised values from it, so the documented vocabulary can't drift from what the tool honors (no hand-duplicated list).

## Verification

- `make -C mcp check` green — 308 passed, 10 live deselected.
- New tests: `applied_filters`/`filter_mode` present on filtered calls, absent on unfiltered; capabilities `sort` present and carrier_count-derived.
- Live-verified against the local Docker stack (rebuilt MCP container): filtered call returns `filter_mode: server` + `applied_filters: {consequence: Missense}` with `total: 88`; unfiltered call omits both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)