### PR TITLE
fix(mcp): contract-fidelity + input-validation fixes from senior tester report

### DIFF
--- a/mcp/src/hnf1b_mcp/server.py
+++ b/mcp/src/hnf1b_mcp/server.py
@@ -126,7 +126,11 @@ class RateLimitMiddleware(FastMCPMiddleware):
                 },
                 "is_error": True,
             }
-            return ToolResult(content=error_payload)
+            # Return the envelope as STRUCTURED output: the tools declare an
+            # output schema, so a result that carries only unstructured content
+            # is rejected by FastMCP ("outputSchema defined but no structured
+            # output returned"). structured_content makes it a clean tool result.
+            return ToolResult(structured_content=error_payload)
         return await call_next(context)
 
 
@@ -217,7 +221,12 @@ class ErrorEnvelopeMiddleware(FastMCPMiddleware):
             return await call_next(context)
         except ValidationError as exc:
             envelope = _validation_error_envelope(exc, context.message.name)
-            return ToolResult(content=envelope)
+            # Must be structured_content (not content): the tools declare an
+            # output schema, so an envelope returned as bare content fails
+            # FastMCP output validation and surfaces the opaque "outputSchema
+            # defined but no structured output returned" string instead of the
+            # actionable invalid_input envelope (this is the bug this maps away).
+            return ToolResult(structured_content=envelope)
 
 
 class OriginValidationMiddleware(BaseHTTPMiddleware):

--- a/mcp/src/hnf1b_mcp/services/capabilities.py
+++ b/mcp/src/hnf1b_mcp/services/capabilities.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Any
 
 from hnf1b_mcp.config import Settings
@@ -181,10 +183,14 @@ _IDENTIFIERS: dict[str, str] = {
 }
 
 _CITATION_CONTRACT: str = (
-    "Every response includes a recommended_citation field that should be "
-    "pasted verbatim when citing retrieved data. Publication records carry a "
-    "date_confidence flag (verified | unverified) indicating whether the "
-    "publication year is confirmed from the source record."
+    "Publication and evidence payloads include a recommended_citation field that "
+    "must be pasted verbatim when citing them — this covers hnf1b_get_publications "
+    "and the publications embedded in individual records. Other record types "
+    "(variants, individuals, statistics) do NOT carry a recommended_citation; "
+    "cite them by their stable identifier (phenopacket_id, variant_id) plus the "
+    "recommended_citation of any publication they reference. Publication records "
+    "also carry a date_confidence flag (verified | unverified) indicating whether "
+    "the publication year is confirmed from the source record."
 )
 
 _DATA_CLASSES: dict[str, str] = {
@@ -257,8 +263,10 @@ def _filterable_fields() -> dict[str, Any]:
                 "hint": (
                     "prefix with '-' for descending; default '-carrier_count' "
                     "(most common first), so the first row IS the top variant by "
-                    "carrier count. Echoed as applied_sort; carrier_count is on "
-                    "every row, so ties are visible without an extra call."
+                    "carrier count. Echoed as applied_sort in your public "
+                    "vocabulary. carrier_count is on every row, so ties are "
+                    "visible without an extra call; ties break by variant_id asc, "
+                    "so ordering within a tie is deterministic across calls."
                 ),
             },
         },
@@ -331,11 +339,12 @@ def get_capabilities() -> dict[str, Any]:
     Returns:
         A dictionary containing canonical workflows, tool inventory,
         filterable-field enums, payload modes, pagination limits, citation
-        contract, error codes, data-class taxonomy, v1 exclusions, and safety
-        notices.
+        contract, error codes, data-class taxonomy, v1 exclusions, safety
+        notices, and a content ``capabilities_version`` hash a warm client can
+        compare to skip re-fetching an unchanged descriptor.
     """
     settings = Settings()
-    return {
+    descriptor: dict[str, Any] = {
         "canonical_workflows": _CANONICAL_WORKFLOWS,
         "tools": _TOOLS,
         "filterable_fields": _filterable_fields(),
@@ -345,9 +354,24 @@ def get_capabilities() -> dict[str, Any]:
         },
         "limits": _LIMITS,
         "identifiers": _IDENTIFIERS,
+        "pagination_semantics": (
+            "List/search 'total' is the full count AFTER all filters are applied "
+            "server-side (post-filter), so 'total' and 'has_more' stay trustworthy "
+            "across pages — never just the current page's count. "
+            "hnf1b_search_variants also returns filtered_count (== total) when a "
+            "consequence filter is active."
+        ),
         "citation_contract": _CITATION_CONTRACT,
         "error_codes": sorted(ERROR_CODES),
         "data_classes": _DATA_CLASSES,
         "exclusions": _EXCLUSIONS,
         "safety": _SAFETY,
     }
+    # Deterministic content hash so a warm client can detect "nothing changed"
+    # and skip re-fetching the (~9k char) descriptor. Stable across calls until
+    # the descriptor content itself changes (no timestamps / non-determinism).
+    digest = hashlib.sha256(
+        json.dumps(descriptor, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+    descriptor["capabilities_version"] = f"sha256:{digest[:16]}"
+    return descriptor

--- a/mcp/src/hnf1b_mcp/services/compare.py
+++ b/mcp/src/hnf1b_mcp/services/compare.py
@@ -145,14 +145,21 @@ async def compare_phenotypes(
 
     features.sort(key=lambda f: f["total_observed"], reverse=True)
     total_distinct = len(features)
+    shown = features[:top_n]
 
     return {
         "groups": groups,
-        "features": features[:top_n],
+        "features": shown,
         "total_distinct_features": total_distinct,
+        # Make truncation explicit so the caller knows how many features are
+        # hidden and can widen top_n to retrieve them — never a silent cut.
+        "returned_features": len(shown),
+        "top_n": top_n,
+        "has_more": total_distinct > len(shown),
         "note": (
             "Per-group counts: observed (HPO present), excluded (confirmed"
             " absent), unknown (carrier did not report the term). Ranked by"
-            " total observed across groups; truncated to top_n."
+            " total observed across groups; the top top_n of"
+            " total_distinct_features are returned — see has_more/top_n."
         ),
     }

--- a/mcp/src/hnf1b_mcp/services/individuals.py
+++ b/mcp/src/hnf1b_mcp/services/individuals.py
@@ -50,6 +50,30 @@ _INDIVIDUAL_FIELDS_BY_MODE: dict[str, tuple[str, ...]] = {
 _ALWAYS_KEEP = ("phenopacket_id", "uri")
 
 
+def _matches_filters(individual: dict[str, Any], filters: dict[str, Any]) -> bool:
+    """Return whether a shaped individual satisfies the active ``sex``/``has_variants``.
+
+    Used to apply filters to an explicit ``ids`` batch so the filter is honored
+    rather than silently ignored (the batch endpoint does not filter). Operates
+    on the fully-shaped record (subject + variants present before projection).
+
+    Args:
+        individual: A shaped individual dict (subject + variants present).
+        filters: Active filter dict, e.g. ``{"sex": "MALE", "has_variants": True}``.
+
+    Returns:
+        ``True`` when the record matches every active filter.
+    """
+    sex = filters.get("sex")
+    if sex is not None and individual.get("subject", {}).get("sex") != sex:
+        return False
+    has_variants = filters.get("has_variants")
+    if has_variants is not None:
+        if bool(individual.get("variants")) != bool(has_variants):
+            return False
+    return True
+
+
 def _project_individual(record: dict[str, Any], mode: str) -> dict[str, Any]:
     """Project a shaped individual down to the fields allowed by *mode*.
 
@@ -345,11 +369,18 @@ async def get_individuals(
                 "phenopacket": phenopacket_content,
             }
             individuals.append(_shape_individual(record))
-        total = len(individuals)
         # Surface which requested IDs the batch endpoint did not return, so a
         # caller can distinguish "does not exist" from a silently-dropped id.
+        # Computed BEFORE filtering: not_found means "absent", not "filtered out".
         returned_ids = {ind.get("phenopacket_id") for ind in individuals}
         not_found = [i for i in ids if i not in returned_ids]
+        # Apply sex/has_variants to the explicit batch so the filter is HONORED,
+        # not silently ignored (the batch endpoint itself does not filter). The
+        # applied filters are echoed in meta so the result is never a confident
+        # wrong answer.
+        if filters:
+            individuals = [i for i in individuals if _matches_filters(i, filters)]
+        total = len(individuals)
     else:
         # Discovery list endpoint
         # Response: {data:[ITEM,...], meta:{page:{totalRecords:N}}, links:{}}
@@ -428,6 +459,12 @@ async def get_individuals(
     if ids is not None:
         result["requested"] = len(ids)
         result["not_found"] = not_found
+
+    # Echo any active filters so an agent can confirm what was applied (the
+    # batch path applies them client-side; the discovery path forwards them to
+    # the API). Makes "filtered cohort" results self-describing, never silent.
+    if filters:
+        result["_meta"] = {"applied_filters": dict(filters)}
 
     # Enforce the advertised char budget on the (potentially large) batch: trim
     # the individuals list to the mode ceiling rather than overflowing it.

--- a/mcp/src/hnf1b_mcp/services/search.py
+++ b/mcp/src/hnf1b_mcp/services/search.py
@@ -229,9 +229,26 @@ async def search(
         hits.append(hit)
         counts[norm_type] = counts.get(norm_type, 0) + 1
 
-    return {
+    result: dict[str, Any] = {
         "query": query.strip(),
         "hits": hits,
         "counts": counts,
         "guidance": _GUIDANCE,
     }
+
+    # When a query matched ONLY publications while individuals/variants were also
+    # requested, a free-text phenotype phrase likely matched publication text but
+    # not the cohort. Nudge toward the HPO-precise path so the agent does not
+    # mistake "publications only" for "no individuals have this phenotype".
+    if (
+        hits
+        and set(counts) <= {"publication"}
+        and ({"individual", "variant"} & set(types))
+    ):
+        result["phenotype_hint"] = (
+            "Only publications matched. If this is a phenotype query, resolve it"
+            " to HPO IDs via hnf1b_resolve_terms(text=..., vocabulary='hpo'),"
+            " then call hnf1b_find_individuals_by_phenotype(hpo_ids=[...])."
+        )
+
+    return result

--- a/mcp/src/hnf1b_mcp/services/variants.py
+++ b/mcp/src/hnf1b_mcp/services/variants.py
@@ -60,6 +60,14 @@ _SORT_FIELD_TRANSLATION: dict[str, str] = {
     "variant_type": "variant_type",
 }
 
+# Reverse map: backend ORDER BY token -> canonical public field. Used to echo
+# ``applied_sort`` in the CALLER's vocabulary (e.g. ``-carrier_count``), never
+# the internal column name (``-individualCount``). An echo field exists to
+# confirm what the server did, so it must speak the public token the caller used.
+_BACKEND_TO_PUBLIC: dict[str, str] = {
+    backend: public for public, backend in VARIANT_SORT_FIELDS.items()
+}
+
 
 def _translate_sort(sort: str | None) -> tuple[str | None, list[str]]:
     """Map an MCP-friendly sort expression to the backend token.
@@ -82,6 +90,30 @@ def _translate_sort(sort: str | None) -> tuple[str | None, list[str]]:
     if backend_field is None:
         return None, ["sort"]
     return (f"-{backend_field}" if descending else backend_field), []
+
+
+def _public_sort(sort: str | None) -> str | None:
+    """Return the canonical *public* form of a honored sort, else ``None``.
+
+    Normalizes both public keys and accepted backend-token aliases to the public
+    vocabulary (e.g. ``-carrier_count`` and ``-individualCount`` both echo back as
+    ``-carrier_count``). ``None`` when the field is not sortable server-side.
+
+    Args:
+        sort: A sort expression, optionally ``-``-prefixed for descending.
+
+    Returns:
+        The public canonical sort token, or ``None`` when not honored.
+    """
+    if not sort:
+        return None
+    descending = sort.startswith("-")
+    field = sort[1:] if descending else sort
+    backend_field = _SORT_FIELD_TRANSLATION.get(field)
+    if backend_field is None:
+        return None
+    public = _BACKEND_TO_PUBLIC.get(backend_field, field)
+    return f"-{public}" if descending else public
 
 
 # Per-mode field policies (Anthropic: smallest high-signal payload).  Fields not
@@ -373,17 +405,19 @@ async def search_variants(
         extra_meta["applied_filters"] = applied_filters
         extra_meta["filter_mode"] = "server"
 
-    # Echo the sort actually applied server-side and name any parameter that was
-    # requested but could not be honored. An LLM cannot self-correct on a
-    # silently-dropped argument.
+    # Echo the sort actually applied in the CALLER's public vocabulary (never the
+    # internal column name) and name any parameter that was requested but could
+    # not be honored. An LLM cannot self-correct on a silently-dropped argument,
+    # and a leaked internal token (``-individualCount``) erodes trust in the one
+    # field whose job is to confirm what the server did.
     if sort is not None:
-        extra_meta["applied_sort"] = backend_sort
+        extra_meta["applied_sort"] = _public_sort(sort)
         extra_meta["ignored_params"] = ignored_sort
         if ignored_sort:
             extra_meta["sort_note"] = (
                 f"sort={sort!r} is not sortable server-side; default order"
-                " (carrier_count desc) was used. Sortable fields: "
-                f"{sorted(_SORT_FIELD_TRANSLATION)}"
+                " (carrier_count desc, then variant_id asc) was used. Sortable"
+                f" fields: {sorted(VARIANT_SORT_FIELDS)}"
             )
 
     if extra_meta:

--- a/mcp/src/hnf1b_mcp/tools/individuals.py
+++ b/mcp/src/hnf1b_mcp/tools/individuals.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from fastmcp import FastMCP
 
 from hnf1b_mcp.client.api_client import ApiClient
+from hnf1b_mcp.contract import SexFilter
 from hnf1b_mcp.services import individuals as individuals_service
 from hnf1b_mcp.services.dataclass import DataClass
+from hnf1b_mcp.services.errors import McpToolError
 from hnf1b_mcp.services.safe_tool import run_tool
 from hnf1b_mcp.services.shaping import resolve_mode
+
+# Canonical HPO term-ID shape: "HP:" + exactly 7 digits (e.g. HP:0000107).
+_HPO_ID_RE = re.compile(r"^HP:\d{7}$")
 
 
 def register(mcp: FastMCP, client: ApiClient | None) -> None:
@@ -99,7 +105,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
     )
     async def hnf1b_get_individuals(
         ids: list[str] | None = None,
-        sex: str | None = None,
+        sex: SexFilter | None = None,
         has_variants: bool | None = None,
         page_size: int = 25,
         expand: bool = False,
@@ -116,13 +122,15 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         discover individuals sharing a given HPO term before fetching them.
 
         Args:
-            ids: Optional list of phenopacket IDs for batch retrieval.  When
-                supplied, ``sex`` and ``has_variants`` filters are ignored.
-            sex: Filter by biological sex — e.g. ``"MALE"`` or ``"FEMALE"``.
-                Applied only when ``ids`` is not provided.
+            ids: Optional list of phenopacket IDs for batch retrieval.  The
+                ``sex`` / ``has_variants`` filters are applied to the batch too
+                (and echoed in ``meta.applied_filters``), so a filtered id set is
+                never silently returned unfiltered.
+            sex: Filter by biological sex — one of ``"MALE"`` or ``"FEMALE"``.
+                An invalid value returns an ``invalid_input`` error. Applied in
+                both the batch (``ids``) and discovery paths.
             has_variants: Filter to individuals with (``True``) or without
-                (``False``) recorded variants.  Applied only when ``ids`` is
-                not provided.
+                (``False``) recorded variants.  Applied in both paths.
             page_size: Maximum number of results per page (discovery endpoint
                 only).  Defaults to 25.
             expand: When ``True`` and using the discovery endpoint, fetch each
@@ -209,8 +217,10 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
             individuals, not the returned page), ``returned`` (page size
             actually returned), ``has_more`` (whether ``total`` exceeds the
             page), ``match_mode`` (``"any"``), ``hpo_ids`` (echoed), plus
-            ``page_size``, ``data_class`` and ``meta``. An empty/invalid HPO set
-            returns ``total: 0`` (never the whole cohort).
+            ``page_size``, ``data_class`` and ``meta``. A malformed HPO ID (not
+            ``HP:`` + 7 digits) returns an ``invalid_input`` error (with a hint to
+            resolve free text via ``hnf1b_resolve_terms``), distinct from a real
+            empty cohort which returns ``total: 0``.
         """
         resolved = resolve_mode(response_mode)
         # Cap on cursor pages per HPO term so an honest total cannot trigger an
@@ -250,6 +260,22 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
             return ids, True  # page cap hit
 
         async def handler() -> dict[str, Any]:
+            # Validate HPO ID shape FIRST so a malformed term (e.g. "renal cyst")
+            # returns invalid_input — never total:0, which is indistinguishable
+            # from a real empty cohort and would read as a confident wrong answer.
+            malformed = [h for h in hpo_ids if not _HPO_ID_RE.match(h)]
+            if malformed:
+                raise McpToolError(
+                    "invalid_input",
+                    f"not valid HPO term IDs: {malformed}. Expected 'HP:' + 7"
+                    " digits (e.g. 'HP:0000107').",
+                    field="hpo_ids",
+                    hint=(
+                        "resolve free-text phenotypes to HPO IDs first via"
+                        " hnf1b_resolve_terms(text=..., vocabulary='hpo')"
+                    ),
+                )
+
             seen: dict[str, None] = {}
             capped = False
             for hpo_id in hpo_ids:

--- a/mcp/tests/test_capabilities.py
+++ b/mcp/tests/test_capabilities.py
@@ -10,11 +10,26 @@ from hnf1b_mcp.services.capabilities import get_capabilities
 from hnf1b_mcp.services.resources import RESOURCE_URIS, load_resource
 
 
+def test_capabilities_version_present_and_deterministic():
+    """A content hash is exposed and stable across calls (warm-client skip)."""
+    cap = get_capabilities()
+    assert cap["capabilities_version"].startswith("sha256:")
+    assert cap["capabilities_version"] == get_capabilities()["capabilities_version"]
+
+
+def test_capabilities_citation_contract_scoped_to_publications():
+    """The citation claim is scoped, not the falsified universal 'every response'."""
+    contract = get_capabilities()["citation_contract"].lower()
+    assert "publication and evidence payloads" in contract
+    assert "every response includes a recommended_citation" not in contract
+
+
 def test_capabilities_shape():
     cap = get_capabilities()
     assert "canonical_workflows" in cap
     assert "tools" in cap and len(cap["tools"]) >= 10
     assert cap["citation_contract"]
+    assert cap["pagination_semantics"]
     assert set(cap["error_codes"]) == {
         "invalid_input",
         "not_found",

--- a/mcp/tests/test_compare.py
+++ b/mcp/tests/test_compare.py
@@ -62,6 +62,34 @@ async def test_compare_phenotypes_tabulates_by_group():
     assert hp2["ga4gh:VA.B"] == {"observed": 1, "excluded": 0, "unknown": 0}
     # ranked by total observed (HP:1 total 2 > HP:2 total 1)
     assert result["features"][0]["hpo_id"] == "HP:1"
+    # full result set fit within top_n=10, so nothing is hidden.
+    assert result["total_distinct_features"] == 2
+    assert result["returned_features"] == 2
+    assert result["top_n"] == 10
+    assert result["has_more"] is False
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_compare_phenotypes_truncation_is_transparent():
+    """top_n smaller than the distinct-feature count exposes has_more, not a silent cut."""
+    respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.A").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                _carrier("p1", [("HP:1", "F1", False), ("HP:2", "F2", False)]),
+            ],
+        )
+    )
+    c = ApiClient(base_url=BASE)
+    result = await compare_phenotypes(c, ["ga4gh:VA.A"], top_n=1)
+    await c.aclose()
+
+    assert result["total_distinct_features"] == 2
+    assert result["returned_features"] == 1
+    assert result["top_n"] == 1
+    assert result["has_more"] is True
+    assert len(result["features"]) == 1
 
 
 @pytest.mark.asyncio

--- a/mcp/tests/test_individuals.py
+++ b/mcp/tests/test_individuals.py
@@ -356,6 +356,41 @@ async def test_get_individuals_by_ids_uses_batch():
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_get_individuals_batch_applies_sex_filter():
+    """The sex filter is HONORED on an explicit ids batch and echoed in _meta."""
+    respx.get(f"{BASE}/phenopackets/batch").mock(
+        return_value=httpx.Response(200, json=[_BATCH_ITEM_A, _BATCH_ITEM_B])
+    )
+    c = ApiClient(base_url=BASE)
+    # A is FEMALE, B is MALE — filtering to MALE must drop A.
+    result = await get_individuals(c, ids=["A", "B"], filters={"sex": "MALE"})
+    await c.aclose()
+
+    assert {i["phenopacket_id"] for i in result["individuals"]} == {"B"}
+    assert result["total"] == 1
+    # not_found stays existence-based, not "filtered out".
+    assert result["not_found"] == []
+    assert result["_meta"]["applied_filters"] == {"sex": "MALE"}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_individuals_batch_sex_filter_no_match():
+    """A batch filtered to a sex none of the records have returns total 0."""
+    respx.get(f"{BASE}/phenopackets/batch").mock(
+        return_value=httpx.Response(200, json=[_BATCH_ITEM_B])  # B is MALE
+    )
+    c = ApiClient(base_url=BASE)
+    result = await get_individuals(c, ids=["B"], filters={"sex": "FEMALE"})
+    await c.aclose()
+
+    assert result["individuals"] == []
+    assert result["total"] == 0
+    assert result["_meta"]["applied_filters"] == {"sex": "FEMALE"}
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_get_individuals_batch_reports_not_found():
     """A requested id the batch endpoint does not return appears in not_found."""
     respx.get(f"{BASE}/phenopackets/batch").mock(

--- a/mcp/tests/test_search_service.py
+++ b/mcp/tests/test_search_service.py
@@ -424,3 +424,43 @@ async def test_search_hits_carry_resolve_with():
     assert by_type["variant"]["resolve_with"]["tool"] == "hnf1b_get_variant"
     assert by_type["variant"]["resolve_with"]["value"] == "HNF1B:c.494G>A"
     assert by_type["gene"]["resolve_with"]["tool"] == "hnf1b_get_gene_context"
+
+
+_PUB_ONLY_RESPONSE = {
+    "results": [
+        {"id": "pub_12345678", "label": "Smith et al. 2020", "type": "publication"},
+        {"id": "pub_22222222", "label": "Doe et al. 2021", "type": "publication"},
+    ]
+}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_publication_only_emits_phenotype_hint():
+    """A phenotype-ish query matching only publications nudges to the HPO path."""
+    respx.get(f"{BASE}/search/global").mock(
+        return_value=httpx.Response(200, json=_PUB_ONLY_RESPONSE)
+    )
+    c = ApiClient(base_url=BASE)
+    # Default types include individual + variant, but only publications matched.
+    result = await search(c, query="renal cysts and diabetes")
+    await c.aclose()
+
+    assert set(result["counts"]) == {"publication"}
+    assert "phenotype_hint" in result
+    assert "hnf1b_resolve_terms" in result["phenotype_hint"]
+    assert "hnf1b_find_individuals_by_phenotype" in result["phenotype_hint"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_with_individual_hits_omits_phenotype_hint():
+    """The nudge is suppressed when individuals/variants are among the hits."""
+    respx.get(f"{BASE}/search/global").mock(
+        return_value=httpx.Response(200, json=_SEARCH_RESPONSE)
+    )
+    c = ApiClient(base_url=BASE)
+    result = await search(c, query="HNF1B")
+    await c.aclose()
+
+    assert "phenotype_hint" not in result

--- a/mcp/tests/test_tool_individuals.py
+++ b/mcp/tests/test_tool_individuals.py
@@ -166,6 +166,43 @@ async def test_get_individual_happy_path():
 
 
 @pytest.mark.asyncio
+async def test_find_by_phenotype_rejects_malformed_hpo_id():
+    """A non-HPO-ID string returns invalid_input, not a misleading total:0."""
+    mcp = FastMCP("test")
+    register(mcp, ApiClient(base_url=BASE))
+
+    r = await mcp.call_tool(
+        "hnf1b_find_individuals_by_phenotype", {"hpo_ids": ["renal cyst"]}
+    )
+    sc = r.structured_content
+    assert sc["is_error"] is True
+    assert sc["error"]["code"] == "invalid_input"
+    assert sc["error"]["field"] == "hpo_ids"
+    # The hint must route the agent to the resolver, not leave it guessing.
+    assert "resolve" in sc["error"]["hint"].lower()
+
+
+@pytest.mark.asyncio
+async def test_find_by_phenotype_accepts_valid_hpo_id_shape():
+    """A well-formed HP:####### id passes validation (reaches the search call)."""
+    mcp = FastMCP("test")
+    with respx.mock:
+        respx.get(f"{BASE}/phenopackets/search").mock(
+            return_value=httpx.Response(
+                200, json={"data": [], "meta": {"page": {"hasNextPage": False}}}
+            )
+        )
+        register(mcp, ApiClient(base_url=BASE))
+        r = await mcp.call_tool(
+            "hnf1b_find_individuals_by_phenotype", {"hpo_ids": ["HP:0000107"]}
+        )
+    sc = r.structured_content
+    # Valid shape, no matches -> a real empty cohort (total 0), NOT invalid_input.
+    assert sc.get("is_error") is not True
+    assert sc["total"] == 0
+
+
+@pytest.mark.asyncio
 @respx.mock
 async def test_get_individual_subject_and_uri():
     respx.get(f"{BASE}/phenopackets/X").mock(

--- a/mcp/tests/test_variants.py
+++ b/mcp/tests/test_variants.py
@@ -261,7 +261,7 @@ async def test_search_variants_no_filter_omits_filter_meta():
 @pytest.mark.asyncio
 @respx.mock
 async def test_search_variants_translates_and_echoes_sort():
-    """A row-name sort key is translated to the backend token and echoed."""
+    """Sort is translated to the backend token but echoed in the PUBLIC token."""
     route = respx.get(f"{BASE}/phenopackets/aggregate/all-variants").mock(
         return_value=httpx.Response(
             200, json={"data": [], "meta": {"page": {"totalRecords": 0}}}
@@ -272,10 +272,30 @@ async def test_search_variants_translates_and_echoes_sort():
     await client.aclose()
 
     sent_params = dict(route.calls[0].request.url.params)
-    # carrier_count -> individualCount (the only token the backend honors here).
+    # Wire: carrier_count -> individualCount (the token the backend honors).
     assert sent_params["sort"] == "-individualCount"
-    assert result["_meta"]["applied_sort"] == "-individualCount"
+    # Echo: the caller's public vocabulary, never the internal column name.
+    assert result["_meta"]["applied_sort"] == "-carrier_count"
     assert result["_meta"]["ignored_params"] == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_variants_sort_alias_echoes_public_token():
+    """A backend-token alias is accepted but echoed normalized to public form."""
+    route = respx.get(f"{BASE}/phenopackets/aggregate/all-variants").mock(
+        return_value=httpx.Response(
+            200, json={"data": [], "meta": {"page": {"totalRecords": 0}}}
+        )
+    )
+    client = ApiClient(base_url=BASE)
+    result = await search_variants(client, sort="-individualCount")
+    await client.aclose()
+
+    sent_params = dict(route.calls[0].request.url.params)
+    assert sent_params["sort"] == "-individualCount"
+    # Even when the caller used the internal alias, the echo is the public token.
+    assert result["_meta"]["applied_sort"] == "-carrier_count"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context

A senior LLM tester exercised all 12 tools (happy-path + edge + boundary + error) and scored the server **8.3/10** — "top-decile design; deductions cluster in validation and contract fidelity, not capability." All three HIGH issues reduce to one theme: *the server is more trustworthy than its uniformity lets an agent assume.* This PR makes every tool validate inputs and honor the capabilities contract the way `get_publications` and the `not_found` path already did.

## HIGH

- **Invalid enums returned a raw framework error, not `invalid_input`.** `classification=DISEASE_CAUSING`, `metric=not_a_metric`, `vocabulary=not_a_vocab` all returned `"Output validation error: outputSchema defined but no structured output returned"`. Root cause: the middlewares returned the error envelope as unstructured `content`, but the tools declare an output schema, so FastMCP rejected it. Fix: return it as `structured_content`. Now **all** typed-enum tools yield the clean `invalid_input` envelope (field + allowed values + hint).
- **`get_individuals.sex` silently ignored when `ids` given.** `ids=[86,133]` (both MALE) returned 2 rows under `sex=MALE`, `FEMALE`, and `BANANA`. Now `sex` is a `SexFilter` enum (bad value → `invalid_input`), the filter is **applied** to the batch, and `applied_filters` is echoed in `meta`. `has_variants` honored likewise.
- **Citation-contract overclaim.** Capabilities claimed "Every response includes a `recommended_citation` field"; only publication/evidence payloads do. Narrowed to the truth; other records are cited by stable id.

## MED

- **`find_individuals_by_phenotype` conflated bad input with empty result.** A non-HPO-ID (`"renal cyst"`) returned `total:0`. Now regex-validates `^HP:\d{7}$` → `invalid_input` with a hint to `resolve_terms`, distinct from a real empty cohort.
- **`applied_sort` leaked the internal column** (`-individualCount`). Now echoes the caller's public token (`-carrier_count`), normalizing backend aliases.

## LOW

- `compare_phenotypes` exposes `top_n`/`returned_features`/`has_more` (was a silent truncation).
- `search` nudges toward `resolve_terms → find_individuals_by_phenotype` when only publications match a phenotype query.
- Capabilities adds a deterministic `capabilities_version` hash (warm-client re-fetch skip) and a `pagination_semantics` note (total is post-filter); sort doc states the `variant_id` tie-break.

## Verification

- Every fix reproduced as broken on the live stack, then re-verified fixed (invalid enums → `invalid_input`; `sex=FEMALE` on two males → `total:0` + `applied_filters`; `sex=BANANA` → `invalid_input`; malformed HPO → `invalid_input`; `applied_sort: -carrier_count`; compare `has_more`; `capabilities_version`/`pagination_semantics` present; `phenotype_hint` on publication-only matches).
- `make -C mcp check` green — **318 passed**, 10 live deselected; 9 new regression tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)