### PR TITLE
fix(reference): self-healing reference data, initialized idempotently on every container start

### DIFF
--- a/backend/app/reference/service/hnf1b_importer.py
+++ b/backend/app/reference/service/hnf1b_importer.py
@@ -84,12 +84,35 @@ async def get_gene_by_symbol(
     return result.scalar_one_or_none()
 
 
+#: Authoritative HNF1B cross-references (curated seed). Kept as a constant so the
+#: create path and the self-heal path below can never drift.
+_HNF1B_GENE_XREFS: dict[str, str] = {
+    "ncbi_gene_id": "6928",
+    "hgnc_id": "HGNC:11630",
+    "omim_id": "189907",
+}
+
+
 async def import_hnf1b_gene(
     db: AsyncSession, genome_id: uuid.UUID
 ) -> tuple[Gene, bool]:
-    """Import or fetch the HNF1B gene row."""
+    """Import or fetch (and self-heal) the HNF1B gene row.
+
+    Idempotent. If the chr17q12 region sync (Ensembl) already created the HNF1B
+    row with only coordinates + ensembl_id, this backfills the authoritative
+    NCBI / HGNC / OMIM cross-references so ``get_gene_context`` never reports
+    degraded ``cross_references``. A fully-populated row is left untouched.
+    """
     existing = await get_gene_by_symbol(db, "HNF1B", genome_id)
     if existing:
+        healed = False
+        for attr, value in _HNF1B_GENE_XREFS.items():
+            if not getattr(existing, attr, None):
+                setattr(existing, attr, value)
+                healed = True
+        if healed:
+            await db.flush()
+            logger.info("Healed existing HNF1B gene cross-references (NCBI/HGNC/OMIM)")
         return existing, False
 
     gene = Gene(
@@ -102,9 +125,7 @@ async def import_hnf1b_gene(
         strand="-",
         genome_id=genome_id,
         ensembl_id="ENSG00000275410",
-        ncbi_gene_id="6928",
-        hgnc_id="HGNC:11630",
-        omim_id="189907",
+        **_HNF1B_GENE_XREFS,
         source="NCBI Gene",
         source_version="2025-01",
         source_url="https://www.ncbi.nlm.nih.gov/gene/6928",

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -74,9 +74,8 @@ run_data_import() {
     if [ "${ENABLE_DATA_IMPORT:-false}" = "true" ]; then
         log_info "Data import is ENABLED, checking configuration..."
 
-        # Step 1: Always initialize reference data first (GRCh38 + HNF1B)
-        # This is idempotent and required for proper gene/variant context
-        sync_reference_data
+        # Reference data is already ensured in main() on every start (idempotent),
+        # so it is not repeated here.
 
         # Note: GOOGLE_SHEETS_ID is optional - the migration script has a default value
         # If set, it will override the default. If not set, the hardcoded default is used.
@@ -113,22 +112,17 @@ run_data_import() {
     fi
 }
 
-# Initialize reference data (GRCh38 + HNF1B + transcript + domains)
+# Ensure reference data (GRCh38 + HNF1B + transcript + exons + domains).
+# The init script is idempotent and self-healing — it creates only what is
+# missing and backfills the HNF1B NCBI/HGNC/OMIM cross-references — so it is run
+# unconditionally rather than gated on a coarse "genome exists" check (which left
+# a partially-seeded DB, e.g. a region-synced gene with no transcripts/domains).
 sync_reference_data() {
-    log_info "Checking reference data..."
-
-    # Check if reference data is initialized (GRCh38 genome exists)
-    local genome_count=$(get_count genomes)
-
-    if [ "$genome_count" = "0" ]; then
-        log_info "Initializing reference data (GRCh38 + HNF1B + transcript + domains)..."
-        if python scripts/sync_reference_data.py --init; then
-            log_info "Reference data initialized successfully!"
-        else
-            log_warn "Reference data initialization failed, but continuing startup..."
-        fi
+    log_info "Ensuring reference data (GRCh38 + HNF1B transcript / exons / domains)..."
+    if python scripts/sync_reference_data.py --init; then
+        log_info "Reference data ensured."
     else
-        log_info "Reference data already initialized"
+        log_warn "Reference data init failed, but continuing startup..."
     fi
 }
 
@@ -205,6 +199,12 @@ main() {
 
     # Run migrations
     run_migrations || exit 1
+
+    # Ensure essential reference data (GRCh38 + HNF1B transcript / exons / protein
+    # domains + cross-references). Idempotent and self-healing, so it runs on
+    # EVERY start regardless of ENABLE_DATA_IMPORT — the gene/variant context the
+    # app contract depends on is always complete out of the box.
+    sync_reference_data
 
     # Create admin user
     create_admin_user

--- a/backend/scripts/sync_reference_data.py
+++ b/backend/scripts/sync_reference_data.py
@@ -70,21 +70,12 @@ async def run_init(session: AsyncSession) -> bool:
     print("=" * 70)
     print()
 
-    # Check current status
-    status = await get_reference_data_status(session)
-    if status.has_grch38 and status.has_hnf1b:
-        print("Reference data already initialized:")
-        print("  - GRCh38 genome: Present")
-        print("  - HNF1B gene: Present")
-        print(f"  - Transcripts: {status.transcript_count}")
-        print(f"  - Exons: {status.exon_count}")
-        print(f"  - Protein domains: {status.domain_count}")
-        print()
-        print("No action needed.")
-        return True
-
-    # Run initialization
-    print("Creating reference data...")
+    # initialize_reference_data is idempotent and self-healing (each item is
+    # created only if missing, and the HNF1B gene's cross-refs are backfilled if
+    # absent), so run it UNCONDITIONALLY. The previous "skip when genome+gene
+    # exist" short-circuit left a partially-seeded DB stuck — e.g. a gene created
+    # by the chr17q12 region sync with no transcripts/exons/domains.
+    print("Ensuring reference data (idempotent)...")
     result = await initialize_reference_data(session)
 
     if result.errors > 0:
@@ -94,11 +85,17 @@ async def run_init(session: AsyncSession) -> bool:
                 print(f"  Error: {msg}")
         return False
 
+    status = await get_reference_data_status(session)
     print()
     print("Summary:")
-    print(f"  - Items created: {result.imported}")
+    print(f"  - Items created this run: {result.imported}")
+    print(f"  - GRCh38 genome: {'Present' if status.has_grch38 else 'MISSING'}")
+    print(f"  - HNF1B gene:    {'Present' if status.has_hnf1b else 'MISSING'}")
+    print(f"  - Transcripts:   {status.transcript_count}")
+    print(f"  - Exons:         {status.exon_count}")
+    print(f"  - Protein domains: {status.domain_count}")
     print()
-    print("Reference data initialized successfully!")
+    print("Reference data ensured.")
     return True
 
 

--- a/backend/tests/test_reference_importer.py
+++ b/backend/tests/test_reference_importer.py
@@ -1,0 +1,91 @@
+"""Reference-data importer: idempotency + HNF1B gene cross-ref self-heal.
+
+Guards the bootstrap contract that `get_gene_context` depends on: the reference
+chain (GRCh38 + HNF1B gene/transcript/exons/domains) is created on demand, the
+init is safe to run on every container start, and a gene left without
+NCBI/HGNC/OMIM cross-references by the chr17q12 region sync is healed rather
+than skipped.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.reference.models import Gene
+from app.reference.service.hnf1b_importer import (
+    get_gene_by_symbol,
+    get_or_create_grch38_genome,
+    import_hnf1b_gene,
+    initialize_reference_data,
+)
+from app.reference.service.status import get_reference_data_status
+
+
+@pytest.mark.asyncio
+async def test_initialize_reference_data_populates_full_chain(db_session):
+    """A single init seeds genome + gene (with xrefs) + transcript + exons + domains."""
+    await initialize_reference_data(db_session)
+    status = await get_reference_data_status(db_session)
+
+    assert status.has_grch38 is True
+    assert status.has_hnf1b is True
+    assert status.transcript_count >= 1
+    assert status.exon_count >= 9
+    assert status.domain_count >= 4
+
+    genome = await get_or_create_grch38_genome(db_session)
+    gene = await get_gene_by_symbol(db_session, "HNF1B", genome[0].id)
+    assert gene is not None
+    assert gene.ncbi_gene_id == "6928"
+    assert gene.hgnc_id == "HGNC:11630"
+    assert gene.omim_id == "189907"
+
+
+@pytest.mark.asyncio
+async def test_initialize_reference_data_is_idempotent(db_session):
+    """Running init twice creates nothing new the second time and never errors."""
+    await initialize_reference_data(db_session)
+    second = await initialize_reference_data(db_session)
+    assert second.errors == 0
+    assert second.imported == 0
+
+
+@pytest.mark.asyncio
+async def test_import_hnf1b_gene_heals_missing_xrefs(db_session):
+    """A region-synced HNF1B row with empty xrefs is healed, not skipped.
+
+    Reproduces the real bug: the chr17q12 Ensembl sync creates the HNF1B gene
+    with coordinates + ensembl_id but blank NCBI/HGNC/OMIM, and the importer
+    used to early-return without enriching it — leaving get_gene_context
+    reporting degraded cross_references forever.
+    """
+    genome, _ = await get_or_create_grch38_genome(db_session)
+    existing = await get_gene_by_symbol(db_session, "HNF1B", genome.id)
+    if existing is None:
+        existing = Gene(
+            id=uuid.uuid4(),
+            symbol="HNF1B",
+            name="HNF1 homeobox B",
+            chromosome="17",
+            start=37686431,
+            end=37745091,
+            strand="-",
+            genome_id=genome.id,
+            ensembl_id="ENSG00000275410",
+            source="Ensembl REST API",
+        )
+        db_session.add(existing)
+    # Force the "region-synced, no cross-refs" state.
+    existing.ncbi_gene_id = None
+    existing.hgnc_id = None
+    existing.omim_id = None
+    await db_session.flush()
+
+    healed, created = await import_hnf1b_gene(db_session, genome.id)
+
+    assert created is False  # the row already existed
+    assert healed.ncbi_gene_id == "6928"
+    assert healed.hgnc_id == "HGNC:11630"
+    assert healed.omim_id == "189907"

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -94,11 +94,13 @@ docker compose -f docker/docker-compose.yml logs -f
 > publication RAG index). To populate the publication full-text RAG corpus on an
 > existing DB, run `make publications-backfill`.
 
-A first startup with `ENABLE_DATA_IMPORT=true` (set in `.env.docker`) will:
+Every startup (regardless of `ENABLE_DATA_IMPORT`) will:
 1. Run database migrations
-2. Create admin user (if credentials provided)
-3. Initialize reference data (GRCh38 + HNF1B)
-4. Import phenopackets from Google Sheets
+2. Ensure reference data (GRCh38 + HNF1B transcript/exons/domains + cross-refs) — idempotent
+3. Create admin user (if credentials provided)
+
+A first startup additionally with `ENABLE_DATA_IMPORT=true` (set in `.env.docker`) will:
+4. Import phenopackets from Google Sheets (if the DB is empty)
 5. Sync publication metadata from PubMed
 6. Sync VEP variant annotations from Ensembl
 7. Sync chr17q12 region genes from Ensembl
@@ -246,42 +248,50 @@ Production overlay features:
 
 ### Sync Pipeline Overview
 
-When `ENABLE_DATA_IMPORT=true`, the container entrypoint executes a sync pipeline:
+The container entrypoint runs this pipeline on every start:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
 │                    Container Startup Pipeline                        │
 ├─────────────────────────────────────────────────────────────────────┤
 │  1. Wait for PostgreSQL                                              │
-│  2. Run Alembic migrations                                           │
-│  3. Create admin user (if credentials set)                           │
-│  4. ENABLE_DATA_IMPORT=true?                                         │
-│     ├── Initialize reference data (GRCh38 + HNF1B) ─────────────────│─► Idempotent
+│  2. Run Alembic migrations ─────────────────────────────────────────│─► Idempotent (every start)
+│  3. Ensure reference data (GRCh38 + HNF1B + transcript/exons/        │
+│     domains + cross-refs) ──────────────────────────────────────────│─► Idempotent (every start)
+│  4. Create admin user (if credentials set)                           │
+│  5. ENABLE_DATA_IMPORT=true?  (heavy / external — opt-in)           │
 │     ├── Import phenopackets (if empty) ─────────────────────────────│─► One-time
 │     ├── Sync publication metadata ──────────────────────────────────│─► Idempotent
 │     ├── Sync VEP annotations ───────────────────────────────────────│─► Idempotent
 │     └── Sync chr17q12 genes ────────────────────────────────────────│─► Idempotent
-│  5. Start uvicorn                                                    │
+│  6. Start uvicorn                                                    │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-All sync operations are **idempotent** (safe to run multiple times).
+Reference data is **essential static seed** the app contract depends on
+(`get_gene_context`), so it is initialized on **every** start regardless of
+`ENABLE_DATA_IMPORT`. The heavy/external syncs (phenopackets from Google Sheets,
+PubMed, Ensembl) remain behind `ENABLE_DATA_IMPORT=true`. All steps are
+**idempotent** (safe to run repeatedly).
 
 ### Reference Data Initialization
 
-Initializes core genomic reference data:
+Seeds (and self-heals) core genomic reference data on every container start:
 
 | Data | Description |
 |------|-------------|
 | GRCh38 Genome | Reference genome assembly |
-| HNF1B Gene | chr17:36,098,063-36,112,306 |
+| HNF1B Gene | chr17:36,098,063-36,112,306 + NCBI/HGNC/OMIM cross-refs |
 | NM_000458.4 Transcript | Canonical transcript |
 | Exon coordinates | 9 exons |
 | Protein domains | 4 domains from UniProt P35680 |
 
-**Trigger condition:** Runs if no genome assemblies exist.
+**Idempotency:** each item is created only if missing, and a gene left by the
+chr17q12 region sync without NCBI/HGNC/OMIM cross-references is **healed** (the
+init no longer short-circuits on a coarse "genome exists" check).
 
-**Script:** `backend/scripts/sync_reference_data.py --init`
+**Script:** `backend/scripts/sync_reference_data.py --init` (run manually with
+`make reference-init`).
 
 ### chr17q12 Genes Sync
 


### PR DESCRIPTION
## Problem
`hnf1b_get_gene_context` returned **degraded** reference data — empty `transcripts`/`domains`, null NCBI/HGNC/OMIM cross-refs — on any stack that ran the chr17q12 region sync but not the full reference init (e.g. the local dev stack). It flagged this honestly via `reference_data_status`, but the data was simply never seeded. Three root causes:

1. **`import_hnf1b_gene` not self-healing** — it early-returned on an existing gene, so the authoritative NCBI/HGNC/OMIM cross-refs the region sync leaves blank were never backfilled.
2. **`run_init` coarse skip** — it bailed out ("already initialized") whenever the genome + gene existed, ignoring missing transcripts/exons/domains, leaving a partially-seeded DB stuck. So even `make reference-init` was a no-op.
3. **Entrypoint gated reference init behind `ENABLE_DATA_IMPORT=true`** (off by default) → essential static reference data never got seeded on a normal start.

## Fix (community-standard idempotent bootstrap)
- `import_hnf1b_gene` self-heals missing xrefs from the curated seed (DRY constant shared with the create path); a complete row is untouched.
- `run_init` always runs the idempotent initializer and reports status (no coarse short-circuit).
- The entrypoint runs reference init on **every** start, after migrations, **independent** of `ENABLE_DATA_IMPORT`. Heavy/external syncs (Google Sheets, PubMed, Ensembl) stay opt-in. This matches the standard separation of *idempotent reference seed (every env, every start)* vs *heavy dev/test import (opt-in)*.

## Verification
- New `backend/tests/test_reference_importer.py`: full-chain seed, idempotent re-run (`imported == 0`), and xref self-heal. Passing.
- **Live**: `make reference-init` healed the running DB; `get_gene_context` now returns the gene xrefs (`6928`/`HGNC:11630`/`189907`) + canonical transcript NM_000458.4 + 9 exons + 4 UniProt domains, **no degraded flag**. The rebuilt API container runs the init idempotently on startup (no-op when already seeded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)