### PR TITLE
feat(frontend): MCP Access page + footer link next to API

### DIFF
--- a/frontend/public/config/footerConfig.json
+++ b/frontend/public/config/footerConfig.json
@@ -7,17 +7,17 @@
     "enabled": true
   },
   {
-    "id": "api-docs",
-    "title": "API Documentation",
-    "icon": "mdi-api",
-    "url": "__API_DOCS_URL__",
-    "enabled": true
-  },
-  {
     "id": "license",
     "title": "CC BY 4.0 License",
     "icon": "mdi-creative-commons",
     "url": "https://creativecommons.org/licenses/by/4.0/",
+    "enabled": true
+  },
+  {
+    "id": "api-docs",
+    "title": "API Documentation",
+    "icon": "mdi-api",
+    "url": "__API_DOCS_URL__",
     "enabled": true
   }
 ]

--- a/frontend/src/components/FooterBar.vue
+++ b/frontend/src/components/FooterBar.vue
@@ -192,6 +192,19 @@ const refreshHealth = async () => {
   await healthService.checkBackendHealth();
 };
 
+// Keep the API docs link last among external links so the internal MCP button
+// (rendered immediately after the external-link loop) is always adjacent to it,
+// regardless of footerConfig.json ordering.
+const sortApiDocsLast = (links) => {
+  const apiIndex = links.findIndex((link) => link.id === 'api-docs');
+  if (apiIndex === -1) {
+    return links;
+  }
+  const reordered = [...links];
+  reordered.push(reordered.splice(apiIndex, 1)[0]);
+  return reordered;
+};
+
 const loadFooterConfig = async () => {
   const rawApi = import.meta.env.VITE_API_URL || '';
   const isProd = import.meta.env.PROD === true;
@@ -212,13 +225,15 @@ const loadFooterConfig = async () => {
     const response = await fetch('/config/footerConfig.json');
     const config = await response.json();
 
-    footerLinks.value = config
-      .filter((link) => link.enabled)
-      .map((link) => ({
-        ...link,
-        url: link.url === '__API_DOCS_URL__' ? apiDocsUrl : link.url,
-      }))
-      .filter((link) => link.url); // drop entries with null URL (unconfigured API docs)
+    footerLinks.value = sortApiDocsLast(
+      config
+        .filter((link) => link.enabled)
+        .map((link) => ({
+          ...link,
+          url: link.url === '__API_DOCS_URL__' ? apiDocsUrl : link.url,
+        }))
+        .filter((link) => link.url) // drop entries with null URL (unconfigured API docs)
+    );
 
     window.logService.info('Footer configuration loaded', {
       linksCount: footerLinks.value.length,
@@ -229,7 +244,7 @@ const loadFooterConfig = async () => {
       path: '/config/footerConfig.json',
     });
     // Fallback to default links; API docs entry is filtered if unconfigured.
-    footerLinks.value = [
+    footerLinks.value = sortApiDocsLast([
       {
         id: 'github',
         title: 'GitHub Repository',
@@ -242,7 +257,6 @@ const loadFooterConfig = async () => {
         icon: 'mdi-creative-commons',
         url: 'https://creativecommons.org/licenses/by/4.0/',
       },
-      // API docs is last so the internal MCP button renders next to it.
       ...(apiDocsUrl
         ? [
             {
@@ -253,7 +267,7 @@ const loadFooterConfig = async () => {
             },
           ]
         : []),
-    ];
+    ]);
   }
 };
 

--- a/frontend/src/components/FooterBar.vue
+++ b/frontend/src/components/FooterBar.vue
@@ -77,6 +77,27 @@
         <v-icon size="small">{{ link.icon }}</v-icon>
       </v-btn>
 
+      <!-- MCP Access (internal page) — sits next to the API docs link -->
+      <v-tooltip
+        location="top"
+        text="Connect an AI agent (MCP)"
+        aria-label="Connect an AI agent (MCP)"
+      >
+        <template #activator="{ props }">
+          <v-btn
+            v-bind="props"
+            to="/mcp"
+            icon
+            variant="text"
+            size="small"
+            class="mx-1"
+            aria-label="MCP access"
+          >
+            <v-icon size="small">mdi-robot-outline</v-icon>
+          </v-btn>
+        </template>
+      </v-tooltip>
+
       <!-- Log Viewer Toggle -->
       <v-btn
         icon="mdi-text-box-search-outline"
@@ -215,6 +236,13 @@ const loadFooterConfig = async () => {
         icon: 'mdi-github',
         url: 'https://github.com/berntpopp/hnf1b-db',
       },
+      {
+        id: 'license',
+        title: 'CC BY 4.0 License',
+        icon: 'mdi-creative-commons',
+        url: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+      // API docs is last so the internal MCP button renders next to it.
       ...(apiDocsUrl
         ? [
             {
@@ -225,12 +253,6 @@ const loadFooterConfig = async () => {
             },
           ]
         : []),
-      {
-        id: 'license',
-        title: 'CC BY 4.0 License',
-        icon: 'mdi-creative-commons',
-        url: 'https://creativecommons.org/licenses/by/4.0/',
-      },
     ];
   }
 };

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -113,6 +113,12 @@ const routes = [
     meta: { title: 'FAQ' },
   },
   {
+    path: '/mcp',
+    name: 'McpAccess',
+    component: () => import(/* webpackChunkName: "mcp-access" */ '../views/McpAccess.vue'),
+    meta: { title: 'MCP Access' },
+  },
+  {
     path: '/login',
     name: 'Login',
     component: () => import(/* webpackChunkName: "login" */ '../views/Login.vue'),

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -116,7 +116,7 @@ const routes = [
     path: '/mcp',
     name: 'McpAccess',
     component: () => import(/* webpackChunkName: "mcp-access" */ '../views/McpAccess.vue'),
-    meta: { title: 'MCP Access' },
+    meta: { title: 'Connect an AI Agent' },
   },
   {
     path: '/login',

--- a/frontend/src/views/McpAccess.vue
+++ b/frontend/src/views/McpAccess.vue
@@ -1,0 +1,271 @@
+<!-- src/views/McpAccess.vue -->
+<!--
+  MCP Access page.
+
+  Explains how to connect the public, read-only HNF1B-db MCP server
+  (https://mcp.hnf1b.org/mcp) to AI clients: Claude (web + desktop), ChatGPT,
+  and coding agents (Claude Code, Codex CLI).
+
+  This is an information page — the address it documents is an MCP transport
+  endpoint for AI clients, not a website that renders in a browser.
+-->
+<template>
+  <v-container class="py-8">
+    <v-row justify="center">
+      <v-col cols="12" md="10" lg="9">
+        <!-- Header -->
+        <div class="text-center mb-8">
+          <v-avatar color="teal" size="80" class="mb-4">
+            <v-icon size="48" color="white">mdi-robot-outline</v-icon>
+          </v-avatar>
+          <h1 class="text-h3 font-weight-bold text-grey-darken-3 mb-2">
+            Connect an AI Agent (MCP)
+          </h1>
+          <p class="text-h6 text-grey-darken-1">
+            Query HNF1B-db from Claude, ChatGPT, and coding agents over the Model Context Protocol
+          </p>
+        </div>
+
+        <!-- Page-vs-endpoint notice -->
+        <v-alert type="info" variant="tonal" class="mb-6" icon="mdi-information-outline">
+          This page explains how to connect. The address below is an MCP
+          <strong>transport endpoint for AI clients</strong> — not a website, so opening it in a
+          browser will not show a page.
+        </v-alert>
+
+        <!-- What you get -->
+        <v-card class="mb-6" elevation="2">
+          <v-card-title class="bg-teal-lighten-5">
+            <v-icon left color="teal">mdi-database-search-outline</v-icon>
+            What you get
+          </v-card-title>
+          <v-card-text class="pa-6">
+            <p class="text-body-1 mb-3">
+              A <strong>read-only</strong> connection to curated HNF1B gene, variant, individual,
+              and publication data. Your agent can search the cohort, fetch phenopackets and
+              variants, pull gene context and statistics, and cite publications — all without any
+              write access.
+            </p>
+            <p class="text-body-2 text-grey-darken-1 mb-0">
+              Public — no sign-in or API key required. Research use only; not clinical decision
+              support.
+            </p>
+          </v-card-text>
+        </v-card>
+
+        <!-- Server address -->
+        <v-card class="mb-6" elevation="2">
+          <v-card-title class="bg-teal-lighten-5">
+            <v-icon left color="teal">mdi-link-variant</v-icon>
+            Server address
+          </v-card-title>
+          <v-card-text class="pa-6">
+            <div class="d-flex align-center flex-wrap">
+              <code class="endpoint-code mr-3">{{ endpoint }}</code>
+              <v-btn
+                size="small"
+                variant="tonal"
+                color="teal"
+                prepend-icon="mdi-content-copy"
+                @click="copy(endpoint, 'Server address')"
+              >
+                Copy
+              </v-btn>
+            </div>
+            <p class="text-body-2 text-grey-darken-1 mt-3 mb-0">
+              Transport: MCP Streamable HTTP. Use this same address in every client below.
+            </p>
+          </v-card-text>
+        </v-card>
+
+        <!-- Per-client instructions -->
+        <h2 class="text-h5 font-weight-bold text-grey-darken-3 mb-4">How to connect</h2>
+        <v-row>
+          <v-col v-for="client in clients" :key="client.id" cols="12" md="6">
+            <v-card class="h-100 d-flex flex-column" elevation="2">
+              <v-card-title class="d-flex align-center">
+                <v-icon :color="client.color" class="mr-2">{{ client.icon }}</v-icon>
+                {{ client.name }}
+              </v-card-title>
+              <v-card-text class="flex-grow-1">
+                <ol class="client-steps mb-3">
+                  <li v-for="(step, i) in client.steps" :key="i" class="mb-1">{{ step }}</li>
+                </ol>
+                <div class="snippet-wrap">
+                  <pre class="snippet"><code>{{ client.snippet }}</code></pre>
+                  <v-btn
+                    class="snippet-copy"
+                    size="x-small"
+                    variant="text"
+                    icon="mdi-content-copy"
+                    :aria-label="`Copy ${client.name} configuration`"
+                    @click="copy(client.snippet, `${client.name} configuration`)"
+                  />
+                </div>
+                <p v-if="client.note" class="text-caption text-grey-darken-1 mt-2 mb-0">
+                  {{ client.note }}
+                </p>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+
+        <!-- Verify tip -->
+        <v-alert type="success" variant="tonal" class="mt-6" icon="mdi-check-circle-outline">
+          Once connected, ask your agent to call <code>hnf1b_get_capabilities</code> first — it
+          lists every available tool and how to use it.
+        </v-alert>
+
+        <p class="text-caption text-grey mt-4 mb-0">
+          New to MCP? See the
+          <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener noreferrer">
+            Model Context Protocol
+          </a>
+          documentation.
+        </p>
+      </v-col>
+    </v-row>
+
+    <!-- Copy confirmation -->
+    <v-snackbar v-model="snackbar" :timeout="2000" color="success">
+      {{ snackbarMessage }}
+    </v-snackbar>
+  </v-container>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+// Public, read-only MCP transport endpoint (Streamable HTTP).
+const endpoint = 'https://mcp.hnf1b.org/mcp';
+
+// Connection recipes per client, verified against current (2026) official docs.
+// Steps are intentionally short; the copy-pasteable command/config lives in
+// `snippet`, and `note` carries the most important caveat.
+const clients = [
+  {
+    id: 'claude',
+    name: 'Claude (web & desktop)',
+    icon: 'mdi-creation',
+    color: 'deep-orange',
+    steps: [
+      'In Claude, open Customize → Connectors (claude.ai/customize/connectors).',
+      'Click “+”, then “Add custom connector”.',
+      'Paste the server address into the URL field and click Add (leave the OAuth fields empty).',
+      'In a chat, open “+” → Connectors and toggle hnf1b-db on.',
+    ],
+    snippet: 'https://mcp.hnf1b.org/mcp',
+    note: 'Same steps on claude.ai and Claude Desktop. Custom connectors are in beta; the Free plan allows one.',
+  },
+  {
+    id: 'chatgpt',
+    name: 'ChatGPT',
+    icon: 'mdi-chat-processing-outline',
+    color: 'green-darken-1',
+    steps: [
+      'On chatgpt.com, open Settings → Apps → Advanced settings and turn on Developer mode.',
+      'Click “Create app”.',
+      'Set Name to HNF1B-db, URL to the server address, Authentication to “No authentication”, then Create.',
+      'In a chat, open “+” and enable the HNF1B-db app.',
+    ],
+    snippet: 'Name:  HNF1B-db\nURL:   https://mcp.hnf1b.org/mcp\nAuth:  No authentication',
+    note: 'Web only (chatgpt.com); Plus, Pro, Business, Enterprise, or Edu. Developer mode is in beta.',
+  },
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    icon: 'mdi-console',
+    color: 'blue-grey-darken-1',
+    steps: [
+      'Run the command below (flags go before the server name).',
+      'For a shared/team setup, add --scope project to write it into .mcp.json.',
+      'Verify with “claude mcp list”, or run “/mcp” inside a session.',
+    ],
+    snippet: 'claude mcp add --transport http hnf1b-db https://mcp.hnf1b.org/mcp',
+    note: 'Or hand-edit .mcp.json → { "mcpServers": { "hnf1b-db": { "type": "http", "url": "…/mcp" } } }',
+  },
+  {
+    id: 'codex',
+    name: 'Codex CLI',
+    icon: 'mdi-code-braces',
+    color: 'indigo-darken-1',
+    steps: [
+      'Run the command below, or add the table to ~/.codex/config.toml by hand.',
+      'Verify with “codex mcp list”, then start Codex.',
+      'If it does not connect, update Codex to the latest release first.',
+    ],
+    snippet:
+      'codex mcp add hnf1b-db --url https://mcp.hnf1b.org/mcp\n\n# or in ~/.codex/config.toml:\n[mcp_servers.hnf1b-db]\nurl = "https://mcp.hnf1b.org/mcp"',
+    note: 'Remote Streamable-HTTP servers are first-class in current Codex releases.',
+  },
+];
+
+// Copy confirmation snackbar state.
+const snackbar = ref(false);
+const snackbarMessage = ref('');
+
+/**
+ * Copy text to the clipboard and show a confirmation snackbar.
+ * Mirrors the established clipboard pattern used in PageVariant.vue.
+ */
+const copy = (text, label) => {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        snackbarMessage.value = `${label} copied to clipboard`;
+        snackbar.value = true;
+        window.logService.debug('MCP page clipboard copy', { label });
+      })
+      .catch((err) => {
+        snackbarMessage.value = 'Failed to copy to clipboard';
+        snackbar.value = true;
+        window.logService.warn('MCP page clipboard copy failed', {
+          label,
+          error: err.message,
+        });
+      });
+  }
+};
+</script>
+
+<style scoped>
+.endpoint-code {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #cfd8e3;
+  border-radius: 6px;
+  background: #f6f8fb;
+  color: #102033;
+  font-size: 0.95rem;
+  word-break: break-all;
+}
+
+.client-steps {
+  padding-left: 1.15rem;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.snippet-wrap {
+  position: relative;
+}
+
+.snippet {
+  overflow-x: auto;
+  margin: 0;
+  padding: 0.75rem 2.25rem 0.75rem 0.85rem;
+  border: 1px solid #cfd8e3;
+  border-radius: 6px;
+  background: #f6f8fb;
+  color: #102033;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  white-space: pre;
+}
+
+.snippet-copy {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.3rem;
+}
+</style>

--- a/frontend/src/views/McpAccess.vue
+++ b/frontend/src/views/McpAccess.vue
@@ -18,10 +18,10 @@
           <v-avatar color="teal" size="80" class="mb-4">
             <v-icon size="48" color="white">mdi-robot-outline</v-icon>
           </v-avatar>
-          <h1 class="text-h3 font-weight-bold text-grey-darken-3 mb-2">
+          <h1 class="text-h3 font-weight-bold text-high-emphasis mb-2">
             Connect an AI Agent (MCP)
           </h1>
-          <p class="text-h6 text-grey-darken-1">
+          <p class="text-h6 text-medium-emphasis">
             Query HNF1B-db from Claude, ChatGPT, and coding agents over the Model Context Protocol
           </p>
         </div>
@@ -35,8 +35,8 @@
 
         <!-- What you get -->
         <v-card class="mb-6" elevation="2">
-          <v-card-title class="bg-teal-lighten-5">
-            <v-icon left color="teal">mdi-database-search-outline</v-icon>
+          <v-card-title class="card-band">
+            <v-icon color="teal" class="mr-2">mdi-database-search-outline</v-icon>
             What you get
           </v-card-title>
           <v-card-text class="pa-6">
@@ -46,7 +46,7 @@
               variants, pull gene context and statistics, and cite publications — all without any
               write access.
             </p>
-            <p class="text-body-2 text-grey-darken-1 mb-0">
+            <p class="text-body-2 text-medium-emphasis mb-0">
               Public — no sign-in or API key required. Research use only; not clinical decision
               support.
             </p>
@@ -55,8 +55,8 @@
 
         <!-- Server address -->
         <v-card class="mb-6" elevation="2">
-          <v-card-title class="bg-teal-lighten-5">
-            <v-icon left color="teal">mdi-link-variant</v-icon>
+          <v-card-title class="card-band">
+            <v-icon color="teal" class="mr-2">mdi-link-variant</v-icon>
             Server address
           </v-card-title>
           <v-card-text class="pa-6">
@@ -72,14 +72,14 @@
                 Copy
               </v-btn>
             </div>
-            <p class="text-body-2 text-grey-darken-1 mt-3 mb-0">
+            <p class="text-body-2 text-medium-emphasis mt-3 mb-0">
               Transport: MCP Streamable HTTP. Use this same address in every client below.
             </p>
           </v-card-text>
         </v-card>
 
         <!-- Per-client instructions -->
-        <h2 class="text-h5 font-weight-bold text-grey-darken-3 mb-4">How to connect</h2>
+        <h2 class="text-h5 font-weight-bold text-high-emphasis mb-4">How to connect</h2>
         <v-row>
           <v-col v-for="client in clients" :key="client.id" cols="12" md="6">
             <v-card class="h-100 d-flex flex-column" elevation="2">
@@ -102,7 +102,7 @@
                     @click="copy(client.snippet, `${client.name} configuration`)"
                   />
                 </div>
-                <p v-if="client.note" class="text-caption text-grey-darken-1 mt-2 mb-0">
+                <p v-if="client.note" class="text-caption text-medium-emphasis mt-2 mb-0">
                   {{ client.note }}
                 </p>
               </v-card-text>
@@ -116,7 +116,7 @@
           lists every available tool and how to use it.
         </v-alert>
 
-        <p class="text-caption text-grey mt-4 mb-0">
+        <p class="text-caption text-medium-emphasis mt-4 mb-0">
           New to MCP? See the
           <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener noreferrer">
             Model Context Protocol
@@ -127,7 +127,7 @@
     </v-row>
 
     <!-- Copy confirmation -->
-    <v-snackbar v-model="snackbar" :timeout="2000" color="success">
+    <v-snackbar v-model="snackbar" :timeout="2000" :color="snackbarSuccess ? 'success' : 'error'">
       {{ snackbarMessage }}
     </v-snackbar>
   </v-container>
@@ -190,52 +190,66 @@ const clients = [
     icon: 'mdi-code-braces',
     color: 'indigo-darken-1',
     steps: [
-      'Run the command below, or add the table to ~/.codex/config.toml by hand.',
+      'Add the table below to ~/.codex/config.toml (or run the shortcut command).',
       'Verify with “codex mcp list”, then start Codex.',
       'If it does not connect, update Codex to the latest release first.',
     ],
     snippet:
-      'codex mcp add hnf1b-db --url https://mcp.hnf1b.org/mcp\n\n# or in ~/.codex/config.toml:\n[mcp_servers.hnf1b-db]\nurl = "https://mcp.hnf1b.org/mcp"',
+      '# ~/.codex/config.toml\n[mcp_servers.hnf1b-db]\nurl = "https://mcp.hnf1b.org/mcp"\n\n# or, on current Codex releases:\ncodex mcp add hnf1b-db --url https://mcp.hnf1b.org/mcp',
     note: 'Remote Streamable-HTTP servers are first-class in current Codex releases.',
   },
 ];
 
 // Copy confirmation snackbar state.
 const snackbar = ref(false);
+const snackbarSuccess = ref(true);
 const snackbarMessage = ref('');
 
+const showSnackbar = (message, success) => {
+  snackbarMessage.value = message;
+  snackbarSuccess.value = success;
+  snackbar.value = true;
+};
+
 /**
- * Copy text to the clipboard and show a confirmation snackbar.
- * Mirrors the established clipboard pattern used in PageVariant.vue.
+ * Copy text to the clipboard and surface the outcome via the snackbar.
+ * Uses the async Clipboard API (available in secure contexts); failures and
+ * unsupported environments report an error rather than failing silently.
  */
 const copy = (text, label) => {
   if (navigator.clipboard && navigator.clipboard.writeText) {
     navigator.clipboard
       .writeText(text)
       .then(() => {
-        snackbarMessage.value = `${label} copied to clipboard`;
-        snackbar.value = true;
+        showSnackbar(`${label} copied to clipboard`, true);
         window.logService.debug('MCP page clipboard copy', { label });
       })
       .catch((err) => {
-        snackbarMessage.value = 'Failed to copy to clipboard';
-        snackbar.value = true;
+        showSnackbar('Failed to copy — select and copy manually', false);
         window.logService.warn('MCP page clipboard copy failed', {
           label,
           error: err.message,
         });
       });
+  } else {
+    showSnackbar('Copying is unavailable — select and copy manually', false);
+    window.logService.warn('MCP page clipboard API unavailable', { label });
   }
 };
 </script>
 
 <style scoped>
+/* Theme-aware "code surface": faint on-surface tint that follows light/dark. */
+.card-band {
+  background-color: rgba(var(--v-theme-primary), 0.08);
+}
+
 .endpoint-code {
   padding: 0.35rem 0.6rem;
-  border: 1px solid #cfd8e3;
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
   border-radius: 6px;
-  background: #f6f8fb;
-  color: #102033;
+  background: rgba(var(--v-theme-on-surface), 0.04);
+  color: rgb(var(--v-theme-on-surface));
   font-size: 0.95rem;
   word-break: break-all;
 }
@@ -254,10 +268,10 @@ const copy = (text, label) => {
   overflow-x: auto;
   margin: 0;
   padding: 0.75rem 2.25rem 0.75rem 0.85rem;
-  border: 1px solid #cfd8e3;
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
   border-radius: 6px;
-  background: #f6f8fb;
-  color: #102033;
+  background: rgba(var(--v-theme-on-surface), 0.04);
+  color: rgb(var(--v-theme-on-surface));
   font-size: 0.82rem;
   line-height: 1.45;
   white-space: pre;

--- a/frontend/tests/unit/components/FooterBar.spec.js
+++ b/frontend/tests/unit/components/FooterBar.spec.js
@@ -84,8 +84,8 @@ describe('FooterBar API docs link (M10)', () => {
   it('omits the API docs link when VITE_API_URL is unset in prod build', async () => {
     await withEnv({ PROD: true, VITE_API_URL: '' }, async () => {
       mockFetchConfig([
-        { enabled: true, id: 'api', label: 'API', url: '__API_DOCS_URL__' },
-        { enabled: true, id: 'gh', label: 'GitHub', url: 'https://github.com/x/y' },
+        { enabled: true, id: 'api-docs', title: 'API Documentation', url: '__API_DOCS_URL__' },
+        { enabled: true, id: 'gh', title: 'GitHub', url: 'https://github.com/x/y' },
       ]);
       const wrapper = mount(makeAppWrapper(), {
         global: { plugins: [vuetify, pinia] },
@@ -103,7 +103,9 @@ describe('FooterBar API docs link (M10)', () => {
 
   it('includes the API docs link when VITE_API_URL is set', async () => {
     await withEnv({ PROD: true, VITE_API_URL: 'https://api.example.com/api/v2' }, async () => {
-      mockFetchConfig([{ enabled: true, id: 'api', label: 'API', url: '__API_DOCS_URL__' }]);
+      mockFetchConfig([
+        { enabled: true, id: 'api-docs', title: 'API Documentation', url: '__API_DOCS_URL__' },
+      ]);
       const wrapper = mount(makeAppWrapper(), {
         global: { plugins: [vuetify, pinia] },
       });
@@ -115,7 +117,9 @@ describe('FooterBar API docs link (M10)', () => {
 
   it('falls back to localhost in dev when VITE_API_URL is unset', async () => {
     await withEnv({ PROD: false, VITE_API_URL: '' }, async () => {
-      mockFetchConfig([{ enabled: true, id: 'api', label: 'API', url: '__API_DOCS_URL__' }]);
+      mockFetchConfig([
+        { enabled: true, id: 'api-docs', title: 'API Documentation', url: '__API_DOCS_URL__' },
+      ]);
       const wrapper = mount(makeAppWrapper(), {
         global: { plugins: [vuetify, pinia] },
       });
@@ -125,15 +129,38 @@ describe('FooterBar API docs link (M10)', () => {
     });
   });
 
-  it('renders an internal MCP access link (next to the API docs link)', async () => {
-    mockFetchConfig([{ enabled: true, id: 'api', label: 'API', url: 'https://x.test/docs' }]);
+  it('renders the internal MCP access link immediately after the API docs link', async () => {
+    // api-docs is listed in the MIDDLE here; the component must still force it
+    // last so the hardcoded MCP button stays adjacent to it.
+    mockFetchConfig([
+      { enabled: true, id: 'gh', title: 'GitHub', icon: 'mdi-github', url: 'https://x.test/gh' },
+      {
+        enabled: true,
+        id: 'api-docs',
+        title: 'API Documentation',
+        icon: 'mdi-api',
+        url: 'https://x.test/docs',
+      },
+      {
+        enabled: true,
+        id: 'license',
+        title: 'License',
+        icon: 'mdi-creative-commons',
+        url: 'https://x.test/license',
+      },
+    ]);
     const wrapper = mount(makeAppWrapper(), {
       global: { plugins: [vuetify, pinia] },
     });
     await new Promise((r) => setTimeout(r, 20));
-    // The MCP button is an internal route button (not a config-driven external
-    // link), identified by its icon and aria-label.
-    expect(wrapper.html()).toContain('mdi-robot-outline');
+
+    // The MCP button is an internal route button (not config-driven).
     expect(wrapper.find('[aria-label="MCP access"]').exists()).toBe(true);
+
+    const html = wrapper.html();
+    // api-docs forced last among external links (after license)...
+    expect(html.indexOf('mdi-api')).toBeGreaterThan(html.indexOf('mdi-creative-commons'));
+    // ...and the MCP button renders immediately after the API docs link.
+    expect(html.indexOf('mdi-robot-outline')).toBeGreaterThan(html.indexOf('mdi-api'));
   });
 });

--- a/frontend/tests/unit/components/FooterBar.spec.js
+++ b/frontend/tests/unit/components/FooterBar.spec.js
@@ -124,4 +124,16 @@ describe('FooterBar API docs link (M10)', () => {
       expect(hrefs).toContain('http://localhost:8000/api/v2/docs');
     });
   });
+
+  it('renders an internal MCP access link (next to the API docs link)', async () => {
+    mockFetchConfig([{ enabled: true, id: 'api', label: 'API', url: 'https://x.test/docs' }]);
+    const wrapper = mount(makeAppWrapper(), {
+      global: { plugins: [vuetify, pinia] },
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    // The MCP button is an internal route button (not a config-driven external
+    // link), identified by its icon and aria-label.
+    expect(wrapper.html()).toContain('mdi-robot-outline');
+    expect(wrapper.find('[aria-label="MCP access"]').exists()).toBe(true);
+  });
 });

--- a/frontend/tests/unit/views/McpAccess.spec.js
+++ b/frontend/tests/unit/views/McpAccess.spec.js
@@ -1,0 +1,78 @@
+/**
+ * Tests for McpAccess.vue — the "Connect an AI Agent (MCP)" page.
+ *
+ * Verifies the observable, user-facing behavior: the public endpoint is
+ * documented, the page is clearly distinguished from the transport endpoint,
+ * all four supported clients are listed with their copy-pasteable config, and
+ * the copy-to-clipboard action works. Vuetify is registered globally in
+ * tests/setup.js, so no per-test plugin wiring is needed.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+
+import McpAccess from '@/views/McpAccess.vue';
+
+const ENDPOINT = 'https://mcp.hnf1b.org/mcp';
+
+describe('McpAccess view', () => {
+  let writeText;
+  let vuetify;
+
+  beforeEach(() => {
+    vuetify = createVuetify({ components, directives });
+    writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+    window.logService = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const factory = () => mount(McpAccess, { global: { plugins: [vuetify] } });
+
+  it('documents the public MCP endpoint', () => {
+    const wrapper = factory();
+    expect(wrapper.text()).toContain(ENDPOINT);
+  });
+
+  it('clarifies that the address is a transport endpoint, not a browser page', () => {
+    const wrapper = factory();
+    expect(wrapper.text().toLowerCase()).toContain('not a website');
+  });
+
+  it('lists all four supported clients', () => {
+    const text = factory().text();
+    expect(text).toContain('Claude (web & desktop)');
+    expect(text).toContain('ChatGPT');
+    expect(text).toContain('Claude Code');
+    expect(text).toContain('Codex CLI');
+  });
+
+  it('shows the Claude Code add command and the Codex config table', () => {
+    const text = factory().text();
+    expect(text).toContain(`claude mcp add --transport http hnf1b-db ${ENDPOINT}`);
+    expect(text).toContain('[mcp_servers.hnf1b-db]');
+  });
+
+  it('copies the server address to the clipboard', async () => {
+    const wrapper = factory();
+    const copyBtn = wrapper.findAll('button').find((b) => b.text().includes('Copy'));
+    expect(copyBtn).toBeTruthy();
+    await copyBtn.trigger('click');
+    await flushPromises();
+    expect(writeText).toHaveBeenCalledWith(ENDPOINT);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a concise, public **"Connect an AI Agent (MCP)"** page (`/mcp`) plus a
bottom-bar (footer) menu item next to the existing **API** item, as requested.
The page explains — simply — how to connect the public, read-only HNF1B-db MCP
server (`https://mcp.hnf1b.org/mcp`) to **Claude** (web + desktop), **ChatGPT**,
and coding agents **Claude Code** and **Codex CLI**.

Mirrors the SysNDD `McpInfoView` pattern. Each connection recipe was researched
against current (2026) official docs.

## What changed

- **`McpAccess.vue` + `/mcp` route** — hero, a notice that the address is an MCP
  transport endpoint for clients (not a browsable website), a "what you get"
  card, the server address with copy-to-clipboard, and four per-client cards
  (short steps + copy-pasteable command/config + the key caveat):
  - **Claude:** Customize → Connectors → Add custom connector (paste URL, no auth).
  - **ChatGPT:** Settings → Apps → Developer mode → Create app (No authentication).
  - **Claude Code:** `claude mcp add --transport http hnf1b-db <url>` / `.mcp.json`.
  - **Codex CLI:** `~/.codex/config.toml` `[mcp_servers.hnf1b-db] url=…` / `codex mcp add … --url`.
- **Footer** — internal-route MCP button (`mdi-robot-outline`, tooltip
  "Connect an AI agent (MCP)") placed next to the API docs link. `sortApiDocsLast()`
  forces API docs last among external links so the MCP button is reliably
  adjacent regardless of `footerConfig.json` ordering.

## Quality

- Theme-aware throughout (works in light **and** dark theme — no hardcoded
  colors; `text-*-emphasis` + `rgba(var(--v-theme-*))`).
- Copy action reports success/failure via snackbar + `logService` (no silent
  no-op).
- Adversarially reviewed across 4 dimensions (spec, code quality, a11y/dark
  theme, instruction accuracy); all findings addressed.

## Testing

- `frontend`: `npm test` → **432 passed** (+1 expected-fail); `eslint` clean;
  `prettier --check` (src + tests) clean; `npm run build` OK.
- New `McpAccess.spec.js` (endpoint, page-vs-endpoint clarity, all four clients,
  Claude Code/Codex snippets, clipboard); extended `FooterBar.spec.js` (DOM-order
  assertion that the MCP button is adjacent to API docs).
- Playwright-verified on the running stack (`/mcp` renders, footer button next
  to API, copy works, light + dark theme legible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
