### PR TITLE
fix(backend): correct curated HPO labels to authoritative ontology + drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,20 @@ jobs:
         ADMIN_PASSWORD: test-admin-password-ci-2026
       run: |
         cd backend
-        uv run pytest -m "not benchmark" --cov=app --cov=migration --cov-report=xml --cov-report=term-missing
+        uv run pytest -m "not benchmark and not network" --cov=app --cov=migration --cov-report=xml --cov-report=term-missing
+
+    - name: Validate curated HPO labels against live ontology (network)
+      # Guard against the hpo_terms_lookup labels drifting from the authoritative
+      # HPO ontology (the root cause of the HP:0033133 opposite-meaning error).
+      # Transient API outages skip rather than fail; only a real mismatch is red.
+      env:
+        ENVIRONMENT: development
+        DATABASE_URL: postgresql+asyncpg://hnf1b_user:hnf1b_pass@localhost:5432/hnf1b_test
+        JWT_SECRET: test-secret-key-for-ci
+        ADMIN_PASSWORD: test-admin-password-ci-2026
+      run: |
+        cd backend
+        uv run pytest -m network -v
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v6

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -28,8 +28,11 @@ check-env:  ## Verify virtual environment integrity
 	@echo "✅ Dependencies OK"
 	@echo "✅ Environment is healthy"
 
-test: check-env  ## Run tests (excluding benchmarks)
-	uv run pytest -m "not benchmark"
+test: check-env  ## Run tests (excluding benchmarks and live-network guards)
+	uv run pytest -m "not benchmark and not network"
+
+test-network: check-env  ## Run live-network guard tests (hits external APIs, e.g. HPO ontology)
+	uv run pytest -m network -v
 
 test-all: check-env  ## Run all tests including benchmarks
 	uv run pytest

--- a/backend/alembic/versions/d4e9c1a2b3f5_fix_curated_hpo_labels_to_authoritative.py
+++ b/backend/alembic/versions/d4e9c1a2b3f5_fix_curated_hpo_labels_to_authoritative.py
@@ -1,0 +1,100 @@
+"""fix_curated_hpo_labels_to_authoritative
+
+Revision ID: d4e9c1a2b3f5
+Revises: c8d2a3f1e0b5
+Create Date: 2026-05-29 00:00:00.000000
+
+Corrects five curated HPO labels in ``hpo_terms_lookup`` that were hand-typed in
+migration ``0bd1567a483c`` and never validated against the ontology. Four had
+drifted to older/looser names; HP:0033133 was recorded with the clinically
+OPPOSITE finding ("Renal cortical hyperechogenicity" / "Increased echogenecity"
+instead of "Renal cortical hypoechogeneity"), which could reach cited output.
+
+Values below are the authoritative HPO term names (HPO API at ontology.jax.org,
+cross-checked against EBI OLS4) as of 2026-05-29. This migration only rewrites
+data — no schema change. A network-gated guard test
+(``tests/test_hpo_label_integrity.py``, marker ``network``) re-validates every
+curated label against the live ontology so drift can no longer slip in silently.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e9c1a2b3f5"
+down_revision: Union[str, Sequence[str], None] = "c8d2a3f1e0b5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# (hpo_id, authoritative label) — the corrected value each row must hold.
+_LABEL_FIXES: list[tuple[str, str]] = [
+    ("HP:0000708", "Atypical behavior"),
+    ("HP:0002910", "Elevated circulating hepatic transaminase concentration"),
+    ("HP:0012443", "Abnormal brain morphology"),
+    ("HP:0012622", "Chronic kidney disease"),
+    ("HP:0033133", "Renal cortical hypoechogeneity"),
+]
+
+# The pre-fix labels, used to restore state on downgrade.
+_LABEL_ROLLBACK: list[tuple[str, str]] = [
+    ("HP:0000708", "Behavioral abnormality"),
+    ("HP:0002910", "Elevated hepatic transaminase"),
+    ("HP:0012443", "Abnormality of brain morphology"),
+    ("HP:0012622", "chronic kidney disease, not specified"),
+    ("HP:0033133", "Renal cortical hyperechogenicity"),
+]
+
+_SET_LABEL = sa.text(
+    "UPDATE hpo_terms_lookup SET label = :label WHERE hpo_id = :hpo_id"
+)
+
+
+def _apply_labels(pairs: list[tuple[str, str]]) -> None:
+    """Set ``label`` for each (hpo_id, label) pair via a parameterized UPDATE."""
+    bind = op.get_bind()
+    for hpo_id, label in pairs:
+        bind.execute(_SET_LABEL, {"label": label, "hpo_id": hpo_id})
+
+
+def upgrade() -> None:
+    """Correct the five drifted/incorrect curated HPO labels.
+
+    Rewrites the five labels to HPO-authoritative values, and additionally
+    corrects HP:0033133's category, description, and synonyms (they encoded the
+    opposite, "increased-echogenicity" meaning).
+    """
+    _apply_labels(_LABEL_FIXES)
+
+    # HP:0033133's category/description/synonyms described the opposite finding.
+    op.get_bind().execute(
+        sa.text(
+            """
+            UPDATE hpo_terms_lookup
+            SET category = 'Hypoechogenicity',
+                description = 'Decreased echogenicity of the kidney cortex.',
+                synonyms = 'Hypoechogenic renal cortex'
+            WHERE hpo_id = 'HP:0033133'
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Restore the pre-fix (incorrect) labels and HP:0033133 metadata."""
+    _apply_labels(_LABEL_ROLLBACK)
+
+    op.get_bind().execute(
+        sa.text(
+            """
+            UPDATE hpo_terms_lookup
+            SET category = 'Hyperechogenicity',
+                description = 'Increased echogenecity of the kidney cortex.',
+                synonyms = 'No synonyms found for this term.'
+            WHERE hpo_id = 'HP:0033133'
+            """
+        )
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -171,7 +171,7 @@ class HPOTermsConfig(BaseModel):
         "HP:0000107",  # Renal cyst
         "HP:0000122",  # Unilateral renal agenesis
         "HP:0012210",  # Abnormal renal morphology
-        "HP:0033133",  # Renal cortical hyperechogenicity
+        "HP:0033133",  # Renal cortical hypoechogeneity
         "HP:0000108",  # Multiple glomerular cysts
         "HP:0001970",  # Oligomeganephronia
     ]

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -5,6 +5,7 @@ asyncio_mode = auto
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     benchmark: marks tests as benchmarks (deselect with '-m "not benchmark"')
+    network: marks tests that hit live external APIs (run with '-m network'; deselected by default)
 
 # Filter known harmless warnings
 filterwarnings =

--- a/backend/tests/test_hpo_label_integrity.py
+++ b/backend/tests/test_hpo_label_integrity.py
@@ -1,0 +1,65 @@
+"""Guard: every curated HPO label matches the authoritative ontology.
+
+The ``hpo_terms_lookup`` table is seeded by Alembic migrations with hand-authored
+labels. Hand-authoring drifts: labels fall behind ontology renames and, in one
+case, encoded the clinically opposite finding (HP:0033133). This test re-fetches
+the authoritative HPO term name from the live HPO API for every ``HP:`` row and
+fails on any mismatch, so drift can never reach cited output unnoticed again.
+
+It is marked ``network`` and excluded from the default unit-test run; CI invokes
+it in a dedicated step (``pytest -m network``). Transient API/network failures
+``skip`` rather than fail — only a definitive label mismatch turns the build red.
+Non-HPO identifiers (e.g. ``ORPHA:*``) are skipped: they are not HPO terms.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from sqlalchemy import text
+
+HPO_API = "https://ontology.jax.org/api/hp/terms"
+
+pytestmark = pytest.mark.network
+
+
+async def _authoritative_label(client: httpx.AsyncClient, hpo_id: str) -> str | None:
+    """Return the current HPO term name, or None on any transient API failure."""
+    try:
+        resp = await client.get(f"{HPO_API}/{hpo_id}", timeout=20)
+    except (httpx.HTTPError, httpx.TimeoutException):
+        return None
+    if resp.status_code != 200:
+        return None
+    return resp.json().get("name")
+
+
+@pytest.mark.asyncio
+async def test_curated_hpo_labels_match_authoritative_ontology(db_session):
+    """Each curated HP:* label equals the authoritative HPO term name."""
+    rows = (
+        await db_session.execute(
+            text("SELECT hpo_id, label FROM hpo_terms_lookup WHERE hpo_id LIKE 'HP:%'")
+        )
+    ).all()
+    assert rows, "hpo_terms_lookup has no HP:* rows — is the table seeded?"
+
+    mismatches: list[str] = []
+    checked = 0
+    async with httpx.AsyncClient() as client:
+        for hpo_id, our_label in rows:
+            official = await _authoritative_label(client, hpo_id)
+            if official is None:
+                continue  # transient/unavailable — do not fail the build
+            checked += 1
+            if official != our_label:
+                mismatches.append(
+                    f"{hpo_id}: stored {our_label!r} != authoritative {official!r}"
+                )
+
+    if checked == 0:
+        pytest.skip("HPO API unreachable for all terms; skipping integrity check")
+
+    assert not mismatches, (
+        "Curated HPO labels disagree with the ontology:\n" + "\n".join(mismatches)
+    )

--- a/backend/tests/test_hpo_label_integrity.py
+++ b/backend/tests/test_hpo_label_integrity.py
@@ -36,13 +36,25 @@ async def _authoritative_label(client: httpx.AsyncClient, hpo_id: str) -> str | 
 
 @pytest.mark.asyncio
 async def test_curated_hpo_labels_match_authoritative_ontology(db_session):
-    """Each curated HP:* label equals the authoritative HPO term name."""
+    """Each curated HP:* label equals the authoritative HPO term name.
+
+    Scoped to ``recommendation IS NOT NULL`` so only the *canonical curated seed*
+    rows are validated. Every seeded row carries the full phenotype metadata
+    (category/recommendation/group); bare ``(hpo_id, label, phenopacket_count)``
+    rows inserted by other tests' fixtures (e.g. test_ontology_autocomplete) have
+    those columns NULL. The shared CI test database exempts this static lookup
+    table from inter-test truncation, so without this scope a leaked fixture row
+    would make the guard fail on synthetic data instead of the real seed.
+    """
     rows = (
         await db_session.execute(
-            text("SELECT hpo_id, label FROM hpo_terms_lookup WHERE hpo_id LIKE 'HP:%'")
+            text(
+                "SELECT hpo_id, label FROM hpo_terms_lookup "
+                "WHERE hpo_id LIKE 'HP:%' AND recommendation IS NOT NULL"
+            )
         )
     ).all()
-    assert rows, "hpo_terms_lookup has no HP:* rows — is the table seeded?"
+    assert rows, "hpo_terms_lookup has no curated HP:* rows — is the table seeded?"
 
     mismatches: list[str] = []
     checked = 0


### PR DESCRIPTION
## Why

The curated `hpo_terms_lookup` table (HNF1B phenotype categories, read by the MCP `summary`/`by_feature` stats and the frontend phenotype grouping) had **5 of 36 labels wrong or stale**. They were hand-typed in migration `0bd1567a483c` and never validated against the HPO ontology.

The backend *has* an HPO/OLS API client (`OntologyService` → HPO API / EBI OLS4 / Monarch), but the seed bypasses it — so hand-entry errors went uncaught, including a clinically **opposite** finding:

| HPO ID | Stored (wrong/stale) | Authoritative HPO |
|---|---|---|
| HP:0033133 | Renal cortical **hyper**echogenicity *(opposite!)* | Renal cortical **hypo**echogeneity |
| HP:0000708 | Behavioral abnormality | Atypical behavior |
| HP:0002910 | Elevated hepatic transaminase | Elevated circulating hepatic transaminase concentration |
| HP:0012443 | Abnormality of brain morphology | Abnormal brain morphology |
| HP:0012622 | chronic kidney disease, not specified | Chronic kidney disease |

## What

- **Migration `d4e9c1a2b3f5`** rewrites the 5 labels to HPO-authoritative values (HPO API, cross-checked vs OLS4) and fixes HP:0033133's `category`/`description`/`synonyms` (they encoded the increased-echogenicity meaning). Data-only, offline, deterministic — no network at migration time.
- **Network-gated drift guard** (`tests/test_hpo_label_integrity.py`, marker `network`): re-validates *every* curated HP:* label against the live ontology so drift can never silently reach cited output again. Skips on API outage; only a real mismatch is red. Runs in a dedicated CI step (`pytest -m network`); the default run excludes it (`pytest.ini` marker + Makefile/CI kept in lockstep).
- Fixed the stale `hyperechogenicity` comment in `config.py`.

## Verification

- Applied to the live DB; read-only re-check: **35/35 HP labels match, 0 mismatches** (1 ORPHA term correctly skipped — not an HPO term).
- `ruff` + `mypy` clean; marker deselected by default, selected via `-m network`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)