### PR TITLE
fix(backend): stop test suite leaking the dev .env into config-validation tests

### DIFF
--- a/backend/migration/direct_sheets_to_phenopackets.py
+++ b/backend/migration/direct_sheets_to_phenopackets.py
@@ -26,9 +26,6 @@ from migration.phenopackets.ontology_mapper import OntologyMapper
 from migration.phenopackets.publication_mapper import PublicationMapper
 from migration.phenopackets.reviewer_mapper import ReviewerMapper
 
-# Load environment variables
-load_dotenv()
-
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
@@ -343,6 +340,12 @@ class DirectSheetsToPhenopackets:
 
 async def main():
     """Run the direct migration."""
+    # Load environment variables from .env when run as a CLI. This is kept out
+    # of module scope on purpose: importing this module (e.g. during test
+    # collection) must not mutate os.environ. See
+    # tests/test_migration_import_no_env_side_effects.py.
+    load_dotenv()
+
     # Get database URL from environment
     target_db = os.getenv(
         "DATABASE_URL",

--- a/backend/tests/test_config_email_backend_override.py
+++ b/backend/tests/test_config_email_backend_override.py
@@ -9,6 +9,30 @@ import pytest
 from app.core.config import EmailConfig, Settings, YamlConfig
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_config_env(monkeypatch):
+    """Isolate these Settings-construction tests from ambient env and .env.
+
+    These tests assert production fail-closed behaviour by passing
+    ``environment="production"`` explicitly. A developer's local ``backend/.env``
+    (or a leaked process env var) carrying ``ENABLE_DEV_AUTH=true`` would trip
+    the dev-auth defense validator *before* the email/cookie validators run,
+    masking the behaviour under test. Clear the dev/email/cookie vars the tests
+    drive themselves; this pairs with ``_env_file=None`` at each construction
+    (which blocks the on-disk ``.env``) for full hermeticity.
+    """
+    for var in (
+        "ENABLE_DEV_AUTH",
+        "ENVIRONMENT",
+        "EMAIL_BACKEND",
+        "SMTP_HOST",
+        "SMTP_USERNAME",
+        "SMTP_PASSWORD",
+        "AUTH_COOKIE_SECURE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
 def _build_settings_with_stub_yaml(
     *,
     env_override: str | None,
@@ -37,7 +61,7 @@ def _build_settings_with_stub_yaml(
         kwargs["EMAIL_BACKEND"] = env_override
 
     with patch("app.core.config.load_yaml_config", return_value=yaml_cfg):
-        return Settings(**kwargs)
+        return Settings(_env_file=None, **kwargs)  # type: ignore[call-arg]
 
 
 def test_email_backend_env_overrides_yaml_console_in_production():
@@ -62,6 +86,7 @@ def test_yaml_smtp_default_without_smtp_host_also_fails_closed():
     with pytest.raises(ValueError, match="SMTP_HOST"):
         with patch("app.core.config.load_yaml_config", return_value=yaml_cfg):
             Settings(
+                _env_file=None,  # type: ignore[call-arg]
                 JWT_SECRET="test-secret-key-abc123",
                 ADMIN_PASSWORD="TestAdminPass!2026",
                 environment="production",
@@ -74,6 +99,7 @@ def test_email_backend_env_override_smtp_requires_smtp_host():
     """EMAIL_BACKEND=smtp without SMTP_HOST must fail-closed (validator runs after override)."""
     with pytest.raises(ValueError, match="SMTP_HOST"):
         Settings(
+            _env_file=None,  # type: ignore[call-arg]
             JWT_SECRET="test-secret-key-abc123",
             ADMIN_PASSWORD="TestAdminPass!2026",
             environment="production",

--- a/backend/tests/test_core_config.py
+++ b/backend/tests/test_core_config.py
@@ -46,6 +46,11 @@ def seed_safe_import_env(monkeypatch):
     monkeypatch.setenv("ADMIN_PASSWORD", "validpassword")
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("AUTH_COOKIE_SECURE", "true")
+    # The production-validation tests below pass environment="production" while
+    # relying on enable_dev_auth defaulting to False. Clear any ambient
+    # ENABLE_DEV_AUTH so a leaked process env var cannot trip the dev-auth
+    # defense validator before the email/cookie validators under test run.
+    monkeypatch.delenv("ENABLE_DEV_AUTH", raising=False)
 
 
 def load_config_module():

--- a/backend/tests/test_migration_import_no_env_side_effects.py
+++ b/backend/tests/test_migration_import_no_env_side_effects.py
@@ -1,0 +1,82 @@
+"""Importing migration modules must not mutate the process environment.
+
+Regression: ``migration/direct_sheets_to_phenopackets.py`` called
+``load_dotenv()`` at module top level, so merely *importing* it wrote the
+developer's ``backend/.env`` into ``os.environ``. Because several test modules
+import that module, test collection alone leaked dev-only flags such as
+``ENABLE_DEV_AUTH=true`` into the process environment — which then contaminated
+the production-config validation tests (they construct ``Settings`` and inherit
+the leaked flag even with ``_env_file=None``, because the value is now a real
+process env var rather than a dotenv entry).
+
+Dotenv loading is a CLI concern and belongs in the script entrypoint, not at
+import time. This test pins that invariant by spying on ``dotenv.load_dotenv``
+in a fresh interpreter: importing the migration module must not invoke it.
+A subprocess is used so the assertion is immune to module caching from earlier
+collection, and a self-sufficient env is supplied so the transitive
+``app.core.config`` import succeeds without depending on an on-disk ``.env``
+(e.g. in CI, which has none).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_importing_direct_sheets_migration_does_not_call_load_dotenv(
+    tmp_path: Path,
+) -> None:
+    """Importing the migration module must not call load_dotenv() at import time."""
+    backend_dir = Path(__file__).resolve().parent.parent
+
+    # Spy on dotenv.load_dotenv BEFORE importing the module. The module binds
+    # its name via ``from dotenv import load_dotenv`` during its own import,
+    # which runs after this patch, so it picks up the spy. An import-time call
+    # flips the flag; a call deferred to main() does not.
+    script = textwrap.dedent(
+        """
+        import sys
+        import dotenv
+
+        called = {"at_import": False}
+        _orig = dotenv.load_dotenv
+
+        def _spy(*args, **kwargs):
+            called["at_import"] = True
+            return _orig(*args, **kwargs)
+
+        dotenv.load_dotenv = _spy
+
+        import migration.direct_sheets_to_phenopackets  # noqa: F401
+
+        sys.exit(1 if called["at_import"] else 0)
+        """
+    )
+
+    # Self-sufficient env so app.core.config's module-level Settings() builds
+    # cleanly without reading any on-disk .env (cwd is an empty tmp dir).
+    child_env = {
+        "PYTHONPATH": str(backend_dir),
+        "PATH": "/usr/bin:/bin",
+        "JWT_SECRET": "0" * 64,
+        "ADMIN_PASSWORD": "TestAdminPass!2026",
+        "DATABASE_URL": "postgresql+asyncpg://x:x@localhost:5432/x_test",
+        "ENVIRONMENT": "development",
+    }
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env=child_env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        "migration.direct_sheets_to_phenopackets called load_dotenv() at import "
+        "time — that mutates os.environ for the whole process and leaks the dev "
+        f".env into the test suite. stdout={result.stdout!r} stderr={result.stderr!r}"
+    )


### PR DESCRIPTION
## Summary

Fixes a test-isolation defect that made `cd backend && make check` fail with **9 errors on a normal developer machine** (one that has a working `backend/.env`), while passing in CI (which has no `.env`). No production code behavior changes — this is test hygiene + one import-time side-effect removal.

## Root cause (two independent leaks, same symptom)

1. **Import-time `.env` leak (systemic).** `migration/direct_sheets_to_phenopackets.py` called `load_dotenv()` at *module top level*, so merely **importing** it wrote the developer's `backend/.env` into `os.environ`. Three test modules import it (`test_direct_phenopackets_migration`, `test_json_api_pagination`, `test_cnv_parser`), so **test collection alone** leaked dev-only flags — notably `ENABLE_DEV_AUTH=true` — into the process environment. That then contaminated the production-config validation tests in `test_core_config.py`: they construct `Settings(_env_file=None, environment="production", …)` and inherited the leaked flag (it's now a real env var, which `_env_file=None` does not block), tripping the dev-auth defense validator *before* the email/cookie validators under test could run.

   Proven: `import migration.direct_sheets_to_phenopackets` flipped `os.environ['ENABLE_DEV_AUTH']` from `None` → `true`.

2. **Direct `.env` read (local).** `test_config_email_backend_override.py` constructed `Settings(**kwargs)` **without** `_env_file=None`, so pydantic-settings read the dev `.env` directly (independent of leak #1) and failed the same way under `environment="production"`.

## Fixes

- **`migration/direct_sheets_to_phenopackets.py`** — move `load_dotenv()` from module scope into `main()`. The CLI still loads `.env` when run as a script (`python -m migration.…`); importing the module now has **no global side effect**. `app/` never imports this module, so nothing else is affected.
- **`tests/test_config_email_backend_override.py`** — add `_env_file=None` to every `Settings(...)` construction and an autouse fixture that clears the dev/email/cookie vars the tests drive themselves, mirroring the hermetic pattern already in `test_config_refuses_dev_auth_in_prod.py`.
- **`tests/test_core_config.py`** — clear `ENABLE_DEV_AUTH` in the shared `seed_safe_import_env` helper (defense-in-depth, so the prod-validation tests can never inherit a leaked flag).
- **New `tests/test_migration_import_no_env_side_effects.py`** — regression test that spies on `dotenv.load_dotenv` in a fresh subprocess and asserts importing the migration module does not call it. Red→green verified.

No assertions were weakened: the fail-closed `pytest.raises(...)` tests still pass, so the validators still fire — they're now just isolated from ambient env.

## Testing

- `cd backend && make check` **with a dev `.env` present (`ENABLE_DEV_AUTH=true`)**: **1504 passed, 0 failed** (previously 9 failures).
- The 3 migration-importing test modules still pass (54 passed).
- The new regression test is red without the fix, green with it.
- ruff clean; `mypy app/ migration/` clean (mypy is not run on `tests/` in any gate — `backend-mypy` pre-commit hook and CI both scope to `app/ migration/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
