### PR TITLE
fix(docker): make `make dev-up` boot the full stack + document the run

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -6,6 +6,18 @@
 #
 # NEVER commit .env.docker to version control!
 # ============================================
+#
+# ── LOCAL FULL-STACK DEV (`make dev-up`) ──────────────────────────────────────
+# `make dev-up` runs the whole stack in Docker via `--env-file .env.docker`.
+# For local dev, set in your .env.docker:
+#     ENVIRONMENT=development              # relaxes the prod SMTP/TLS/cookie validators
+#     ADMIN_PASSWORD=<any-strong-value>    # REQUIRED — it has no default
+# Keep POSTGRES_PASSWORD=hnf1b_pass to match an existing `hnf1b_postgres_data`
+# volume (Postgres only honours POSTGRES_PASSWORD on the first init of an empty
+# volume). The DB image is pgvector/pgvector:pg15 and the API auto-runs
+# `alembic upgrade head` on startup. Once up, backfill the RAG corpus with
+# `make publications-backfill`.
+# ──────────────────────────────────────────────────────────────────────────────
 
 # ============================================
 # PostgreSQL Database

--- a/Makefile
+++ b/Makefile
@@ -119,17 +119,19 @@ hybrid-down:  ## Stop PostgreSQL and Redis services
 	$(DOCKER_COMPOSE) -f $(COMPOSE_DEV) down
 
 # Full Docker Development Commands
-dev-up:  ## Start full stack in Docker (with ports exposed)
-	$(DOCKER_COMPOSE) -f $(COMPOSE_BASE) up -d --build
+dev-up:  ## Start full stack in Docker (with ports exposed). Needs .env.docker (see .env.docker.example; set ENVIRONMENT=development).
+	@test -f $(ENV_FILE) || { echo "❌ $(ENV_FILE) not found. Run: cp .env.docker.example $(ENV_FILE) and set ENVIRONMENT=development + ADMIN_PASSWORD"; exit 1; }
+	$(DOCKER_COMPOSE) -f $(COMPOSE_BASE) --env-file $(ENV_FILE) up -d --build
 	@echo ""
 	@echo "✅ Full stack started!"
 	@echo "  Frontend: http://localhost:3000"
 	@echo "  Backend API: http://localhost:8000"
 	@echo "  API Docs: http://localhost:8000/docs"
+	@echo "  MCP: http://localhost:8788/health"
 	@echo ""
 
-dev-down:  ## Stop all Docker services
-	$(DOCKER_COMPOSE) -f $(COMPOSE_BASE) down
+dev-down:  ## Stop all Docker services (preserves volumes)
+	$(DOCKER_COMPOSE) -f $(COMPOSE_BASE) --env-file $(ENV_FILE) down
 
 dev-logs:  ## Show Docker logs
 	$(DOCKER_COMPOSE) -f $(COMPOSE_BASE) logs -f

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ make backend
 make frontend
 ```
 
+### Or: run the entire stack in Docker
+
+```bash
+cp .env.docker.example .env.docker   # then set ENVIRONMENT=development + ADMIN_PASSWORD
+make dev-up                          # builds + starts db, cache, api, mcp, frontend
+# API http://localhost:8000 · Docs /docs · MCP http://localhost:8788/health · Frontend http://localhost:3000
+make dev-down                        # stop (preserves the postgres volume)
+```
+
+`make dev-up` loads `.env.docker` (`--env-file`) and uses the
+`pgvector/pgvector:pg15` database; the API container auto-applies Alembic
+migrations on startup. Once healthy, populate the publication RAG corpus with
+`make publications-backfill`.
+
 See [docs/deployment/docker.md](docs/deployment/docker.md) for full Docker
 deployment instructions (including production with Nginx Proxy Manager).
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -95,7 +95,11 @@ services:
       REDIS_URL: redis://hnf1b_cache:6379/0
       # Security
       JWT_SECRET: ${JWT_SECRET:-dev-secret-change-in-production}
-      # App config
+      # App config. ENVIRONMENT defaults to production (fail-closed: the Wave 5c
+      # validators then require real SMTP + secure cookies + a non-empty
+      # ADMIN_PASSWORD). Set ENVIRONMENT=development in --env-file to boot the
+      # local full-stack dev (see `make dev-up` and .env.docker.example).
+      ENVIRONMENT: ${ENVIRONMENT:-production}
       DEBUG: ${DEBUG:-false}
       LOG_LEVEL: ${LOG_LEVEL_API:-INFO}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000,http://localhost:5173}
@@ -138,6 +142,7 @@ services:
     container_name: hnf1b_mcp
     restart: unless-stopped
     environment:
+      ENVIRONMENT: ${ENVIRONMENT:-production}
       HNF1B_MCP_API_BASE_URL: http://hnf1b_api:8000/api/v2
       HNF1B_MCP_PORT: 8788
       HNF1B_MCP_REDIS_URL: redis://hnf1b_cache:6379/1

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -68,14 +68,33 @@ docker compose version    # Docker Compose V2
 git clone https://github.com/berntpopp/hnf1b-db.git
 cd hnf1b-db
 
-# Start all services with data import
-ENABLE_DATA_IMPORT=true docker compose -f docker/docker-compose.yml up -d --build
+# Configure the docker env (REQUIRED). At minimum set:
+#   ENVIRONMENT=development     (relaxes the prod SMTP/TLS/cookie validators)
+#   ADMIN_PASSWORD=<strong>     (no default — the app refuses to boot if empty)
+cp .env.docker.example .env.docker
+$EDITOR .env.docker
+
+# Build + start the whole stack (db, cache, api, mcp, frontend)
+make dev-up
+# equivalently:
+#   docker compose -f docker/docker-compose.yml --env-file .env.docker up -d --build
 
 # Watch logs
 docker compose -f docker/docker-compose.yml logs -f
 ```
 
-The first startup with `ENABLE_DATA_IMPORT=true` will:
+> **Why `--env-file` / `ENVIRONMENT=development` are required.** The base compose
+> is production-oriented: `ENVIRONMENT` defaults to `production`, where the Wave 5c
+> fail-closed validators require real SMTP, secure cookies, and a non-empty
+> `ADMIN_PASSWORD`. `make dev-up` loads `.env.docker` so those values are present;
+> set `ENVIRONMENT=development` there to boot locally without SMTP/TLS.
+>
+> The API container runs `alembic upgrade head` automatically on startup; the DB
+> image is `pgvector/pgvector:pg15` (provides the `vector` extension for the
+> publication RAG index). To populate the publication full-text RAG corpus on an
+> existing DB, run `make publications-backfill`.
+
+A first startup with `ENABLE_DATA_IMPORT=true` (set in `.env.docker`) will:
 1. Run database migrations
 2. Create admin user (if credentials provided)
 3. Initialize reference data (GRCh38 + HNF1B)
@@ -176,21 +195,24 @@ cp .env.docker.example .env.docker
 
 ### Local Development
 
-For development with ports exposed:
+For development with ports exposed (requires `.env.docker` with
+`ENVIRONMENT=development` + `ADMIN_PASSWORD`; see Quick Start above):
 
 ```bash
-# Start services
-docker compose -f docker/docker-compose.yml up -d --build
+# Start services (loads .env.docker via --env-file)
+make dev-up
+# equivalently:
+#   docker compose -f docker/docker-compose.yml --env-file .env.docker up -d --build
 
-# With data import
-ENABLE_DATA_IMPORT=true docker compose -f docker/docker-compose.yml up -d --build
+# Stop services (preserves volumes)
+make dev-down
 
-# Stop services
-docker compose -f docker/docker-compose.yml down
-
-# Stop and remove volumes (clean reset)
-docker compose -f docker/docker-compose.yml down -v
+# Stop and remove volumes (CLEAN RESET — destroys all DB data)
+docker compose -f docker/docker-compose.yml --env-file .env.docker down -v
 ```
+
+> Omitting `--env-file` (or leaving `ENVIRONMENT` unset) boots the stack in
+> production mode, where the API refuses to start with an empty `ADMIN_PASSWORD`.
 
 ### Production with NPM
 


### PR DESCRIPTION
## Problem
Running the whole stack in Docker was undocumented and broken. `make dev-up` ran the base compose with **no `--env-file` and no `ENVIRONMENT` override**, so the app booted in **production** mode and crashed on the unset `ADMIN_PASSWORD`:

```
pydantic_core.ValidationError: ADMIN_PASSWORD is required ...
[ERROR] Migration failed!
```

The only working invocation was an untracked throwaway `docker-compose.monkeytest.yml`.

## Fix
- **`docker-compose.yml`**: honour `${ENVIRONMENT:-production}` on `hnf1b_api` + `hnf1b_mcp` so an env-file can flip the local stack to `development` (relaxes the prod SMTP/TLS/cookie validators). Defaults to `production` — backward compatible.
- **`Makefile`**: `dev-up`/`dev-down` now pass `--env-file $(ENV_FILE)` (`.env.docker`); `dev-up` guards that the file exists with an actionable hint.
- **`.env.docker.example`**: documents the local-dev minimum (`ENVIRONMENT=development` + `ADMIN_PASSWORD`; keep `POSTGRES_PASSWORD=hnf1b_pass` to match an existing volume).
- **`README.md` + `docs/deployment/docker.md`**: add the correct full-stack-in-docker runbook and explain why `--env-file`/`ENVIRONMENT=development` are required (the old `docker compose up` snippets booted production and failed).

## Verification
`cp .env.docker.example .env.docker` (+ `ENVIRONMENT=development`, `ADMIN_PASSWORD`) then **`make dev-up`** brings `db` (pgvector/pgvector:pg15) + cache + api + mcp + frontend up **healthy**; the API auto-applies `alembic upgrade head`; existing data is preserved (923 phenopackets). The superseded throwaway overlay is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)