### PR TITLE
fix(mcp): remediate 6 findings from MCP QA test pass (#329)

### DIFF
--- a/backend/alembic/versions/f3a9c1d4e7b2_search_mv_phenotype_text.py
+++ b/backend/alembic/versions/f3a9c1d4e7b2_search_mv_phenotype_text.py
@@ -1,0 +1,254 @@
+"""global_search_index: phenopacket branch searchable by phenotype/disease text
+
+Revision ID: f3a9c1d4e7b2
+Revises: e7a1b9c3d2f4
+Create Date: 2026-05-30 11:00:00.000000
+
+Folds disease term labels and non-excluded phenotypicFeatures labels into the
+phenopacket branch ``search_vector`` so ``/search/global`` (and the MCP
+``hnf1b_search`` tool that consumes it) returns individuals for free-text
+clinical queries like "renal cysts" or "diabetes".
+
+The gene / domain / transcript / publication (static) branches and the
+variant branch are byte-for-byte identical to the definition installed by
+b7c1f0a9d2e4 (which is still the live definition at e7a1b9c3d2f4 — no
+intermediate migration altered the MV). Only the phenopacket branch changes:
+``upgrade()`` enriches its ``search_vector`` and ``downgrade()`` restores the
+phenotype-blind (phenopacket_id + subject.id) branch exactly as it stood at
+e7a1b9c3d2f4.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f3a9c1d4e7b2"
+down_revision: Union[str, Sequence[str], None] = "e7a1b9c3d2f4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Shared public-filter fragment (I3 + I7 + I1) — qualified on ``p``.
+_PUBLIC_FILTER = (
+    "p.deleted_at IS NULL"
+    "\n          AND p.state = 'published'"
+    "\n          AND p.head_published_revision_id IS NOT NULL"
+)
+
+# Synthetic-record exclusion (e2e fixtures must not surface in public search).
+_NO_E2E = "p.phenopacket_id NOT LIKE 'e2e-%'"
+
+DROP_GLOBAL_SEARCH_MV = "DROP MATERIALIZED VIEW IF EXISTS global_search_index;"
+
+MV_INDEXES = [
+    "CREATE UNIQUE INDEX idx_global_search_id ON global_search_index (id);",
+    "CREATE INDEX idx_global_search_vector "
+    "ON global_search_index USING GIN (search_vector);",
+    "CREATE INDEX idx_global_search_label_trgm "
+    "ON global_search_index USING GIN (label gin_trgm_ops);",
+    "CREATE INDEX idx_global_search_type ON global_search_index (type);",
+]
+
+# Non-phenopacket/variant branches — identical to b7c1f0a9d2e4 (the live
+# definition at e7a1b9c3d2f4). Shared verbatim by both upgrade/downgrade.
+_STATIC_BRANCHES = """
+-- Genes
+SELECT
+    'gene_' || id::text AS id,
+    symbol AS label,
+    'Gene'::text AS type,
+    'Symbol'::text AS subtype,
+    setweight(to_tsvector('simple', symbol), 'A') ||
+    setweight(to_tsvector('english', COALESCE(name, '')), 'B') AS search_vector,
+    name AS extra_info
+FROM genes
+
+UNION ALL
+
+-- Protein domains
+SELECT
+    'domain_' || id::text AS id,
+    name AS label,
+    'Gene Feature'::text AS type,
+    'Domain'::text AS subtype,
+    to_tsvector('english', name) AS search_vector,
+    short_name AS extra_info
+FROM protein_domains
+
+UNION ALL
+
+-- Transcripts
+SELECT
+    'transcript_' || id::text AS id,
+    transcript_id AS label,
+    'Gene Feature'::text AS type,
+    'Transcript'::text AS subtype,
+    to_tsvector('simple', transcript_id) AS search_vector,
+    NULL::text AS extra_info
+FROM transcripts
+
+UNION ALL
+
+-- Publications with authors
+SELECT
+    'pub_' || pmid AS id,
+    title AS label,
+    'Publication'::text AS type,
+    'Article'::text AS subtype,
+    setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+    setweight(to_tsvector('simple', COALESCE(
+        (SELECT string_agg(a->>'name', ' ') FROM jsonb_array_elements(authors) AS a),
+        ''
+    )), 'B') ||
+    setweight(to_tsvector('english', COALESCE(journal, '')), 'C') AS search_vector,
+    journal AS extra_info
+FROM publication_metadata
+WHERE title IS NOT NULL
+"""
+
+# Variant branch — identical to b7c1f0a9d2e4 (resolvable descriptor ids;
+# deduplicated by descriptor_id; published-only; e2e excluded).
+_VARIANT_BRANCH = f"""
+-- Variants (deduplicated by resolvable VRS/CNV descriptor id; published-only)
+SELECT * FROM (
+    SELECT DISTINCT ON (descriptor_id)
+        'var_' || descriptor_id AS id,
+        variant_label AS label,
+        'Variant'::text AS type,
+        molecule_context AS subtype,
+        to_tsvector('simple', search_text) AS search_vector,
+        pathogenicity AS extra_info
+    FROM (
+        SELECT
+            gi.value->'variantInterpretation'->'variationDescriptor'->>'id'
+                AS descriptor_id,
+            COALESCE(
+                gi.value->'variantInterpretation'->'variationDescriptor'->>'label',
+                COALESCE(
+                    gi.value->'variantInterpretation'->'variationDescriptor'
+                        ->'geneContext'->>'symbol',
+                    'Unknown'
+                ) || ':' || COALESCE(
+                    (gi.value->'variantInterpretation'->'variationDescriptor'
+                        ->'expressions'->0)->>'value',
+                    'unknown'
+                )
+            ) AS variant_label,
+            COALESCE(
+                gi.value->'variantInterpretation'->'variationDescriptor'
+                    ->>'moleculeContext',
+                'genomic'
+            ) AS molecule_context,
+            COALESCE(
+                gi.value->'variantInterpretation'->'variationDescriptor'->>'label', ''
+            ) || ' ' ||
+            COALESCE(
+                gi.value->'variantInterpretation'->'variationDescriptor'
+                    ->'geneContext'->>'symbol', ''
+            ) || ' ' ||
+            COALESCE((
+                SELECT string_agg(e->>'value', ' ')
+                FROM jsonb_array_elements(
+                    gi.value->'variantInterpretation'->'variationDescriptor'
+                        ->'expressions'
+                ) AS e
+            ), '') AS search_text,
+            gi.value->'variantInterpretation'
+                ->>'acmgPathogenicityClassification' AS pathogenicity
+        FROM phenopackets p
+        JOIN phenopacket_revisions r ON r.id = p.head_published_revision_id,
+             LATERAL jsonb_array_elements(
+                 r.content_jsonb->'interpretations') AS interp,
+             LATERAL jsonb_array_elements(
+                 interp.value->'diagnosis'->'genomicInterpretations') AS gi
+        WHERE {_PUBLIC_FILTER}
+          AND {_NO_E2E}
+          AND gi.value->'variantInterpretation'->'variationDescriptor'->>'id'
+              IS NOT NULL
+    ) AS raw_variants
+    ORDER BY descriptor_id, variant_label
+) AS unique_variants;
+"""
+
+# Phenopacket branch — ENRICHED. phenopacket_id + subject.id stay weight 'A'
+# (verbatim from b7c1f0a9d2e4); disease term labels join at weight 'B' and
+# non-excluded phenotypicFeatures labels at weight 'C'.
+_PHENO_BRANCH_NEW = f"""
+-- Phenopackets (phenotype/disease text searchable; published-only)
+SELECT
+    'pp_' || p.phenopacket_id AS id,
+    COALESCE(r.content_jsonb->'subject'->>'id', p.phenopacket_id) AS label,
+    'Phenopacket'::text AS type,
+    'Individual'::text AS subtype,
+    setweight(to_tsvector(
+        'simple',
+        p.phenopacket_id || ' '
+            || COALESCE(r.content_jsonb->'subject'->>'id', '')
+    ), 'A') ||
+    setweight(to_tsvector('english', COALESCE((
+        SELECT string_agg(DISTINCT d->'term'->>'label', ' ')
+        FROM jsonb_array_elements(r.content_jsonb->'diseases') AS d
+    ), '')), 'B') ||
+    setweight(to_tsvector('english', COALESCE((
+        SELECT string_agg(DISTINCT pf->'type'->>'label', ' ')
+        FROM jsonb_array_elements(r.content_jsonb->'phenotypicFeatures') AS pf
+        WHERE COALESCE((pf->>'excluded')::boolean, false) = false
+    ), '')), 'C') AS search_vector,
+    NULL::text AS extra_info
+FROM phenopackets p
+JOIN phenopacket_revisions r ON r.id = p.head_published_revision_id
+WHERE {_PUBLIC_FILTER}
+  AND {_NO_E2E}
+"""
+
+# Phenopacket branch — PREVIOUS (phenotype-blind), for downgrade(). This is the
+# exact branch installed by b7c1f0a9d2e4 and still live at e7a1b9c3d2f4:
+# phenopacket_id + subject.id only, single 'simple' to_tsvector (no weights).
+_PHENO_BRANCH_PREV = f"""
+-- Phenopackets (head-published content; published-only; phenopacket_id searchable)
+SELECT
+    'pp_' || p.phenopacket_id AS id,
+    COALESCE(r.content_jsonb->'subject'->>'id', p.phenopacket_id) AS label,
+    'Phenopacket'::text AS type,
+    'Individual'::text AS subtype,
+    to_tsvector(
+        'simple',
+        p.phenopacket_id || ' '
+            || COALESCE(r.content_jsonb->'subject'->>'id', '')
+    ) AS search_vector,
+    NULL::text AS extra_info
+FROM phenopackets p
+JOIN phenopacket_revisions r ON r.id = p.head_published_revision_id
+WHERE {_PUBLIC_FILTER}
+  AND {_NO_E2E}
+"""
+
+# Branch order matches the live MV (b7c1f0a9d2e4): static, phenopacket, variant.
+CREATE_MV_NEW = (
+    "CREATE MATERIALIZED VIEW global_search_index AS\n"
+    f"{_STATIC_BRANCHES}\nUNION ALL\n{_PHENO_BRANCH_NEW}\nUNION ALL\n{_VARIANT_BRANCH}"
+)
+CREATE_MV_PREV = (
+    "CREATE MATERIALIZED VIEW global_search_index AS\n"
+    f"{_STATIC_BRANCHES}\nUNION ALL\n{_PHENO_BRANCH_PREV}\nUNION ALL\n{_VARIANT_BRANCH}"
+)
+
+
+def _recreate_indexes() -> None:
+    for stmt in MV_INDEXES:
+        op.execute(stmt)
+
+
+def upgrade() -> None:
+    """Rebuild global_search_index with a phenotype/disease-searchable phenopacket branch."""
+    op.execute(DROP_GLOBAL_SEARCH_MV)
+    op.execute(CREATE_MV_NEW)
+    _recreate_indexes()
+
+
+def downgrade() -> None:
+    """Restore the e7a1b9c3d2f4 phenotype-blind phenopacket branch (== b7c1f0a9d2e4)."""
+    op.execute(DROP_GLOBAL_SEARCH_MV)
+    op.execute(CREATE_MV_PREV)
+    _recreate_indexes()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -326,6 +326,23 @@ class PublicationsRagConfig(BaseModel):
     # Default candidate pool sizes for the two retrieval legs before fusion.
     lexical_candidate_limit: int = 50
     dense_candidate_limit: int = 50
+    # Minimum lexical relevance floor (recall fix): the OR-recall ``to_tsquery``
+    # leg matches any passage sharing one English token with the query, so
+    # without a floor, gibberish-plus-common-words queries surface
+    # confident-looking passages. Candidates whose computed ``ts_rank_cd``
+    # ``lex_score`` falls below this are dropped before fusion.
+    min_lex_score: float = Field(
+        default=0.15,
+        ge=0.0,
+        description=(
+            "Minimum ts_rank_cd lexical score a passage must reach to be a "
+            "candidate. 0.0 disables the floor (legacy behavior). A small "
+            "positive value drops OR-recall-only noise: the weak "
+            "``to_tsquery`` leg scores incidental single-token overlaps at "
+            "~0.1 while phrase/websearch hits score >= 0.2, so 0.15 cleanly "
+            "separates them."
+        ),
+    )
 
 
 class YamlConfig(BaseModel):

--- a/backend/app/phenopackets/routers/aggregations/publications.py
+++ b/backend/app/phenopackets/routers/aggregations/publications.py
@@ -89,27 +89,19 @@ async def get_publications_timeline(
         ]
     """
     # Public endpoint — apply public visibility filter (I3 + I7)
+    # Year comes from the publication_metadata cache (run `make publications-sync`).
+    # Publications without cached metadata have NULL year and are excluded.
     query = """
     WITH publication_years AS (
         SELECT
             p.phenopacket_id,
-            p.created_at,
             ext_ref->>'id' as pmid,
-            COALESCE(
-                NULLIF(
-                    regexp_replace(
-                        ext_ref->>'description',
-                        '.*[, ](\\d{4}).*',
-                        '\\1'
-                    ),
-                    ext_ref->>'description'
-                )::integer,
-                EXTRACT(YEAR FROM p.created_at)::integer
-            ) as pub_year
+            pm.year as pub_year
         FROM phenopackets p,
             jsonb_array_elements(
                 p.phenopacket->'metaData'->'externalReferences'
             ) as ext_ref
+        LEFT JOIN publication_metadata pm ON pm.pmid = ext_ref->>'id'
         WHERE p.deleted_at IS NULL
           AND p.state = 'published'
           AND p.head_published_revision_id IS NOT NULL

--- a/backend/app/publications/fulltext/retrieval.py
+++ b/backend/app/publications/fulltext/retrieval.py
@@ -85,14 +85,22 @@ async def _lexical_candidates(
 
     filter_sql, params = _apply_filters(params, pmids, sections)
 
+    # Lexical relevance floor (recall fix): the OR-recall ``to_tsquery`` leg
+    # matches any passage sharing one English token with the query, so without a
+    # floor weak-only hits look as confident as strong ones after RRF re-ranks by
+    # rank. Wrap the candidate selection in a CTE that computes ``lex_score`` and
+    # drop rows below the configured floor. ``min_lex_score == 0.0`` makes the
+    # predicate a no-op (legacy behavior preserved).
+    params["min_lex_score"] = float(settings.publications_rag.min_lex_score)
     sql = (
-        f"WITH q AS (SELECT {', '.join(q_ctes)}) "
-        "SELECT f.pmid, f.passage_id, f.section, f.seq, f.text, "
+        f"WITH q AS (SELECT {', '.join(q_ctes)}), "
+        "cand AS (SELECT f.pmid, f.passage_id, f.section, f.seq, f.text, "
         "f.char_count, f.token_count, f.source, "
         f"GREATEST({', '.join(select_rank)}) AS lex_score "
         "FROM publication_fulltext f, q "
-        f"WHERE {''.join(where)}{filter_sql} "
-        "ORDER BY lex_score DESC, f.pmid, f.seq "
+        f"WHERE {''.join(where)}{filter_sql}) "
+        "SELECT * FROM cand WHERE lex_score >= :min_lex_score "
+        "ORDER BY lex_score DESC, pmid, seq "
         "LIMIT :lex_limit"
     )
     stmt = _with_filter_bindparams(text(sql), pmids, sections)

--- a/backend/tests/test_aggregations_endpoints.py
+++ b/backend/tests/test_aggregations_endpoints.py
@@ -117,3 +117,95 @@ class TestAggregationTimelineEndpoints:
 
         body = response.json()
         assert isinstance(body, list)
+
+
+@pytest.mark.asyncio
+class TestPublicationsTimelineYearCorrectness:
+    """Regression: timeline must bucket by publication_metadata.year, not created_at."""
+
+    async def _seed_published_phenopacket_citing(
+        self, db_session, admin_user, phenopacket_id: str, pmid: str
+    ) -> None:
+        """Insert a published phenopacket whose externalReferences cite ``pmid``.
+
+        The timeline only counts PMIDs cited by a *published* phenopacket
+        (``state='published'`` AND ``head_published_revision_id IS NOT NULL``),
+        so we mirror the ``published_record`` conftest fixture: insert the
+        phenopacket, flush to get its id, create the head revision, then point
+        ``head_published_revision_id`` at it. Without this the timeline would
+        be empty and the regression assertion would pass trivially.
+        """
+        from app.phenopackets.models import Phenopacket, PhenopacketRevision
+
+        content = {
+            "id": phenopacket_id,
+            "metaData": {
+                "externalReferences": [
+                    {"id": pmid, "description": "no year in this string"}
+                ]
+            },
+        }
+        pp = Phenopacket(
+            phenopacket_id=phenopacket_id,
+            phenopacket=content,
+            state="published",
+            revision=1,
+            created_by_id=admin_user.id,
+        )
+        db_session.add(pp)
+        await db_session.flush()
+
+        rev = PhenopacketRevision(
+            record_id=pp.id,
+            revision_number=1,
+            state="published",
+            content_jsonb=content,
+            change_reason="init",
+            actor_id=admin_user.id,
+            from_state=None,
+            to_state="published",
+            is_head_published=True,
+        )
+        db_session.add(rev)
+        await db_session.flush()
+
+        pp.head_published_revision_id = rev.id
+
+    async def test_timeline_buckets_by_real_publication_year(
+        self, async_client: AsyncClient, db_session, admin_user
+    ) -> None:
+        """Seeded publications must bucket by their real metadata year, never the import year."""
+        from sqlalchemy import text as _text
+
+        # Two cached publications with distinct, non-current years.
+        # ``authors`` is NOT NULL in the schema, so we pass an empty JSON array.
+        await db_session.execute(
+            _text(
+                "INSERT INTO publication_metadata (pmid, title, authors, year) "
+                "VALUES "
+                "('PMID:11111111', 'Old paper', '[]'::jsonb, 2008), "
+                "('PMID:22222222', 'Newer paper', '[]'::jsonb, 2017) "
+                "ON CONFLICT (pmid) DO UPDATE SET year = EXCLUDED.year"
+            )
+        )
+
+        # Attach the seeded PMIDs to published phenopackets so they are counted.
+        await self._seed_published_phenopacket_citing(
+            db_session, admin_user, "timeline-year-test-1", "PMID:11111111"
+        )
+        await self._seed_published_phenopacket_citing(
+            db_session, admin_user, "timeline-year-test-2", "PMID:22222222"
+        )
+        await db_session.commit()
+
+        resp = await async_client.get(
+            "/api/v2/phenopackets/aggregate/publications-timeline"
+        )
+        assert resp.status_code == 200, resp.text
+        years = {row["year"] for row in resp.json()}
+        # The bug bucketed everything under the import year (2026). The fix must
+        # surface each publication's real metadata year via the join to
+        # publication_metadata.year, so the seeded years must actually appear
+        # (proving a non-empty timeline) and the import year must never leak in.
+        assert {2008, 2017}.issubset(years), resp.json()
+        assert 2026 not in years, resp.json()

--- a/backend/tests/test_fulltext_retrieval.py
+++ b/backend/tests/test_fulltext_retrieval.py
@@ -214,6 +214,51 @@ async def test_rrf_falls_back_when_no_embeddings_stored(db_session):
 
 
 @pytest.mark.asyncio
+async def test_min_lex_score_floor_drops_weak_only_matches(db_session, monkeypatch):
+    """A query that matches only via the weak OR-recall leg is filtered by the floor.
+
+    The seeded corpus is the four ``_PASSAGES`` for ``PMID:1``. The ``strong``
+    query ("renal cysts diabetes") hits the results passage via the phrase leg
+    and scores ``ts_rank_cd`` ~0.3, well above the floor. The ``junk`` query
+    ("zqxjkv ... disease ... observed ...") shares only incidental single tokens
+    with the corpus and matches *exclusively* through the weak OR-recall
+    ``to_tsquery`` leg, which scores ~0.1 — so the floor (0.15) removes it.
+
+    The floor is applied to ``lex_score`` inside ``_lexical_candidates`` (before
+    RRF fusion), so a filtered junk query yields no candidates at all and the
+    fused result is empty. (The final ``.score`` on a returned passage is the
+    fused RRF score, not the raw lexical score, so the empty-list arm is the
+    load-bearing assertion here.)
+    """
+    await _seed(db_session)
+
+    # A strong query still returns its target above the floor.
+    strong = await search_passages(
+        db_session, query="renal cysts diabetes", rerank="lexical", limit=8
+    )
+    assert strong.passages
+    assert any(p.pmid == PMID for p in strong.passages)
+
+    # A query whose only overlap with the corpus is incidental common tokens
+    # ("disease", "observed") must return nothing once the floor is applied.
+    from app.core.config import get_settings
+
+    # Pin the floor the assertion depends on, independent of the config default.
+    monkeypatch.setattr(
+        get_settings().publications_rag, "min_lex_score", 0.15, raising=False
+    )
+    junk = await search_passages(
+        db_session,
+        query="zqxjkv unrelated disease was observed elsewhere",
+        rerank="lexical",
+        limit=8,
+    )
+    assert (
+        junk.passages == []
+    )  # floor applied pre-fusion drops the OR-recall-only candidates entirely
+
+
+@pytest.mark.asyncio
 async def test_invalid_rerank_and_mode_raise(db_session):
     with pytest.raises(ValueError):
         await search_passages(db_session, "x", rerank="bogus")

--- a/backend/tests/test_global_search.py
+++ b/backend/tests/test_global_search.py
@@ -814,3 +814,116 @@ class TestGlobalSearchVisibility:
                 text("REFRESH MATERIALIZED VIEW global_search_index")
             )
             await db_session.commit()
+
+
+# ============================================================================
+# Workstream C: individuals must be searchable by phenotype/disease free text.
+# The global_search_index phenopacket branch must fold disease term labels and
+# non-excluded phenotypicFeatures labels into its search_vector so that
+# /search/global (and the MCP hnf1b_search tool that consumes it) returns
+# ``pp_`` hits for queries like "renal cysts" / "diabetes".
+# ============================================================================
+
+
+class TestGlobalSearchPhenotypeText:
+    """The global_search_index must match individuals by clinical free text."""
+
+    @pytest.mark.asyncio
+    async def test_global_search_matches_individual_by_phenotype_text(
+        self, async_client, db_session: AsyncSession, published_record
+    ):
+        """A published individual must be findable by its disease term label."""
+        await db_session.execute(
+            text(
+                "UPDATE phenopacket_revisions SET content_jsonb = "
+                "jsonb_set(content_jsonb, '{diseases}', "
+                '\'[{"term": {"id": "MONDO:0011593", '
+                '"label": "Renal cysts and diabetes syndrome"}}]\'::jsonb) '
+                "WHERE id = (SELECT head_published_revision_id FROM phenopackets "
+                "WHERE phenopacket_id = :pid)"
+            ),
+            {"pid": published_record.phenopacket_id},
+        )
+        await db_session.commit()
+        await db_session.execute(text("REFRESH MATERIALIZED VIEW global_search_index"))
+        await db_session.commit()
+
+        try:
+            resp = await async_client.get(
+                "/api/v2/search/global",
+                params={"q": "renal cysts", "page_size": 20},
+            )
+            assert resp.status_code == 200, resp.text
+            ids = [r["id"] for r in resp.json()["results"]]
+            assert any(i.startswith("pp_") for i in ids), resp.json()
+        finally:
+            await db_session.execute(
+                text("REFRESH MATERIALIZED VIEW global_search_index")
+            )
+            await db_session.commit()
+
+    @pytest.mark.asyncio
+    async def test_global_search_phenotypic_features_weight_c_and_excluded(
+        self, async_client, db_session: AsyncSession, published_record
+    ):
+        """Weight-C phenotypicFeatures are searchable; excluded ones are not.
+
+        Covers two facets of the MV enrichment that the disease-label test
+        (weight B) does not exercise:
+
+        * the ``phenotypicFeatures`` label fold at weight 'C' — a NON-excluded
+          feature must be findable via /search/global, and
+        * the ``WHERE COALESCE((pf->>'excluded')::boolean, false) = false``
+          filter — an EXCLUDED feature must NOT leak into the search_vector.
+
+        The two HPO labels ("Pancreatic hypoplasia" vs "Hyperuricemia") share
+        no search tokens with each other or with the seeded subject/phenopacket
+        id ("wave7-published-1"), so each assertion is unambiguous on a fresh
+        test DB whose only published phenopacket row is this one. The query
+        tokens "hypoplasia" / "hyperuricemia" are chosen so they survive the
+        ``english`` stemming used to build the weight-C lexemes and therefore
+        match the ``simple``-config OR-prefix tsquery the route emits (the same
+        constraint that makes the sibling test use "renal", not "cysts").
+        """
+        await db_session.execute(
+            text(
+                "UPDATE phenopacket_revisions SET content_jsonb = "
+                "jsonb_set(content_jsonb, '{phenotypicFeatures}', "
+                '\'[{"type": {"id": "HP:0012736", '
+                '"label": "Pancreatic hypoplasia"}}, '
+                '{"type": {"id": "HP:0002149", '
+                '"label": "Hyperuricemia"}, "excluded": true}]\'::jsonb) '
+                "WHERE id = (SELECT head_published_revision_id FROM phenopackets "
+                "WHERE phenopacket_id = :pid)"
+            ),
+            {"pid": published_record.phenopacket_id},
+        )
+        await db_session.commit()
+        await db_session.execute(text("REFRESH MATERIALIZED VIEW global_search_index"))
+        await db_session.commit()
+
+        try:
+            # Weight-C path: the NON-excluded feature label is findable.
+            resp = await async_client.get(
+                "/api/v2/search/global",
+                params={"q": "hypoplasia", "page_size": 20},
+            )
+            assert resp.status_code == 200, resp.text
+            ids = [r["id"] for r in resp.json()["results"]]
+            assert any(i.startswith("pp_") for i in ids), resp.json()
+
+            # Excluded filter: the EXCLUDED feature label is NOT findable.
+            # Without the migration's ``WHERE ... excluded ... = false`` guard
+            # this query WOULD return a pp_ hit, so the assertion guards it.
+            resp = await async_client.get(
+                "/api/v2/search/global",
+                params={"q": "hyperuricemia", "page_size": 20},
+            )
+            assert resp.status_code == 200, resp.text
+            ids = [r["id"] for r in resp.json()["results"]]
+            assert not any(i.startswith("pp_") for i in ids), resp.json()
+        finally:
+            await db_session.execute(
+                text("REFRESH MATERIALIZED VIEW global_search_index")
+            )
+            await db_session.commit()

--- a/mcp/src/hnf1b_mcp/services/individuals.py
+++ b/mcp/src/hnf1b_mcp/services/individuals.py
@@ -278,9 +278,21 @@ async def get_individual(
         A plain dict with shaped individual data, projected to *response_mode*
         and *fields*.
     """
-    record: dict[str, Any] = await client.get(
-        PHENOPACKETS_BY_PHENOPACKET_ID.format(phenopacket_id=phenopacket_id)
-    )
+    try:
+        record: dict[str, Any] = await client.get(
+            PHENOPACKETS_BY_PHENOPACKET_ID.format(phenopacket_id=phenopacket_id)
+        )
+    except McpToolError as exc:
+        # The shared client raises a generic, value-less not_found on 404. Re-raise
+        # the rich form (field + offending id) to match get_variant, so callers
+        # learn WHICH id was missing. Any other error propagates unchanged.
+        if exc.code == "not_found":
+            raise McpToolError(
+                "not_found",
+                f"individual '{phenopacket_id}' not found",
+                field="phenopacket_id",
+            ) from exc
+        raise
     shaped = _shape_individual(
         record,
         include_phenotypes=include_phenotypes,

--- a/mcp/src/hnf1b_mcp/services/publication_passages.py
+++ b/mcp/src/hnf1b_mcp/services/publication_passages.py
@@ -46,9 +46,10 @@ def _shape_passage(
         citation_map: ``bare_pmid -> {recommended_citation, ...}`` lookup.
 
     Returns:
-        A shaped passage dict carrying the ``passage_id`` citation anchor and
-        the publication's ``recommended_citation``; ``standard``/``full`` add
-        the relevance ``score``, ``seq``, and ``source``.
+        A shaped passage dict carrying the ``passage_id`` citation anchor, the
+        publication's ``recommended_citation``, and the relevance ``score``
+        (emitted in every mode); ``standard``/``full`` add ``seq`` and
+        ``source``.
     """
     pmid = str(passage.get("pmid") or "")
     bare = pmid.replace("PMID:", "")
@@ -66,8 +67,10 @@ def _shape_passage(
         shaped["text"] = text
     if snippet is not None:
         shaped["snippet"] = snippet
+    # Always visible: lets the caller judge relevance even in the default
+    # compact mode (near-zero scores flag weak RAG hits).
+    shaped["score"] = passage.get("score")
     if response_mode in ("standard", "full"):
-        shaped["score"] = passage.get("score")
         shaped["seq"] = passage.get("seq")
         shaped["source"] = passage.get("source")
     return shaped

--- a/mcp/src/hnf1b_mcp/services/publications.py
+++ b/mcp/src/hnf1b_mcp/services/publications.py
@@ -289,7 +289,19 @@ async def get_publication_citing_individuals(
 
     # The endpoint returns a BARE JSON LIST, not a JSON:API envelope.
     # Shape: [{"phenopacket_id": "...", "phenopacket": {...}}, ...]
-    raw = await client.get(path)
+    try:
+        raw = await client.get(path)
+    except McpToolError as exc:
+        # The shared client raises a generic, value-less not_found on 404. Re-raise
+        # the rich form (field + offending pmid) to match get_variant, so callers
+        # learn WHICH pmid was missing. Any other error propagates unchanged.
+        if exc.code == "not_found":
+            raise McpToolError(
+                "not_found",
+                f"publication '{pmid}' not found",
+                field="citing_pmid",
+            ) from exc
+        raise
 
     # Normalise: the endpoint returns a bare list; client.get returns Any.
     items: list[dict[str, Any]]

--- a/mcp/src/hnf1b_mcp/services/reference.py
+++ b/mcp/src/hnf1b_mcp/services/reference.py
@@ -11,6 +11,7 @@ from ..contract._generated_paths import (
     REFERENCE_GENES_BY_SYMBOL_DOMAINS,
     REFERENCE_GENES_BY_SYMBOL_TRANSCRIPTS,
 )
+from .errors import McpToolError
 from .shaping import apply_budget
 
 _HARD_CAP = 80_000
@@ -49,9 +50,21 @@ async def get_gene_context(
     """
     params: dict[str, Any] = {"genome_build": genome_build}
 
-    gene: dict[str, Any] = await client.get(
-        REFERENCE_GENES_BY_SYMBOL.format(symbol=gene_symbol), params=params
-    )
+    try:
+        gene: dict[str, Any] = await client.get(
+            REFERENCE_GENES_BY_SYMBOL.format(symbol=gene_symbol), params=params
+        )
+    except McpToolError as exc:
+        # The shared client raises a generic, value-less not_found on 404. Re-raise
+        # the rich form (field + offending symbol) to match get_variant, so callers
+        # learn WHICH gene was missing. Any other error propagates unchanged.
+        if exc.code == "not_found":
+            raise McpToolError(
+                "not_found",
+                f"gene '{gene_symbol}' not found",
+                field="gene_symbol",
+            ) from exc
+        raise
 
     result: dict[str, Any] = {
         "gene": gene,

--- a/mcp/src/hnf1b_mcp/services/variants.py
+++ b/mcp/src/hnf1b_mcp/services/variants.py
@@ -170,6 +170,72 @@ _ROW_FIELDS_BY_MODE: dict[str, tuple[str, ...]] = {
 }
 
 
+# Scalar field policy for the single-variant detail payload (get_variant), by
+# response mode. Mirrors get_individual's _INDIVIDUAL_FIELDS_BY_MODE and the
+# sibling search_variants._ROW_FIELDS_BY_MODE in this file so the documented
+# response_mode knob actually trims the field set — without it a low-carrier
+# variant (already under the smallest char budget) returned an identical payload
+# for minimal/compact/standard/full because only the carriers LIST was
+# budget-trimmed.
+#
+# Design (honoring the established get_variant contract — see test_variants.py /
+# test_tool_variants.py): ``_DETAIL_ALWAYS`` are the identity + summary keys plus
+# the chainable ``carriers`` list, kept in EVERY mode so the documented
+# carriers -> hnf1b_get_individuals workflow and the carriers char-budget trim
+# (which operates on the carriers list in any mode) keep working. The tiers form
+# a STRICT ladder so the knob can never silently re-collapse:
+#   * minimal  = identity + interpretation (classification/consequence) only;
+#   * compact  = + gene_symbol + structural_type;
+#   * standard = + the genomic-coordinate block (hg38/transcript/protein);
+#   * full     = keep-all (() == keep every field), which additionally surfaces
+#                the provenance prose (data_provenance + note).
+# This yields minimal(8) ⊊ compact(10) ⊊ standard(13) ⊊ full(15), matching the
+# get_individual and search_variants ladders.
+_DETAIL_ALWAYS = (
+    "variant_id",
+    "simple_id",
+    "label",
+    "uri",
+    "carrier_count",
+    "carriers",
+)
+_DETAIL_FIELDS_BY_MODE: dict[str, tuple[str, ...]] = {
+    "minimal": _DETAIL_ALWAYS + ("classification", "consequence"),
+    "compact": _DETAIL_ALWAYS
+    + ("classification", "consequence", "gene_symbol", "structural_type"),
+    "standard": _DETAIL_ALWAYS
+    + (
+        "classification",
+        "consequence",
+        "gene_symbol",
+        "structural_type",
+        "hg38",
+        "transcript",
+        "protein",
+    ),
+    "full": (),  # () == keep every field (adds data_provenance + note)
+}
+
+
+def _project_variant_detail(result: dict[str, Any], mode: str) -> dict[str, Any]:
+    """Trim the detail dict to the field set allowed for ``mode`` (full keeps all).
+
+    Args:
+        result: The fully-built single-variant detail dict (output of
+            :func:`get_variant` before budgeting).
+        mode: One of ``minimal``, ``compact``, ``standard``, ``full``.
+
+    Returns:
+        A new dict containing only the keys permitted in *mode*; ``full`` (or an
+        unknown mode) returns the dict unchanged.
+    """
+    allowed = _DETAIL_FIELDS_BY_MODE.get(mode, ())
+    if not allowed:
+        return result
+    keep = set(allowed) | set(_DETAIL_ALWAYS)
+    return {k: v for k, v in result.items() if k in keep}
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -444,10 +510,13 @@ async def get_variant(
         variant_id: The canonical variant identifier (e.g.
             ``"var:HNF1B:17:36459258-37832869:DEL"``) or the friendly
             ``simple_id`` (e.g. ``"Var6"``).
-        response_mode: Verbosity tier bounding the carrier-list size — one of
-            ``minimal``/``compact``/``standard``/``full``. ``carrier_count`` (the
-            true total) is always preserved; only the ``carriers`` list is
-            trimmed to fit the mode's char budget, with a truncation signal.
+        response_mode: One of ``minimal``/``compact``/``standard``/``full``;
+            controls how much of the record is returned. Narrower modes trim the
+            scalar field set per the per-mode policy (full keeps every field,
+            including ``data_provenance`` + ``note``), AND bound the carriers
+            list size. ``carrier_count`` (the true total) is always preserved;
+            only the ``carriers`` list is trimmed to fit the mode's char budget,
+            with a truncation signal.
 
     Returns:
         A dict with the full variant record: ``variant_id``, ``simple_id``,
@@ -525,12 +594,26 @@ async def get_variant(
         ),
     }
 
+    # Project the SCALAR field set to the requested mode first. Narrower modes
+    # graduate the scalar coordinate fields and drop the provenance prose
+    # (data_provenance + note); the identity/summary keys AND the chainable
+    # ``carriers`` list (all in _DETAIL_ALWAYS) are retained in EVERY mode. This
+    # is what makes a low-carrier variant — already under the smallest budget —
+    # return a genuinely smaller payload for narrower modes. Without it the
+    # budget step below (which only trims the carriers LIST) left minimal ==
+    # standard == full for most variants.
+    result = _project_variant_detail(result, response_mode)
+
     # Enforce the response_mode char budget. A high-carrier variant (e.g. the
     # recurrent 17q12 deletion has ~379 carriers ≈ 7.8 KB) otherwise blows the
     # minimal (4 KB) / compact (12 KB) budget — the documented response_mode knob
-    # was previously a no-op here. ``carrier_count`` stays accurate; only the
-    # ``carriers`` list is trimmed, with a machine-readable truncation signal so
-    # the omission is never silent and the caller can still page carriers.
+    # was previously a no-op here. ``carriers`` is always present (it is in
+    # _DETAIL_ALWAYS, so it survives the projection above in every mode), so this
+    # step genuinely trims the carriers LIST contents down to the mode's char
+    # budget — a real trim in minimal/compact, not a no-op. ``carrier_count``
+    # stays accurate; only the ``carriers`` list shrinks, with a machine-readable
+    # truncation signal so the omission is never silent and the caller can still
+    # page carriers.
     budget = Settings().mode_char_budgets.get(response_mode, 12000)
     result, dropped = apply_budget(result, budget, ["carriers"])
     if dropped:

--- a/mcp/src/hnf1b_mcp/tools/individuals.py
+++ b/mcp/src/hnf1b_mcp/tools/individuals.py
@@ -290,13 +290,21 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
 
             seen: dict[str, None] = {}
             capped = False
+            # Track per-term hits so a well-formed but unmatched HPO id (e.g.
+            # HP:9999999) is reported in unmatched_hpo_ids rather than silently
+            # vanishing into an empty cohort indistinguishable from a real match.
+            per_term_hit: dict[str, bool] = {}
             for hpo_id in hpo_ids:
                 matched, term_capped = await _collect_matches(hpo_id)
                 capped = capped or term_capped
+                per_term_hit[hpo_id] = per_term_hit.get(hpo_id, False) or bool(matched)
                 for item_id in matched:
                     if item_id not in seen:
                         seen[item_id] = None
             merged_ids = list(seen.keys())
+            # Deterministic input-order list of well-formed HPO ids that matched
+            # zero individuals. Always emitted on both return paths.
+            unmatched_hpo_ids = [h for h, hit in per_term_hit.items() if not hit]
             total = len(merged_ids)
             has_more = total > page_size
 
@@ -309,6 +317,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
                     "has_more": False,
                     "match_mode": "any",
                     "hpo_ids": list(hpo_ids),
+                    "unmatched_hpo_ids": unmatched_hpo_ids,
                 }
 
             result = await individuals_service.get_individuals(
@@ -324,6 +333,10 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
             result["has_more"] = has_more
             result["match_mode"] = "any"
             result["hpo_ids"] = list(hpo_ids)
+            # HPO-scoped key set explicitly so it is ALWAYS present and never
+            # collides with the batch-coverage `not_found` key get_individuals
+            # may set for missing phenopacket ids.
+            result["unmatched_hpo_ids"] = unmatched_hpo_ids
             if capped:
                 result["_meta"] = {
                     "total_is_capped": True,

--- a/mcp/src/hnf1b_mcp/tools/publication_passages.py
+++ b/mcp/src/hnf1b_mcp/tools/publication_passages.py
@@ -65,9 +65,9 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
                 back to lexical otherwise), ``lexical``, or ``off``.
             limit: Maximum passages to return (default 8).
             response_mode: Token budget / verbosity — one of ``minimal``,
-                ``compact`` (default), ``standard``, ``full``.
-                ``standard``/``full`` also include per-passage ``score``,
-                ``seq``, and ``source``.
+                ``compact`` (default), ``standard``, ``full``. Every mode
+                includes the per-passage relevance ``score``;
+                ``standard``/``full`` add ``seq`` and ``source``.
 
         Returns:
             A dict with ``query``, ``passages`` (each with ``passage_id``,

--- a/mcp/tests/test_tool_individuals.py
+++ b/mcp/tests/test_tool_individuals.py
@@ -465,4 +465,63 @@ async def test_find_individuals_by_phenotype_empty_search_result():
 
     assert sc["data_class"] == "curated_hnf1b_evidence"
     assert sc["total"] == 0
+    # A well-formed-yet-unmatched HPO id must be flagged, not silently dropped.
+    assert sc["unmatched_hpo_ids"] == ["HP:9999999"]
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_find_by_phenotype_reports_partial_unmatched():
+    # HP:0000107 (first call) matches A; HP:9999999 (second call) does not.
+    call_count = 0
+
+    def search_side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(200, json={"data": [{"id": "A"}]})
+        return httpx.Response(200, json={"data": []})
+
+    respx.get(f"{BASE}/phenopackets/search").mock(side_effect=search_side_effect)
+    respx.get(f"{BASE}/phenopackets/batch").mock(
+        return_value=httpx.Response(200, json={"results": [_PHENOPACKET_A]})
+    )
+    client = ApiClient(base_url=BASE)
+    mcp = FastMCP("test")
+    register(mcp, client)
+
+    r = await mcp.call_tool(
+        "hnf1b_find_individuals_by_phenotype",
+        {"hpo_ids": ["HP:0000107", "HP:9999999"]},
+    )
+    sc = r.structured_content
+
+    assert sc["total"] >= 1
+    assert sc["unmatched_hpo_ids"] == ["HP:9999999"]
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_find_by_phenotype_all_matched_reports_empty_unmatched():
+    """The key is ALWAYS present; a fully-matched query reports an empty list."""
+    respx.get(f"{BASE}/phenopackets/search").mock(
+        return_value=httpx.Response(200, json={"data": [{"id": "A"}]})
+    )
+    respx.get(f"{BASE}/phenopackets/batch").mock(
+        return_value=httpx.Response(200, json={"results": [_PHENOPACKET_A]})
+    )
+    client = ApiClient(base_url=BASE)
+    mcp = FastMCP("test")
+    register(mcp, client)
+
+    r = await mcp.call_tool(
+        "hnf1b_find_individuals_by_phenotype",
+        {"hpo_ids": ["HP:0000083"]},
+    )
+    sc = r.structured_content
+
+    assert sc["total"] >= 1
+    assert sc["unmatched_hpo_ids"] == []
     await client.aclose()

--- a/mcp/tests/test_tool_individuals.py
+++ b/mcp/tests/test_tool_individuals.py
@@ -271,6 +271,8 @@ async def test_get_individual_not_found_returns_error_envelope():
 
     assert sc.get("is_error") is True
     assert sc["error"]["code"] == "not_found"
+    assert sc["error"]["field"] == "phenopacket_id"
+    assert "MISSING" in sc["error"]["message"]
     await client.aclose()
 
 

--- a/mcp/tests/test_tool_publication_passages.py
+++ b/mcp/tests/test_tool_publication_passages.py
@@ -122,18 +122,24 @@ async def test_passage_has_citation_and_snippet() -> None:
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_compact_mode_omits_score_but_full_includes_it() -> None:
+async def test_score_present_in_compact_seq_source_only_in_full() -> None:
     _mock_both()
     mcp, client = _make_mcp_and_client()
+
     compact = await mcp.call_tool(
-        "hnf1b_get_publication_passages", {"query": "x", "response_mode": "compact"}
+        "hnf1b_get_publication_passages", {"query": "renal cysts"}
     )
+    p0 = compact.structured_content["passages"][0]
+    assert "score" in p0  # caller can now judge relevance in the default mode
+    assert "seq" not in p0 and "source" not in p0  # still trimmed in compact
+
     full = await mcp.call_tool(
-        "hnf1b_get_publication_passages", {"query": "x", "response_mode": "full"}
+        "hnf1b_get_publication_passages",
+        {"query": "renal cysts", "response_mode": "full"},
     )
+    pf = full.structured_content["passages"][0]
+    assert "score" in pf and "seq" in pf and "source" in pf
     await client.aclose()
-    assert "score" not in compact.structured_content["passages"][0]
-    assert "score" in full.structured_content["passages"][0]
 
 
 @pytest.mark.asyncio

--- a/mcp/tests/test_tool_publications.py
+++ b/mcp/tests/test_tool_publications.py
@@ -303,3 +303,21 @@ async def test_reverse_lookup_pmid_prefix_stripped() -> None:
     # The pmid field echoes the original input, but the API was called without prefix
     assert "citing_individuals" in sc
     assert sc["total"] == 3
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_reverse_lookup_not_found_returns_rich_error_envelope() -> None:
+    """A 404 reverse lookup surfaces a rich not_found (field + pmid echoed)."""
+    respx.get(f"{BASE}/phenopackets/by-publication/999").mock(
+        return_value=httpx.Response(404)
+    )
+    mcp, client = _make_mcp_and_client()
+    r = await mcp.call_tool("hnf1b_get_publications", {"citing_pmid": "999"})
+    await client.aclose()
+
+    sc = r.structured_content
+    assert sc.get("is_error") is True
+    assert sc["error"]["code"] == "not_found"
+    assert sc["error"]["field"] == "citing_pmid"
+    assert "999" in sc["error"]["message"]

--- a/mcp/tests/test_tool_reference.py
+++ b/mcp/tests/test_tool_reference.py
@@ -231,3 +231,25 @@ async def test_response_mode_reflected_in_meta() -> None:
         assert sc["meta"]["response_mode"] == "full"
     finally:
         await client.aclose()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_gene_context_not_found_returns_rich_error_envelope() -> None:
+    """A 404 gene fetch surfaces a rich not_found (field + gene symbol echoed)."""
+    respx.get(f"{BASE}/reference/genes/NOPE").mock(return_value=httpx.Response(404))
+    client = ApiClient(base_url=BASE)
+    try:
+        mcp = FastMCP("test")
+        register(mcp, client)
+        r = await mcp.call_tool(
+            "hnf1b_get_gene_context",
+            {"gene_symbol": "NOPE"},
+        )
+        sc = r.structured_content
+        assert sc.get("is_error") is True
+        assert sc["error"]["code"] == "not_found"
+        assert sc["error"]["field"] == "gene_symbol"
+        assert "NOPE" in sc["error"]["message"]
+    finally:
+        await client.aclose()

--- a/mcp/tests/test_tool_variants.py
+++ b/mcp/tests/test_tool_variants.py
@@ -183,7 +183,11 @@ async def test_get_variant_happy_path():
     mcp = FastMCP("test")
     register(mcp, client)
 
-    r = await mcp.call_tool("hnf1b_get_variant", {"variant_id": "HNF1B:c.494G>A"})
+    # full mode == keep-all, so the data_provenance/note prose is present.
+    r = await mcp.call_tool(
+        "hnf1b_get_variant",
+        {"variant_id": "HNF1B:c.494G>A", "response_mode": "full"},
+    )
     await client.aclose()
 
     sc = r.structured_content

--- a/mcp/tests/test_variants.py
+++ b/mcp/tests/test_variants.py
@@ -475,7 +475,9 @@ async def test_get_variant_returns_full_record():
         return_value=httpx.Response(200, json=CARRIER_RESPONSE)
     )
     client = ApiClient(base_url=BASE)
-    result = await get_variant(client, "HNF1B:c.494G>A")
+    # full mode == keep-all, so the complete authoritative record (including the
+    # genomic-coordinate block + provenance prose) is returned.
+    result = await get_variant(client, "HNF1B:c.494G>A", response_mode="full")
     await client.aclose()
 
     assert result["variant_id"] == "HNF1B:c.494G>A"
@@ -566,6 +568,43 @@ async def test_get_variant_full_mode_keeps_all_carriers():
 
     assert len(result["carriers"]) == 400
     assert "_dropped" not in result
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_variant_minimal_has_fewer_fields_than_full():
+    """The scalar field set forms a STRICT ladder minimal ⊊ compact ⊊ standard ⊊ full.
+
+    response_mode previously only trimmed the carriers LIST, so a low-carrier
+    variant returned an identical field set for every mode. The per-mode scalar
+    projection must make each tier a genuinely smaller subset of the next; the
+    strict-subset chain is the load-bearing regression guard against re-collapse
+    (the "response_mode is inert" bug this task fixes). minimal keeps identity +
+    interpretation; the coordinate block (hg38/transcript/protein) lands in
+    standard; the provenance prose (data_provenance/note) is full-only.
+    """
+    respx.get(f"{BASE}/phenopackets/aggregate/all-variants").mock(
+        return_value=httpx.Response(200, json=ALL_VARIANTS_RESPONSE)
+    )
+    respx.get(f"{BASE}/phenopackets/by-variant/HNF1B:c.494G>A").mock(
+        return_value=httpx.Response(200, json=CARRIER_RESPONSE)
+    )
+    c = ApiClient(base_url=BASE)
+    minimal = set(await get_variant(c, "HNF1B:c.494G>A", response_mode="minimal"))
+    compact = set(await get_variant(c, "HNF1B:c.494G>A", response_mode="compact"))
+    standard = set(await get_variant(c, "HNF1B:c.494G>A", response_mode="standard"))
+    full = set(await get_variant(c, "HNF1B:c.494G>A", response_mode="full"))
+    await c.aclose()
+
+    # Strict ladder: each tier is a proper subset of the next.
+    assert minimal < compact < standard < full
+    assert {"variant_id", "label", "classification", "carrier_count"} <= minimal
+    # The genomic-coordinate block lands in standard, not compact.
+    assert {"hg38", "transcript", "protein"} <= standard
+    assert "hg38" not in compact
+    # Provenance prose is full-only.
+    assert "data_provenance" not in standard and "note" not in standard
+    assert "data_provenance" in full and "note" in full
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Remediates all six defects from the 2026-05-30 MCP QA test pass. Each fix is test-first (TDD red→green), atomically committed, and split across the backend (SQL/aggregations/migration/RAG) and the read-only MCP sidecar (response shaping/error envelopes/field projection).

Closes #329.

## Findings fixed

| # | Severity | Fix | Commit |
|---|----------|-----|--------|
| **A** | HIGH | `publications_timeline` bucketed every publication into the current year — it parsed a non-existent year out of `externalReferences[].description` and fell back to `EXTRACT(YEAR FROM created_at)`. Now joins `publication_metadata` and groups by `pm.year`, matching the sibling endpoints. | `28dbdb8` |
| **B1** | MED-HIGH | Publication-passages RAG hid the per-passage relevance `score` in the default `compact`/`minimal` modes, so weak hits looked authoritative. `score` is now emitted in **every** mode; `seq`/`source` stay standard/full extras. | `b3755e0` |
| **B2** | MED-HIGH | The lexical leg's OR-recall `to_tsquery` matched any passage sharing one English token with the query, with **no score floor**, so gibberish-plus-common-words queries returned confident junk. Added `PublicationsRagConfig.min_lex_score` (default **0.15**) and filter lexical candidates below it (pre-fusion; semantic leg unaffected). | `8d88834` |
| **C** | MED | `hnf1b_search` never returned individuals for free-text clinical queries — the `global_search_index` phenopacket branch indexed only `phenopacket_id`+`subject.id`. New migration `f3a9c1d4e7b2` folds disease term labels (weight B) and non-excluded `phenotypicFeatures` labels (weight C) into the branch `search_vector`. Round-trips cleanly (downgrade restores the prior MV byte-for-byte). | `36d4eb8` |
| **D** | LOW | `hnf1b_get_variant` ignored `response_mode` (minimal == standard == full) because only the `carriers` list was budget-trimmed, never the scalar field set. Added a graduated per-mode projection (`minimal ⊊ compact ⊊ standard ⊊ full`) mirroring `get_individual`; `carriers`/identity keys retained in all modes, provenance/note full-only. | `be634f4` |
| **E** | LOW | `get_individual`, `get_gene_context`, and the reverse-PMID lookup returned a generic value-less `not_found` (unlike `get_variant`). Each now catches the upstream 404 and re-raises a rich `not_found` with `field` + the offending id echoed. | `43e381b` |
| **F** | LOW | `find_individuals_by_phenotype` silently ignored well-formed-but-unmatched HPO ids (e.g. `HP:9999999`). Now tracks per-term hits and always returns `unmatched_hpo_ids` on both the empty and matched paths. | `e93fb8c` |

## Testing

- **MCP** (`cd mcp && make check`): ruff + mypy (strict) + **345 tests** pass.
- **Backend** (`cd backend && make check`): ruff + mypy pass; full suite **1507 passed** under CI conditions (live Postgres 15 + pgvector test DB).
- **Contract gate** (`gen_contract.py` → paths + enums): clean, no diff — these changes do not alter the OpenAPI surface.
- Migration C verified to round-trip (`alembic downgrade -1 && alembic upgrade head`) with the MV definition restored identically.

Every fix follows TDD: the regression test was confirmed red against the bug, then green after the fix. Each commit is atomic with a conventional-commit message.

## Notes for reviewers

- **Pre-existing (not in this PR):** `make contract-verify` reports a diff in `mcp/src/hnf1b_mcp/contract/_generated_models.py` — this is stale on `main` (the full-text RAG merge updated `openapi.snapshot.json` without regenerating the datamodel-codegen models). CI intentionally excludes `_generated_models.py` from its drift guard (it needs datamodel-codegen from PyPI; flaky), so it does not affect this PR's CI gate. Worth a separate housekeeping commit on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
