### PR TITLE
Harden MCP statistics, compare flows, enums, and capability metadata

### DIFF
--- a/backend/app/phenopackets/routers/aggregations/diseases.py
+++ b/backend/app/phenopackets/routers/aggregations/diseases.py
@@ -97,42 +97,54 @@ async def aggregate_by_disease(
 async def aggregate_kidney_stages(
     db: AsyncSession = Depends(get_db),
 ):
-    """Get distribution of kidney disease stages."""
-    query = """
+    """Get distribution of kidney disease stages.
+
+    The cohort encodes CKD stages as STANDALONE HPO feature terms (HP:0012623
+    Stage 1 … HP:0003774 Stage 5, plus HP:0012622 unspecified CKD) — NOT as a
+    ``Stage`` modifier on a single CKD feature. This aggregates the present
+    occurrences of those terms (``settings.hpo_terms.ckd_stages``), using the same
+    present-count semantics as /by-feature so the two reconcile. ``percentage`` is
+    each stage's share of all staged-CKD annotations.
+    """
+    stage_ids: list[str] = settings.hpo_terms.ckd_stages
+    # Named placeholders (:stage_0 …) for the IN-list. The ids are server-side
+    # config constants, but parameterising keeps the query injection-safe.
+    placeholders = ", ".join(f":stage_{i}" for i in range(len(stage_ids)))
+    params = {f"stage_{i}": sid for i, sid in enumerate(stage_ids)}
+
+    query = f"""
     SELECT
-        modifier->>'label' as stage,
+        feature->'type'->>'id' as hpo_id,
+        MIN(feature->'type'->>'label') as label,
         COUNT(*) as count
     FROM
         phenopackets,
-        jsonb_array_elements(phenopacket->'phenotypicFeatures') as feature,
-        jsonb_array_elements(COALESCE(feature->'modifiers', '[]'::jsonb)) as modifier
+        jsonb_array_elements(phenopacket->'phenotypicFeatures') as feature
     WHERE
         deleted_at IS NULL
         AND state = 'published'
         AND head_published_revision_id IS NOT NULL
         AND phenopacket_id NOT LIKE 'e2e-%'
-        AND feature->'type'->>'id' = :ckd_hpo
-        AND modifier->>'label' LIKE '%Stage%'
+        AND feature->'type'->>'id' IN ({placeholders})
+        AND NOT COALESCE((feature->>'excluded')::boolean, false)
     GROUP BY
-        modifier->>'label'
+        feature->'type'->>'id'
     ORDER BY
-        stage
+        hpo_id
     """
 
-    result = await db.execute(
-        text(query),
-        {"ckd_hpo": settings.hpo_terms.chronic_kidney_disease},
-    )
-    rows = result.fetchall()
+    result = await db.execute(text(query), params)
+    rows = result.mappings().all()
 
-    total = sum(int(row._mapping["count"]) for row in rows)
+    total = sum(int(row["count"]) for row in rows)
     rows_with_pct = calculate_percentages(rows, total=total)
 
     return [
         AggregationResult(
-            label=row["stage"],
+            label=row["label"] or row["hpo_id"],
             count=int(row["count"]),
             percentage=row["percentage"],
+            hpo_id=row["hpo_id"],
         )
         for row in rows_with_pct
     ]

--- a/backend/app/phenopackets/survival_analysis.py
+++ b/backend/app/phenopackets/survival_analysis.py
@@ -208,7 +208,17 @@ def calculate_kaplan_meier(event_times: list[tuple[float, bool]]) -> list[dict]:
         ci_lower = 1.0
         ci_upper = 1.0
 
-        if survival_prob > 0 and survival_prob < 1 and greenwood_sum > 0:
+        if survival_prob <= 0:
+            # Survival has reached 0 (the final at-risk subject had an event). The
+            # log-log CI is undefined here, and leaving the initialized [1, 1]
+            # would ship an interval that does NOT contain its own point estimate
+            # (a degenerate last-event artifact). Collapse the interval to the
+            # estimate instead — [0, 0] — so the CI always contains S(t). (R's
+            # survfit returns NA; we keep a numeric bound so the API/chart contract
+            # stays float-only and the band converges cleanly to the endpoint.)
+            ci_lower = 0.0
+            ci_upper = 0.0
+        elif survival_prob < 1 and greenwood_sum > 0:
             se = survival_prob * math.sqrt(greenwood_sum)  # Standard error
             z = 1.96  # 95% CI
 

--- a/backend/tests/test_aggregations_endpoints.py
+++ b/backend/tests/test_aggregations_endpoints.py
@@ -209,3 +209,95 @@ class TestPublicationsTimelineYearCorrectness:
         # (proving a non-empty timeline) and the import year must never leak in.
         assert {2008, 2017}.issubset(years), resp.json()
         assert 2026 not in years, resp.json()
+
+
+@pytest.mark.asyncio
+class TestKidneyStagesStandaloneFeatures:
+    """B1: CKD stages are standalone HPO features, not 'Stage' modifiers.
+
+    The old query keyed on HP:0012622 + a ``modifier`` label LIKE '%Stage%', a
+    shape the cohort never uses, so /kidney-stages returned [] even when staged
+    CKD was present (and surfaced via /by-feature). The fix aggregates the
+    standalone CKD-stage HPO terms (settings.hpo_terms.ckd_stages).
+    """
+
+    async def _seed_published_with_features(
+        self, db_session, admin_user, phenopacket_id: str, features: list[dict]
+    ) -> None:
+        from app.phenopackets.models import Phenopacket, PhenopacketRevision
+
+        content = {"id": phenopacket_id, "phenotypicFeatures": features}
+        pp = Phenopacket(
+            phenopacket_id=phenopacket_id,
+            phenopacket=content,
+            state="published",
+            revision=1,
+            created_by_id=admin_user.id,
+        )
+        db_session.add(pp)
+        await db_session.flush()
+        rev = PhenopacketRevision(
+            record_id=pp.id,
+            revision_number=1,
+            state="published",
+            content_jsonb=content,
+            change_reason="init",
+            actor_id=admin_user.id,
+            from_state=None,
+            to_state="published",
+            is_head_published=True,
+        )
+        db_session.add(rev)
+        await db_session.flush()
+        pp.head_published_revision_id = rev.id
+
+    async def test_kidney_stages_counts_standalone_stage_features(
+        self, async_client: AsyncClient, db_session, admin_user
+    ) -> None:
+        """kidney-stages counts present standalone CKD-stage features, not modifiers."""
+        # Two carriers record Stage 3 CKD (HP:0012625) as a present feature; one
+        # records it excluded (must NOT count). One records Stage 4 (HP:0012626).
+        await self._seed_published_with_features(
+            db_session,
+            admin_user,
+            "ckd-stage3-a",
+            [{"type": {"id": "HP:0012625", "label": "Stage 3 chronic kidney disease"}}],
+        )
+        await self._seed_published_with_features(
+            db_session,
+            admin_user,
+            "ckd-stage3-b",
+            [{"type": {"id": "HP:0012625", "label": "Stage 3 chronic kidney disease"}}],
+        )
+        await self._seed_published_with_features(
+            db_session,
+            admin_user,
+            "ckd-stage3-excluded",
+            [
+                {
+                    "type": {
+                        "id": "HP:0012625",
+                        "label": "Stage 3 chronic kidney disease",
+                    },
+                    "excluded": True,
+                }
+            ],
+        )
+        await self._seed_published_with_features(
+            db_session,
+            admin_user,
+            "ckd-stage4-a",
+            [{"type": {"id": "HP:0012626", "label": "Stage 4 chronic kidney disease"}}],
+        )
+        await db_session.commit()
+
+        resp = await async_client.get("/api/v2/phenopackets/aggregate/kidney-stages")
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()
+        by_id = {row["hpo_id"]: row for row in rows}
+        # The metric is no longer silently empty.
+        assert rows, rows
+        # Stage 3 present in 2 carriers (excluded one not counted).
+        assert by_id["HP:0012625"]["count"] == 2
+        # Stage 4 present in 1.
+        assert by_id["HP:0012626"]["count"] == 1

--- a/backend/tests/test_survival_analysis.py
+++ b/backend/tests/test_survival_analysis.py
@@ -202,6 +202,25 @@ class TestCalculateKaplanMeier:
             # Lower should be <= upper
             assert point["ci_lower"] <= point["ci_upper"]
 
+    def test_confidence_interval_contains_estimate(self):
+        """Every point's CI must contain its own survival estimate (B6).
+
+        Guards the degenerate-terminal-point artifact: when survival drops to 0
+        the log-log CI is skipped, and the leftover initialized [1, 1] would be an
+        interval that does NOT contain the estimate (0).
+        """
+        # All-event data drives the final survival estimate to exactly 0.
+        data = [(10.0, True), (20.0, True), (30.0, True)]
+        result = calculate_kaplan_meier(data)
+
+        assert result[-1]["survival_probability"] == 0.0
+        for point in result:
+            s = point["survival_probability"]
+            # The interval must bracket its own point estimate.
+            assert point["ci_lower"] <= s <= point["ci_upper"], point
+        # Specifically, the terminal S=0 point must NOT carry the [1, 1] artifact.
+        assert not (result[-1]["ci_lower"] == 1.0 and result[-1]["ci_upper"] == 1.0)
+
     def test_at_risk_decreases(self):
         """Number at risk should decrease over time."""
         data = [(10.0, True), (20.0, True), (30.0, False), (40.0, True)]

--- a/mcp/contract/openapi.snapshot.json
+++ b/mcp/contract/openapi.snapshot.json
@@ -6722,7 +6722,7 @@
     },
     "/api/v2/phenopackets/aggregate/kidney-stages": {
       "get": {
-        "description": "Get distribution of kidney disease stages.",
+        "description": "Get distribution of kidney disease stages.\n\nThe cohort encodes CKD stages as STANDALONE HPO feature terms (HP:0012623\nStage 1 \u2026 HP:0003774 Stage 5, plus HP:0012622 unspecified CKD) \u2014 NOT as a\n``Stage`` modifier on a single CKD feature. This aggregates the present\noccurrences of those terms (``settings.hpo_terms.ckd_stages``), using the same\npresent-count semantics as /by-feature so the two reconcile. ``percentage`` is\neach stage's share of all staged-CKD annotations.",
         "operationId": "aggregate_kidney_stages_api_v2_phenopackets_aggregate_kidney_stages_get",
         "responses": {
           "200": {

--- a/mcp/src/hnf1b_mcp/resources/tool_guide.md
+++ b/mcp/src/hnf1b_mcp/resources/tool_guide.md
@@ -4,7 +4,7 @@
 
 | Tool | Purpose |
 |---|---|
-| `hnf1b_get_capabilities` | Retrieve server capabilities, limits, error codes, and this guide. Recommended (not required) for cold-session orientation; per-tool `filterable_fields` let clients build valid calls directly, and a warm client can compare `capabilities_version` to skip re-fetching. |
+| `hnf1b_get_capabilities` | Retrieve server capabilities, limits, error codes, and this guide. Recommended (not required) for cold-session orientation; per-tool `filterable_fields` let clients build valid calls directly, and a warm client can compare `capabilities_version` and `tool_guide_version` before re-fetching. |
 | `hnf1b_search` | Unified free-text discovery across individuals, variants, and publications (and genes). Returns typed ID hits; each hit carries a `resolve_with` object naming the exact tool + argument to fetch its content. |
 | `hnf1b_get_individual` | Retrieve the full phenopacket record for a single individual by `phenopacket_id`. |
 | `hnf1b_get_individuals` | Retrieve multiple phenopacket records in one call given a list of `phenopacket_id` values (batch fetch). |
@@ -13,9 +13,78 @@
 | `hnf1b_get_variant` | Retrieve the full record for a single variant by `variant_id`, including all associated interpretation details. |
 | `hnf1b_get_gene_context` | Return the HNF1B gene reference record: genomic coordinates, cross-references (HGNC/NCBI/OMIM), transcript IDs, and annotated protein domains. |
 | `hnf1b_get_publications` | List cached publications (keyword `q`, `year`, `has_doi`; `sort`), OR reverse-lookup the individuals citing one publication via `citing_pmid`. Returns `recommended_citation` strings. |
+| `hnf1b_get_publication_passages` | Hybrid RAG retrieval over cached abstracts and license-gated open-access full-text passages. Returns passage IDs, section labels, snippets/text by mode, and citation metadata. |
 | `hnf1b_get_statistics` | Return one aggregate cohort `metric` (variant counts by ACMG class, phenotype frequency, survival, etc.). Supports `dry_run=True` to preview payload cost. |
 | `hnf1b_resolve_terms` | Resolve free text to HPO terms (autocomplete) or list a controlled vocabulary (sex, allelic-state, evidence-code, …). Returns `{id, label, description}` entries. |
 | `hnf1b_compare_phenotypes` | Genotype-phenotype analytics: compare HPO phenotype frequencies (observed/excluded/unknown) across the carrier cohorts of up to 10 variants in a single call. |
+
+## Tool Reference
+
+### `hnf1b_get_capabilities`
+
+Use for server-local discovery: available tools, enum-constrained filters,
+payload-mode budgets, safety/citation contracts, resource versions, and
+descriptor size metadata.
+
+### `hnf1b_search`
+
+Use for broad free-text discovery across individuals, variants, publications,
+and genes. Hits include a `resolve_with` handoff that names the follow-up tool,
+argument, and value.
+
+### `hnf1b_get_individual`
+
+Use when you already have one `phenopacket_id` and need the individual
+phenopacket detail, including observed and excluded phenotype assertions.
+
+### `hnf1b_get_individuals`
+
+Use to batch-fetch multiple phenopacket records from an ordered `ids` list.
+
+### `hnf1b_find_individuals_by_phenotype`
+
+Use when you have exact HPO IDs and want the matching cohort by `match_mode`
+(`any` union or `all` intersection).
+
+### `hnf1b_search_variants`
+
+Use to browse variants with server-side filtering and sorting by classification,
+consequence, type, domain, gene, query text, or carrier count.
+
+### `hnf1b_get_variant`
+
+Use when you have a canonical `variant_id` or accepted `simple_id` and need the
+variant record plus carrier counts and sampled carrier IDs.
+
+### `hnf1b_get_gene_context`
+
+Use for HNF1B reference context: coordinates, external references, transcripts,
+protein domains, and optional exon details.
+
+### `hnf1b_get_publications`
+
+Use to list cached publications or reverse-lookup the individuals citing one
+publication via `citing_pmid`.
+
+### `hnf1b_get_publication_passages`
+
+Use to retrieve ranked publication passages for a query, optionally filtered by
+PMID or section and shaped by `mode` and `rerank`.
+
+### `hnf1b_get_statistics`
+
+Use for one aggregate cohort statistic at a time. Call with `dry_run=True` to
+preview the metric and expected payload before fetching the data.
+
+### `hnf1b_resolve_terms`
+
+Use to resolve free text into controlled-vocabulary entries, especially HPO IDs
+before phenotype searches.
+
+### `hnf1b_compare_phenotypes`
+
+Use for genotype-phenotype comparison across carrier cohorts for up to 10
+variants, including observed, excluded, unknown, and recorded-rate fields.
 
 ## Canonical Workflows
 

--- a/mcp/src/hnf1b_mcp/server.py
+++ b/mcp/src/hnf1b_mcp/server.py
@@ -39,8 +39,9 @@ Workflow primer:
      session (tool inventory, payload modes, pagination limits, citation
      contract) but is OPTIONAL: tools with enum-constrained filters advertise
      them in `filterable_fields`, so many valid calls can be constructed
-     directly. The descriptor is ~11k chars; a warm client should compare the
-     `capabilities_version` content hash and skip re-fetching it when unchanged.
+     directly. A warm client should compare the `capabilities_version` content
+     hash and skip re-fetching it when unchanged; see `meta.descriptor_chars`
+     for the current serialized descriptor size.
   2. Use `hnf1b_search` or `hnf1b_resolve_terms` to resolve free-text into
      stable identifiers (individuals, variants, publications, HPO terms).
   3. Fetch detail with `hnf1b_get_individual`, `hnf1b_get_variant`,

--- a/mcp/src/hnf1b_mcp/services/capabilities.py
+++ b/mcp/src/hnf1b_mcp/services/capabilities.py
@@ -16,6 +16,7 @@ from hnf1b_mcp.contract import (
 from hnf1b_mcp.services.dataclass import DataClass
 from hnf1b_mcp.services.errors import ERROR_CODES
 from hnf1b_mcp.services.publications import PUBLICATION_SORT_FIELDS
+from hnf1b_mcp.services.resources import load_resource
 from hnf1b_mcp.services.statistics import _VALID_METRICS
 from hnf1b_mcp.services.terms import _VALID_VOCABULARIES
 from hnf1b_mcp.services.variants import (
@@ -25,12 +26,15 @@ from hnf1b_mcp.services.variants import (
     VARIANT_SORT_FIELDS,
 )
 
+_TOOL_GUIDE_URI = "hnf1b://schema/tool-guide"
+
 _TOOLS: list[dict[str, str]] = [
     {
         "name": "hnf1b_get_capabilities",
         "summary": (
             "Return server capabilities, tool inventory, filterable-field "
-            "enums, payload modes, limits, citation contract, and error codes."
+            "enums, payload modes, limits, citation contract, error codes, "
+            "resource versions, and descriptor size metadata."
         ),
     },
     {
@@ -469,20 +473,37 @@ def _filterable_fields() -> dict[str, Any]:
     }
 
 
+def _content_version(body: str) -> str:
+    """Return the short sha256 content-version token used in descriptors."""
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    return f"sha256:{digest[:16]}"
+
+
 def get_capabilities() -> dict[str, Any]:
     """Return a complete capabilities descriptor for the HNF1B MCP server.
 
     Returns:
         A dictionary containing canonical workflows, tool inventory,
         filterable-field enums, payload modes, pagination limits, citation
-        contract, error codes, data-class taxonomy, v1 exclusions, safety
-        notices, and a content ``capabilities_version`` hash a warm client can
-        compare to skip re-fetching an unchanged descriptor.
+        contract, error codes, data-class taxonomy, v1 exclusions, packaged
+        resource versions, safety notices, and content hashes a warm client can
+        compare to skip re-fetching unchanged content. ``descriptor_chars`` is
+        an approximate serialized size of the returned descriptor: it includes
+        ``capabilities_version`` but necessarily excludes its own
+        self-referential size field.
     """
     settings = Settings()
+    tool_guide_version = _content_version(load_resource(_TOOL_GUIDE_URI))
     descriptor: dict[str, Any] = {
         "canonical_workflows": _CANONICAL_WORKFLOWS,
         "tools": _TOOLS,
+        "resources": {
+            "tool_guide": {
+                "uri": _TOOL_GUIDE_URI,
+                "version": tool_guide_version,
+            }
+        },
+        "tool_guide_version": tool_guide_version,
         "filterable_fields": _filterable_fields(),
         "payload_modes": {
             mode: {"char_budget": budget}
@@ -504,10 +525,12 @@ def get_capabilities() -> dict[str, Any]:
         "safety": _SAFETY,
     }
     # Deterministic content hash so a warm client can detect "nothing changed"
-    # and skip re-fetching the (~9k char) descriptor. Stable across calls until
-    # the descriptor content itself changes (no timestamps / non-determinism).
-    digest = hashlib.sha256(
-        json.dumps(descriptor, sort_keys=True, default=str).encode("utf-8")
-    ).hexdigest()
-    descriptor["capabilities_version"] = f"sha256:{digest[:16]}"
+    # and skip re-fetching the descriptor. Stable across calls until the
+    # descriptor content itself changes (no timestamps / non-determinism).
+    descriptor["capabilities_version"] = _content_version(
+        json.dumps(descriptor, sort_keys=True, default=str)
+    )
+    descriptor["descriptor_chars"] = len(
+        json.dumps(descriptor, sort_keys=True, default=str)
+    )
     return descriptor

--- a/mcp/src/hnf1b_mcp/services/compare.py
+++ b/mcp/src/hnf1b_mcp/services/compare.py
@@ -3,31 +3,56 @@
 Answers the first-class genotype-phenotype question "how do phenotype
 frequencies differ between carriers of variant X vs Y" in a single call,
 replacing an N-call client-side fan-out + hand-tally.
+
+Output contract (token-efficient, self-documenting):
+
+* ``groups`` — one entry per resolved variant: ``{alias, variant_id, simple_id,
+  n, annotation_completeness}``. ``alias`` (``g0``, ``g1``, …) is a short handle
+  used as the ``by_group`` key so the ~41-char canonical id is never repeated
+  per feature.
+* ``group_aliases`` — ``{alias: variant_id}`` convenience map.
+* ``unmatched_variant_ids`` — caller ids that name no known variant (typo / stale
+  id), ALWAYS present. A real variant with zero phenotyped carriers instead stays
+  in ``groups`` with ``n: 0`` — the two are no longer indistinguishable.
+* ``features`` — each ``{hpo_id, label, total_observed, by_group}`` where
+  ``by_group[alias]`` is the fixed-order tuple
+  ``[observed, excluded, unknown, observed_rate_among_recorded]``.
 """
 
 from __future__ import annotations
 
+from math import comb
 from typing import Any
 
 from ..client.api_client import ApiClient
+from ..config import Settings
 from ..contract._generated_paths import PHENOPACKETS_BY_VARIANT_BY_VARIANT_ID
 from .errors import McpToolError
+from .shaping import apply_budget, resolve_mode
+from .variants import build_variant_id_index
 
 _MAX_VARIANTS = 10
 _MAX_TOP_N = 100
 
+#: One-line, machine-readable description of the ``by_group`` cell layout, echoed
+#: in meta so a consumer never has to infer the tuple order from prose.
+BY_GROUP_FORMAT = (
+    "by_group[alias] = [observed, excluded, unknown, observed_rate_among_recorded];"
+    " keys are group aliases (see group_aliases). rate = observed/(observed+"
+    "excluded) rounded to 3dp, or null when no carrier recorded the term."
+)
+
 
 def _tally_features(
     phenopackets: list[dict[str, Any]],
-) -> tuple[dict[str, dict[str, Any]], int]:
+) -> dict[str, dict[str, Any]]:
     """Tally observed/excluded HPO features across a carrier group.
 
     Args:
         phenopackets: Carrier phenopacket content dicts.
 
     Returns:
-        ``(per_hpo, n)`` where *per_hpo* maps ``hpo_id`` to
-        ``{label, observed, excluded}`` and *n* is the carrier count.
+        ``per_hpo`` mapping ``hpo_id`` to ``{label, observed, excluded}``.
     """
     per_hpo: dict[str, dict[str, Any]] = {}
     for pp in phenopackets:
@@ -44,31 +69,90 @@ def _tally_features(
                 entry["excluded"] += 1
             else:
                 entry["observed"] += 1
-    return per_hpo, len(phenopackets)
+    return per_hpo
+
+
+def _observed_rate(observed: int, excluded: int) -> float | None:
+    """Penetrance among RECORDED carriers: observed/(observed+excluded).
+
+    ``None`` (not ``0``) when no carrier recorded the term, so "nobody assessed
+    it" is never conflated with "assessed and absent in everyone".
+    """
+    recorded = observed + excluded
+    if recorded <= 0:
+        return None
+    return round(observed / recorded, 3)
+
+
+def _fisher_exact_two_sided(a: int, b: int, c: int, d: int) -> float | None:
+    """Two-sided Fisher exact p-value for the 2x2 table ``[[a, b], [c, d]]``.
+
+    Dependency-free (the MCP sidecar ships no scipy/numpy): sums hypergeometric
+    probabilities over all tables with the same margins whose probability is
+    ``<=`` the observed table's (the standard two-sided convention, matching
+    ``scipy.stats.fisher_exact``). EXPLORATORY / uncorrected — research use only.
+
+    Args:
+        a: Top-left cell (e.g. group-0 observed).
+        b: Top-right cell (e.g. group-0 excluded).
+        c: Bottom-left cell (e.g. group-1 observed).
+        d: Bottom-right cell (e.g. group-1 excluded).
+
+    Returns:
+        The two-sided p-value rounded to 4dp, or ``None`` when the table is empty.
+    """
+    n = a + b + c + d
+    if n <= 0:
+        return None
+    r1, r2, c1 = a + b, c + d, a + c
+    denom = comb(n, c1)
+    if denom == 0:
+        return None
+
+    def prob(k: int) -> float:
+        return comb(r1, k) * comb(r2, c1 - k) / denom
+
+    p_obs = prob(a)
+    lo, hi = max(0, c1 - r2), min(r1, c1)
+    total = sum(prob(k) for k in range(lo, hi + 1) if prob(k) <= p_obs * (1 + 1e-7))
+    return min(1.0, round(total, 4))
 
 
 async def compare_phenotypes(
     client: ApiClient,
     variant_ids: list[str],
     top_n: int = 25,
+    response_mode: str = "compact",
+    include_stats: bool = False,
 ) -> dict[str, Any]:
     """Compare HPO phenotype frequencies across carriers of several variants.
 
-    For each variant the carrier cohort is fetched once (``/phenopackets/
-    by-variant/{id}`` returns full phenopacket content), then per-HPO
-    observed / excluded / unknown counts are tabulated per group. Features are
-    ranked by total observed count across groups and the top *top_n* returned.
+    Each variant id (canonical ``variant_id`` OR friendly ``simple_id`` such as
+    ``"Var6"``) is resolved to its canonical id via the shared variant index;
+    ids that name no known variant are returned in ``unmatched_variant_ids`` and
+    omitted from ``groups`` (a typo is no longer indistinguishable from a real
+    zero-carrier variant). For each resolved variant the carrier cohort is fetched
+    once, per-HPO observed/excluded/unknown counts are tabulated, features are
+    ranked by total observed across groups, and the top *top_n* are returned —
+    bounded by the *response_mode* char budget.
 
     Args:
         client: Authenticated :class:`ApiClient` instance.
-        variant_ids: 1–10 canonical variant ids (GA4GH VRS / CNV descriptor).
+        variant_ids: 1–10 variant ids (canonical and/or ``simple_id``).
         top_n: Max distinct HPO features to return (ranked by total observed).
+        response_mode: ``minimal``/``compact``/``standard``/``full`` — controls
+            the char budget the feature list is trimmed to (with a ``_dropped``
+            signal), so a comparison never overflows the mode ceiling.
+        include_stats: When ``True`` and exactly two variants resolve, attach an
+            EXPLORATORY per-feature ``stats`` (two-sided Fisher exact ``fisher_p``
+            + ``effect_direction``). Uncorrected, research use only.
 
     Returns:
-        A dict with ``groups`` (per-variant ``{variant_id, n}``), ``features``
-        (each ``{hpo_id, label, total_observed, by_group: {variant_id:
-        {observed, excluded, unknown}}}``), ``total_distinct_features``, and a
-        ``note`` describing the unknown semantics.
+        A dict with ``groups``, ``group_aliases``, ``unmatched_variant_ids``,
+        ``features`` (``by_group`` keyed by alias, cells
+        ``[observed, excluded, unknown, observed_rate_among_recorded]``),
+        ``total_distinct_features``, ``returned_features``, ``top_n``,
+        ``has_more``, and a ``note``.
 
     Raises:
         McpToolError: ``invalid_input`` for an empty/oversized variant list or
@@ -93,47 +177,98 @@ async def compare_phenotypes(
             argument="top_n",
         )
 
-    groups: list[dict[str, Any]] = []
-    # hpo_id -> {label, by_group: {variant_id: {observed, excluded}}}
-    feature_index: dict[str, dict[str, Any]] = {}
+    mode = resolve_mode(response_mode)
 
-    for vid in variant_ids:
+    # ------------------------------------------------------------------
+    # Resolve ids -> canonical (accepts simple_id); collect unmatched.
+    # ------------------------------------------------------------------
+    index = await build_variant_id_index(client)
+    ordered_canon: list[str] = []
+    group_rows: dict[str, dict[str, Any]] = {}
+    unmatched: list[str] = []
+    seen: set[str] = set()
+    for rid in variant_ids:
+        row = index.get(rid) or index.get(str(rid))
+        if row is None:
+            unmatched.append(rid)
+            continue
+        canon = row["variant_id"]
+        if canon in seen:
+            continue  # same variant supplied twice (e.g. via id + simple_id)
+        seen.add(canon)
+        ordered_canon.append(canon)
+        group_rows[canon] = row
+
+    alias_of: dict[str, str] = {c: f"g{i}" for i, c in enumerate(ordered_canon)}
+
+    # ------------------------------------------------------------------
+    # Fetch + tally each resolved cohort.
+    # ------------------------------------------------------------------
+    group_n: dict[str, int] = {}
+    # hpo_id -> {label, by_alias: {alias: {observed, excluded}}}
+    feature_index: dict[str, dict[str, Any]] = {}
+    for canon in ordered_canon:
+        alias = alias_of[canon]
         raw: Any = await client.get(
-            PHENOPACKETS_BY_VARIANT_BY_VARIANT_ID.format(variant_id=vid)
+            PHENOPACKETS_BY_VARIANT_BY_VARIANT_ID.format(variant_id=canon)
         )
         carriers: list[dict[str, Any]] = raw if isinstance(raw, list) else []
         phenopackets = [
             c.get("phenopacket", {}) for c in carriers if isinstance(c, dict)
         ]
-        per_hpo, n = _tally_features(phenopackets)
-        groups.append({"variant_id": vid, "n": n})
+        per_hpo = _tally_features(phenopackets)
+        group_n[alias] = len(phenopackets)
         for hpo_id, counts in per_hpo.items():
             idx = feature_index.setdefault(
-                hpo_id, {"label": counts["label"], "by_group": {}}
+                hpo_id, {"label": counts["label"], "by_alias": {}}
             )
             if not idx["label"]:
                 idx["label"] = counts["label"]
-            idx["by_group"][vid] = {
+            idx["by_alias"][alias] = {
                 "observed": counts["observed"],
                 "excluded": counts["excluded"],
             }
 
-    group_n: dict[str, int] = {g["variant_id"]: g["n"] for g in groups}
+    aliases = [alias_of[c] for c in ordered_canon]
 
+    # ------------------------------------------------------------------
+    # annotation_completeness per group: mean over the FULL feature universe
+    # of (observed+excluded)/n — the fraction of carriers for whom each term was
+    # assessed. Stable (computed before top_n slicing). None when n == 0.
+    # ------------------------------------------------------------------
+    n_features = len(feature_index)
+    completeness: dict[str, float | None] = {}
+    for alias in aliases:
+        n = group_n.get(alias, 0)
+        if n <= 0 or n_features == 0:
+            completeness[alias] = None
+            continue
+        recorded = 0
+        for idx in feature_index.values():
+            cell = idx["by_alias"].get(alias)
+            if cell:
+                recorded += cell["observed"] + cell["excluded"]
+        completeness[alias] = round(recorded / (n * n_features), 3)
+
+    # ------------------------------------------------------------------
+    # Build features with alias-keyed tuple cells.
+    # ------------------------------------------------------------------
     features: list[dict[str, Any]] = []
     for hpo_id, idx in feature_index.items():
-        by_group: dict[str, dict[str, int]] = {}
+        by_group: dict[str, list[Any]] = {}
         total_observed = 0
-        for vid in variant_ids:
-            cell = idx["by_group"].get(vid, {"observed": 0, "excluded": 0})
+        for alias in aliases:
+            cell = idx["by_alias"].get(alias, {"observed": 0, "excluded": 0})
             observed = cell["observed"]
             excluded = cell["excluded"]
             total_observed += observed
-            by_group[vid] = {
-                "observed": observed,
-                "excluded": excluded,
-                "unknown": max(group_n.get(vid, 0) - observed - excluded, 0),
-            }
+            unknown = max(group_n.get(alias, 0) - observed - excluded, 0)
+            by_group[alias] = [
+                observed,
+                excluded,
+                unknown,
+                _observed_rate(observed, excluded),
+            ]
         features.append(
             {
                 "hpo_id": hpo_id,
@@ -143,23 +278,93 @@ async def compare_phenotypes(
             }
         )
 
-    features.sort(key=lambda f: f["total_observed"], reverse=True)
+    # Deterministic order: total_observed desc, then hpo_id asc for a stable tie-break.
+    features.sort(key=lambda f: (-f["total_observed"], f["hpo_id"]))
     total_distinct = len(features)
     shown = features[:top_n]
 
-    return {
+    # ------------------------------------------------------------------
+    # Optional exploratory enrichment stats (exactly two groups only).
+    # ------------------------------------------------------------------
+    stats_note: str | None = None
+    if include_stats:
+        if len(aliases) == 2:
+            g0, g1 = aliases[0], aliases[1]
+            for feat in shown:
+                a, b, _, r0 = feat["by_group"][g0]
+                c, d, _, r1 = feat["by_group"][g1]
+                if r0 is None or r1 is None:
+                    direction = "insufficient_data"
+                elif r0 > r1:
+                    direction = "higher_in_g0"
+                elif r1 > r0:
+                    direction = "higher_in_g1"
+                else:
+                    direction = "equal"
+                feat["stats"] = {
+                    "fisher_p": _fisher_exact_two_sided(a, b, c, d),
+                    "effect_direction": direction,
+                }
+            stats_note = (
+                "stats.fisher_p is a two-sided Fisher exact test on the 2x2"
+                " [observed, excluded] table for g0 vs g1. EXPLORATORY and"
+                " uncorrected for multiple comparisons — research use only, not a"
+                " confirmatory finding."
+            )
+        else:
+            stats_note = (
+                "include_stats was requested but enrichment stats require exactly"
+                f" two resolved variants; {len(aliases)} resolved — stats omitted."
+            )
+
+    groups = [
+        {
+            "alias": alias_of[c],
+            "variant_id": c,
+            "simple_id": group_rows[c].get("simple_id"),
+            "n": group_n.get(alias_of[c], 0),
+            "annotation_completeness": completeness.get(alias_of[c]),
+        }
+        for c in ordered_canon
+    ]
+
+    note = (
+        "by_group cells are [observed, excluded, unknown,"
+        " observed_rate_among_recorded] keyed by group alias (see group_aliases);"
+        " observed = HPO present, excluded = confirmed absent, unknown = carrier"
+        " did not report the term, observed_rate_among_recorded ="
+        " observed/(observed+excluded) (penetrance among assessed; null when none"
+        " recorded). annotation_completeness is the mean fraction of carriers for"
+        " whom each term was assessed. unmatched_variant_ids lists ids that name"
+        " no known variant (vs a real variant with n:0). Ranked by total observed"
+        " across groups; the top top_n of total_distinct_features are returned."
+    )
+
+    result: dict[str, Any] = {
         "groups": groups,
+        "group_aliases": {alias_of[c]: c for c in ordered_canon},
+        "unmatched_variant_ids": unmatched,
         "features": shown,
         "total_distinct_features": total_distinct,
-        # Make truncation explicit so the caller knows how many features are
-        # hidden and can widen top_n to retrieve them — never a silent cut.
         "returned_features": len(shown),
         "top_n": top_n,
         "has_more": total_distinct > len(shown),
-        "note": (
-            "Per-group counts: observed (HPO present), excluded (confirmed"
-            " absent), unknown (carrier did not report the term). Ranked by"
-            " total observed across groups; the top top_n of"
-            " total_distinct_features are returned — see has_more/top_n."
-        ),
+        "note": note,
+        "_meta": {"by_group_format": BY_GROUP_FORMAT},
     }
+    if stats_note is not None:
+        result["_meta"]["stats_note"] = stats_note
+
+    # ------------------------------------------------------------------
+    # Enforce the response_mode char budget (the only list tool that lacked one):
+    # trim the features list to fit, keeping at least the top-ranked feature, and
+    # re-sync the returned_features/has_more counters with the truncation.
+    # ------------------------------------------------------------------
+    budget = Settings().mode_char_budgets.get(mode, 12000)
+    result, dropped = apply_budget(result, budget, ["features"], keep_min=1)
+    if dropped is not None:
+        result["returned_features"] = len(result["features"])
+        result["has_more"] = total_distinct > len(result["features"])
+        result["_dropped"] = dropped
+
+    return result

--- a/mcp/src/hnf1b_mcp/services/individuals.py
+++ b/mcp/src/hnf1b_mcp/services/individuals.py
@@ -369,7 +369,9 @@ async def get_individuals(
 
     Args:
         client: Authenticated ApiClient instance.
-        ids: Optional list of phenopacket IDs for batch retrieval.
+        ids: Optional list of phenopacket IDs for batch retrieval. Results are
+            returned in this exact order (the batch endpoint's own order is not
+            preserved), so a caller may correlate by position.
         filters: Optional filter dict; keys become ``filter[key]`` params.
         page_size: Number of results per page (discovery endpoint only).
         expand: If True and using discovery, fetch each record in full.
@@ -414,6 +416,14 @@ async def get_individuals(
                 "phenopacket": phenopacket_content,
             }
             individuals.append(_shape_individual(record))
+        # B4: re-emit in the caller's requested `ids` order. The batch endpoint
+        # returns records in its own (DB) order, so [65, 99, 160] could come back
+        # [160, 65, 99] — silently wrong for any caller correlating by position.
+        # Each record self-identifies, so map by phenopacket_id and rebuild in
+        # request order; ids the endpoint did not return are simply absent (and
+        # captured in not_found below). Consistent with find_individuals_by_phenotype.
+        by_id = {ind.get("phenopacket_id"): ind for ind in individuals}
+        individuals = [by_id[i] for i in ids if i in by_id]
         # Surface which requested IDs the batch endpoint did not return, so a
         # caller can distinguish "does not exist" from a silently-dropped id.
         # Computed BEFORE filtering: not_found means "absent", not "filtered out".

--- a/mcp/src/hnf1b_mcp/services/publication_passages.py
+++ b/mcp/src/hnf1b_mcp/services/publication_passages.py
@@ -10,7 +10,7 @@ and the retrieval diagnostics surfaced via ``_meta``.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence
+from typing import Any, Literal, Optional, Sequence
 
 from hnf1b_mcp.client.api_client import ApiClient
 from hnf1b_mcp.config import Settings
@@ -23,6 +23,12 @@ from hnf1b_mcp.services.shaping import apply_budget
 API_MODES = ("brief", "full", "ids_only")
 #: Rerank strategies accepted by the backend endpoint.
 RERANK_MODES = ("rrf", "lexical", "off")
+
+#: Schema-visible enums for the ``mode`` / ``rerank`` tool params. Kept in
+#: lockstep with :data:`API_MODES` / :data:`RERANK_MODES` by a drift-guard test;
+#: the runtime ``_validate_*`` guards stay as defense-in-depth (Literal ⊂ str).
+PassageMode = Literal["brief", "full", "ids_only"]
+RerankMode = Literal["rrf", "lexical", "off"]
 
 #: Snippet length requested from the backend, sized to the response mode.
 _SNIPPET_BY_MODE: dict[str, int] = {

--- a/mcp/src/hnf1b_mcp/services/reference.py
+++ b/mcp/src/hnf1b_mcp/services/reference.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from ..client.api_client import ApiClient
 from ..config import Settings
@@ -15,6 +15,14 @@ from .errors import McpToolError
 from .shaping import apply_budget
 
 _HARD_CAP = 80_000
+
+#: Genome assemblies the gene-context tool advertises. Constrains the param to a
+#: schema-visible enum and — unlike before — rejects an unknown build at
+#: validation time instead of silently forwarding it to the backend (which
+#: defaults to GRCh38 for any value, masking the typo). Kept in lockstep with
+#: :data:`GENOME_BUILDS` by a drift-guard test.
+GENOME_BUILDS = ("GRCh38", "GRCh37")
+GenomeBuild = Literal["GRCh38", "GRCh37"]
 
 # Internal DB artifacts an LLM never needs. Stripped from every mode EXCEPT
 # ``full`` (full = complete provenance record). A row ``id`` is a server-internal
@@ -93,7 +101,18 @@ async def get_gene_context(
         - ``domains`` – list of protein-domain dicts (only when
           *include_domains* is ``True``).
         - ``uri`` – a stable ``hnf1b://gene/{gene_symbol}`` identifier.
+
+    Raises:
+        McpToolError: ``invalid_input`` when *genome_build* is not one of
+            :data:`GENOME_BUILDS`; ``not_found`` when the gene is absent.
     """
+    if genome_build not in GENOME_BUILDS:
+        raise McpToolError(
+            "invalid_input",
+            f"genome_build must be one of {list(GENOME_BUILDS)}",
+            argument="genome_build",
+            choices=list(GENOME_BUILDS),
+        )
     params: dict[str, Any] = {"genome_build": genome_build}
 
     try:

--- a/mcp/src/hnf1b_mcp/services/shaping.py
+++ b/mcp/src/hnf1b_mcp/services/shaping.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from .errors import McpToolError
 
@@ -11,6 +11,15 @@ _T = TypeVar("_T")
 
 MODES = ("minimal", "compact", "standard", "full")
 DEFAULT_MODE = "compact"
+
+#: Schema-visible enum for the ``response_mode`` parameter shared by every tool.
+#: Typing a tool param with this Literal makes the four valid values appear in
+#: the tool's JSON input schema (so a client/agent can autocomplete and a typo is
+#: rejected at validation time), instead of an opaque ``string``. Kept in lockstep
+#: with :data:`MODES` by a drift-guard test (``set(get_args(ResponseMode)) ==
+#: set(MODES)``); ``resolve_mode`` remains the runtime guard (Literal is a ``str``
+#: subtype, so the two compose).
+ResponseMode = Literal["minimal", "compact", "standard", "full"]
 
 # Default cap for an inline id list (carrier ids, citing-individual ids, …) shown
 # without an explicit opt-in. A heavily-populated list (e.g. the recurrent 17q12

--- a/mcp/src/hnf1b_mcp/services/statistics.py
+++ b/mcp/src/hnf1b_mcp/services/statistics.py
@@ -56,6 +56,42 @@ def _round_percentages(obj: Any) -> Any:
     return obj
 
 
+def _null_degenerate_survival_ci(result_data: dict[str, Any]) -> bool:
+    """Null any impossible Kaplan-Meier CI (lower bound above the estimate).
+
+    B6 defense-in-depth: when survival drops to exactly 0 the backend skips the
+    log-log CI math and ships the initialized ``[1.0, 1.0]`` interval alongside
+    ``survival_probability: 0`` — an interval that does not contain its own point
+    estimate. A CI whose lower bound exceeds the estimate is impossible, so null
+    both bounds. The legitimate ``S == 1.0`` anchor (``[1, 1]`` around 1.0) is
+    left untouched (its lower bound is not greater than the estimate). Guarding
+    MCP-side too means a stale hosted backend cannot resurface the artifact.
+
+    Args:
+        result_data: The survival payload (with ``groups[].survival_data``).
+
+    Returns:
+        ``True`` when at least one point's CI was nulled.
+    """
+    fixed = False
+    groups = result_data.get("groups")
+    if not isinstance(groups, list):
+        return False
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        for point in group.get("survival_data") or []:
+            if not isinstance(point, dict):
+                continue
+            estimate = point.get("survival_probability")
+            lower = point.get("ci_lower")
+            if estimate is not None and lower is not None and lower > estimate:
+                point["ci_lower"] = None
+                point["ci_upper"] = None
+                fixed = True
+    return fixed
+
+
 def _downsample(points: list[Any], keep: int) -> list[Any]:
     """Uniformly down-sample a time-series, always retaining first and last.
 
@@ -333,11 +369,49 @@ async def get_statistics(
                     row["publication_count"] = len(row["publications"])
                     row.pop("publications", None)
 
+    if metric == "by_feature":
+        # B3: the backend `percentage` is annotation-SHARE (present_count divided
+        # by the sum of present_counts across ALL features — it sums to ~100% over
+        # rows), NOT cohort prevalence. An LLM reading "Renal cysts 11.9%" as
+        # prevalence is clinically wrong (the real figure is ~44.6%). The honest
+        # numerators/denominators are already in each row's `details`, so derive
+        # the two prevalence figures here (additive — `percentage` is untouched so
+        # the REST/frontend contract does not break).
+        rows = result_data.get("raw")
+        if isinstance(rows, list):
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                details = row.get("details")
+                if (
+                    not isinstance(details, dict)
+                    or details.get("present_count") is None
+                ):
+                    continue
+                present = int(details.get("present_count") or 0)
+                absent = int(details.get("absent_count") or 0)
+                not_reported = int(details.get("not_reported_count") or 0)
+                cohort = present + absent + not_reported
+                reported = present + absent
+                if cohort > 0:
+                    row["prevalence_among_cohort"] = round(100 * present / cohort, 2)
+                if reported > 0:
+                    row["prevalence_among_reported"] = round(
+                        100 * present / reported, 2
+                    )
+
     # We need to account for the wrapper overhead ("metric" key etc.).
     wrapper_overhead = len(json.dumps({"metric": metric, "result": None}))
     inner_budget = max(max_chars - wrapper_overhead, 1)
 
     if metric == "survival":
+        # B6 guard: scrub impossible terminal CIs before shaping (see helper).
+        if _null_degenerate_survival_ci(result_data):
+            result_data["ci_note"] = (
+                "One or more terminal points had an impossible confidence interval"
+                " (lower bound above the survival estimate — a last-event"
+                " artifact); their ci_lower/ci_upper were set to null."
+            )
         # Preserve every comparison arm; down-sample curves to fit the budget.
         shaped_result, dropped = _shape_survival(result_data, inner_budget)
     else:
@@ -371,17 +445,63 @@ async def get_statistics(
                 " count_mode='unique' for a distribution over distinct variants."
             )
 
+    # B3: label what by_feature's fields mean so an annotation-share is never read
+    # as cohort prevalence. `percentage` (kept as-is) is annotation-share;
+    # `prevalence_among_cohort`/`prevalence_among_reported` (added above) are the
+    # clinical figures.
+    if metric == "by_feature":
+        out["unit"] = "annotation_share_pct"
+        out["unit_note"] = (
+            "percentage is each feature's share of all PRESENT annotations (sums"
+            " to ~100% across features) — NOT cohort prevalence. Use"
+            " prevalence_among_cohort = present/(present+absent+not_reported) for"
+            " the clinical prevalence, or prevalence_among_reported ="
+            " present/(present+absent). Raw counts are in each row's details."
+        )
+
+    # B5: reconcile the timeline counters. cumulative is a running SUM of the
+    # per-year count, and a phenopacket cited by publications from >1 year is
+    # counted in EACH year, so cumulative can legitimately exceed
+    # total_phenopackets (~864). Without this note the >total figure reads as a bug.
+    if metric == "publications_timeline":
+        out["unit"] = "phenopackets_per_publication_year"
+        out["unit_note"] = (
+            "count = distinct phenopackets linked to a publication of that year;"
+            " a phenopacket cited across multiple years is counted in EACH, so"
+            " cumulative (a running sum of count) can exceed total_phenopackets"
+            " (~864) — it is not a distinct running total. publication_count ="
+            " distinct PMIDs that year (list them via hnf1b_get_publications"
+            "(year=...))."
+        )
+
+    # Collect any meta signals into a single merged block (run_tool hoists _meta).
+    meta_signals: dict[str, Any] = {}
+
     # Surface a count_mode that was accepted (valid value) but does not apply to
     # this metric, so it is never silently ignored.
     if count_mode is not None and metric not in _VARIANT_INSTANCE_METRICS:
-        out["_meta"] = {
-            "ignored_params": {
-                "count_mode": (
-                    "count_mode applies only to "
-                    f"{sorted(_VARIANT_INSTANCE_METRICS)}; ignored for {metric!r}"
-                )
-            }
+        meta_signals["ignored_params"] = {
+            "count_mode": (
+                "count_mode applies only to "
+                f"{sorted(_VARIANT_INSTANCE_METRICS)}; ignored for {metric!r}"
+            )
         }
+
+    # B1: kidney_stages is correctly wired, but the backend SQL scopes CKD stages
+    # to a modifier the cohort does not use, so it can come back empty. An empty
+    # advertised metric must never be a silent dead-end — point the caller at the
+    # data that does exist instead of leaving a bare {"raw": []}.
+    if metric == "kidney_stages" and isinstance(upstream, list) and not upstream:
+        meta_signals["empty_result"] = (
+            "kidney_stages returned no rows. CKD stages may be recorded as"
+            " standalone HPO features rather than CKD-stage modifiers on this"
+            " backend — try metric='by_feature' (filter labels containing"
+            " 'Stage'), or hnf1b_find_individuals_by_phenotype with a CKD-stage"
+            " HPO id."
+        )
+
+    if meta_signals:
+        out["_meta"] = meta_signals
 
     if dropped is not None:
         out["_dropped"] = dropped

--- a/mcp/src/hnf1b_mcp/services/variants.py
+++ b/mcp/src/hnf1b_mcp/services/variants.py
@@ -401,6 +401,79 @@ def _project_row(row: dict[str, Any], mode: str) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Shared variant-id resolution (used by get_variant AND compare_phenotypes)
+# ---------------------------------------------------------------------------
+
+
+async def build_variant_id_index(
+    client: ApiClient,
+) -> dict[str, dict[str, Any]]:
+    """Map every accepted variant-id form to its full aggregate row.
+
+    Pages the all-variants aggregate endpoint once (~200 rows; the
+    :class:`ApiClient` 300 s cache means a sibling call in the same window — e.g.
+    ``get_variant`` — reuses the warm fetch) and indexes each row under BOTH its
+    canonical ``variant_id`` and the friendly ``str(simple_id)`` (e.g. ``"Var6"``).
+    The single source of truth for "does this id name a real variant, and what is
+    its canonical id" — shared by :func:`get_variant` and
+    :func:`~hnf1b_mcp.services.compare.compare_phenotypes` so both accept a
+    ``simple_id`` and resolve it to the same canonical id (drift-guarded by tests).
+
+    Args:
+        client: Authenticated :class:`ApiClient` instance.
+
+    Returns:
+        ``{accepted_id: row}`` where *accepted_id* is the canonical ``variant_id``
+        or ``str(simple_id)``; the canonical key wins on collision.
+    """
+    listing: dict[str, Any] = await client.get(
+        PHENOPACKETS_AGGREGATE_ALL_VARIANTS,
+        params={"page[number]": 1, "page[size]": _MAX_PAGE_SIZE},
+    )
+    rows: list[dict[str, Any]] = listing.get("data") or []
+    index: dict[str, dict[str, Any]] = {}
+    for item in rows:
+        vid = item.get("variant_id")
+        if not vid:
+            continue
+        index[vid] = item
+        sid = item.get("simple_id")
+        if sid is not None:
+            index.setdefault(str(sid), item)
+    return index
+
+
+async def resolve_variant_ids(
+    client: ApiClient, raw_ids: list[str]
+) -> tuple[dict[str, str], list[str]]:
+    """Resolve caller-supplied variant ids (canonical OR ``simple_id``) to canonical.
+
+    Thin convenience wrapper over :func:`build_variant_id_index`.
+
+    Args:
+        client: Authenticated :class:`ApiClient` instance.
+        raw_ids: The caller-supplied ids (any mix of canonical / ``simple_id``).
+
+    Returns:
+        ``(canonical_by_input, unmatched)`` — *canonical_by_input* maps each
+        resolvable input id to its canonical ``variant_id`` (input order is the
+        caller's responsibility); *unmatched* lists well-formed ids that name no
+        known variant (a typo / stale id), so a caller can distinguish them from a
+        real variant with zero carriers.
+    """
+    index = await build_variant_id_index(client)
+    canonical_by_input: dict[str, str] = {}
+    unmatched: list[str] = []
+    for rid in raw_ids:
+        row = index.get(rid) or index.get(str(rid))
+        if row is not None:
+            canonical_by_input[rid] = row["variant_id"]
+        else:
+            unmatched.append(rid)
+    return canonical_by_input, unmatched
+
+
+# ---------------------------------------------------------------------------
 # Public service functions
 # ---------------------------------------------------------------------------
 
@@ -662,22 +735,12 @@ async def get_variant(
         McpToolError: ``not_found`` if no variant matches *variant_id*;
             ``temporarily_unavailable`` on upstream errors.
     """
-    listing: dict[str, Any] = await client.get(
-        PHENOPACKETS_AGGREGATE_ALL_VARIANTS,
-        params={"page[number]": 1, "page[size]": _MAX_PAGE_SIZE},
-    )
-    rows: list[dict[str, Any]] = listing.get("data") or []
     # Accept either the canonical variant_id (GA4GH VRS / CNV descriptor) or the
-    # friendly simple_id (e.g. "Var6") shown in list payloads.
-    match: dict[str, Any] | None = next(
-        (
-            item
-            for item in rows
-            if item.get("variant_id") == variant_id
-            or str(item.get("simple_id")) == variant_id
-        ),
-        None,
-    )
+    # friendly simple_id (e.g. "Var6") shown in list payloads. The lookup is the
+    # SAME shared index compare_phenotypes uses, so both tools accept a simple_id
+    # and resolve it to one canonical id (drift-guarded by tests).
+    index = await build_variant_id_index(client)
+    match: dict[str, Any] | None = index.get(variant_id) or index.get(str(variant_id))
     if match is None:
         raise McpToolError(
             "not_found",

--- a/mcp/src/hnf1b_mcp/tools/capabilities.py
+++ b/mcp/src/hnf1b_mcp/tools/capabilities.py
@@ -25,6 +25,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:  # noqa: ARG001
         annotations={
             "title": "HNF1B: Capabilities & Tool Inventory",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )

--- a/mcp/src/hnf1b_mcp/tools/capabilities.py
+++ b/mcp/src/hnf1b_mcp/tools/capabilities.py
@@ -42,9 +42,12 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:  # noqa: ARG001
         `filterable_fields`, so many valid calls can be built without a cold
         capabilities load. A
         warm client should compare the returned `capabilities_version` content
-        hash and skip re-fetching this ~11k-char descriptor when it is
-        unchanged.  No arguments are required and no API call is made — the
-        response is assembled from server-local data.
+        hash and skip re-fetching this descriptor when it is unchanged. It can
+        also compare `tool_guide_version` before re-reading the tool-guide
+        resource and inspect `descriptor_chars` (echoed as
+        `meta.descriptor_chars`) for the current serialized descriptor size. No
+        arguments are required and no API call is made — the response is
+        assembled from server-local data.
 
         Returns:
             A dict with keys ``canonical_workflows``, ``tools``,
@@ -52,13 +55,16 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:  # noqa: ARG001
             enum values — read this to construct valid calls), ``payload_modes``,
             ``limits``, ``identifiers`` (the canonical id form per record type),
             ``pagination_semantics``, ``citation_contract``, ``error_codes``,
-            ``data_classes``, ``exclusions``, ``safety``, ``capabilities_version``
-            (a content hash a warm client can compare to skip re-fetching),
+            ``data_classes``, ``exclusions``, ``safety``, ``resources``,
+            ``tool_guide_version``, ``capabilities_version`` (a content hash a
+            warm client can compare to skip re-fetching), ``descriptor_chars``,
             ``data_class``, and ``meta``.
         """
 
         async def handler() -> dict[str, Any]:
-            return get_capabilities()
+            descriptor = get_capabilities()
+            descriptor["_meta"] = {"descriptor_chars": descriptor["descriptor_chars"]}
+            return descriptor
 
         return await run_tool(
             handler, data_class=DataClass.OPERATIONAL, response_mode="compact"

--- a/mcp/src/hnf1b_mcp/tools/compare.py
+++ b/mcp/src/hnf1b_mcp/tools/compare.py
@@ -27,6 +27,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Compare Phenotypes Across Variants",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )

--- a/mcp/src/hnf1b_mcp/tools/compare.py
+++ b/mcp/src/hnf1b_mcp/tools/compare.py
@@ -10,7 +10,7 @@ from hnf1b_mcp.client.api_client import ApiClient
 from hnf1b_mcp.services import compare as compare_service
 from hnf1b_mcp.services.dataclass import DataClass
 from hnf1b_mcp.services.safe_tool import run_tool
-from hnf1b_mcp.services.shaping import resolve_mode
+from hnf1b_mcp.services.shaping import ResponseMode, resolve_mode
 
 
 def register(mcp: FastMCP, client: ApiClient | None) -> None:
@@ -33,7 +33,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
     async def hnf1b_compare_phenotypes(
         variant_ids: list[str],
         top_n: int = 25,
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
     ) -> dict[str, Any]:
         """Compare HPO phenotype frequencies across carriers of several variants.
 

--- a/mcp/src/hnf1b_mcp/tools/compare.py
+++ b/mcp/src/hnf1b_mcp/tools/compare.py
@@ -34,6 +34,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         variant_ids: list[str],
         top_n: int = 25,
         response_mode: ResponseMode | None = None,
+        include_stats: bool = False,
     ) -> dict[str, Any]:
         """Compare HPO phenotype frequencies across carriers of several variants.
 
@@ -41,30 +42,48 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         variant's carriers and tallying HPO terms by hand, this returns per-HPO
         observed / excluded / unknown counts for each variant group in one call.
 
-        Pass the canonical ``variant_id`` values (GA4GH VRS / CNV descriptor, as
-        returned by ``hnf1b_search_variants`` / ``hnf1b_get_variant``). Up to 10
-        variants per call.
+        Pass canonical ``variant_id`` values (GA4GH VRS / CNV descriptor) and/or
+        the friendly ``simple_id`` (e.g. ``"Var6"``) returned by
+        ``hnf1b_search_variants`` / ``hnf1b_get_variant`` — both are accepted and
+        resolved to the canonical id. Up to 10 variants per call. An id that names
+        no known variant (typo / stale id) is returned in
+        ``unmatched_variant_ids`` and omitted from ``groups``; a real variant with
+        no phenotyped carriers instead appears in ``groups`` with ``n: 0`` — the
+        two are reported distinctly.
 
         Args:
-            variant_ids: 1–10 variant ids whose carrier cohorts to compare.
+            variant_ids: 1–10 variant ids (canonical and/or ``simple_id``).
             top_n: Maximum distinct HPO features to return, ranked by total
                 observed count across groups (default 25, max 100).
             response_mode: Response verbosity — one of ``minimal``,
                 ``compact``, ``standard``, ``full``.  Defaults to ``compact``.
+                Controls the char budget the feature list is trimmed to (a
+                ``meta.truncated`` signal fires when it does), so a large
+                comparison never overflows the mode ceiling.
+            include_stats: When ``True`` and exactly two variants resolve, attach
+                an EXPLORATORY per-feature ``stats`` block (two-sided Fisher exact
+                ``fisher_p`` + ``effect_direction``). Uncorrected for multiple
+                comparisons — research use only, not a confirmatory finding.
 
         Returns:
-            A dict with ``groups`` (per-variant ``{variant_id, n}`` carrier
-            counts), ``features`` (each ``{hpo_id, label, total_observed,
-            by_group: {variant_id: {observed, excluded, unknown}}}``),
-            ``total_distinct_features``, a ``note``, ``data_class``, and
-            ``meta``.
+            A dict with ``groups`` (per-variant ``{alias, variant_id, simple_id,
+            n, annotation_completeness}``), ``group_aliases`` (``{alias:
+            variant_id}``), ``unmatched_variant_ids``, ``features`` (each
+            ``{hpo_id, label, total_observed, by_group}`` where ``by_group`` is
+            keyed by group alias with cells ``[observed, excluded, unknown,
+            observed_rate_among_recorded]``), ``total_distinct_features``,
+            ``returned_features``/``has_more``, a ``note``, ``data_class``, and
+            ``meta`` (carrying ``by_group_format``).
         """
+        mode = resolve_mode(response_mode)
         return await run_tool(
             lambda: compare_service.compare_phenotypes(
                 client,  # type: ignore[arg-type]
                 variant_ids,
                 top_n=top_n,
+                response_mode=mode,
+                include_stats=include_stats,
             ),
             data_class=DataClass.DERIVED,
-            response_mode=resolve_mode(response_mode),
+            response_mode=mode,
         )

--- a/mcp/src/hnf1b_mcp/tools/individuals.py
+++ b/mcp/src/hnf1b_mcp/tools/individuals.py
@@ -13,7 +13,7 @@ from hnf1b_mcp.services import individuals as individuals_service
 from hnf1b_mcp.services.dataclass import DataClass
 from hnf1b_mcp.services.errors import McpToolError
 from hnf1b_mcp.services.safe_tool import run_tool
-from hnf1b_mcp.services.shaping import resolve_mode
+from hnf1b_mcp.services.shaping import ResponseMode, resolve_mode
 
 # Canonical HPO term-ID shape: "HP:" + exactly 7 digits (e.g. HP:0000107).
 _HPO_ID_RE = re.compile(r"^HP:\d{7}$")
@@ -50,7 +50,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         include_variants: bool = True,
         include_measurements: bool = True,
         include_publications: bool = True,
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
         fields: list[str] | None = None,
     ) -> dict[str, Any]:
         """Retrieve the full phenopacket record for a single individual.
@@ -133,7 +133,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         page_size: int = 25,
         expand: bool = False,
         dedupe_publications: bool = False,
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
         fields: list[str] | None = None,
     ) -> dict[str, Any]:
         """Retrieve a list of HNF1B-db individuals by IDs or with optional filters.
@@ -216,7 +216,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         page_size: int = 25,
         include_excluded: bool = False,
         match_mode: Literal["any", "all"] = "any",
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
     ) -> dict[str, Any]:
         """Cohort discovery: find individuals sharing one or more HPO phenotype terms.
 

--- a/mcp/src/hnf1b_mcp/tools/individuals.py
+++ b/mcp/src/hnf1b_mcp/tools/individuals.py
@@ -41,6 +41,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Get HNF1B Individual (phenopacket)",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )
@@ -123,6 +124,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Get/List HNF1B Individuals",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )
@@ -208,6 +210,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Find Individuals by HPO Phenotype",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )

--- a/mcp/src/hnf1b_mcp/tools/publication_passages.py
+++ b/mcp/src/hnf1b_mcp/tools/publication_passages.py
@@ -28,6 +28,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Search Publication Passages (RAG)",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )

--- a/mcp/src/hnf1b_mcp/tools/publication_passages.py
+++ b/mcp/src/hnf1b_mcp/tools/publication_passages.py
@@ -9,8 +9,9 @@ from fastmcp import FastMCP
 from hnf1b_mcp.client.api_client import ApiClient
 from hnf1b_mcp.services import publication_passages as passages_service
 from hnf1b_mcp.services.dataclass import DataClass
+from hnf1b_mcp.services.publication_passages import PassageMode, RerankMode
 from hnf1b_mcp.services.safe_tool import run_tool
-from hnf1b_mcp.services.shaping import resolve_mode
+from hnf1b_mcp.services.shaping import ResponseMode, resolve_mode
 
 
 def register(mcp: FastMCP, client: ApiClient | None) -> None:
@@ -34,10 +35,10 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         query: str,
         pmids: list[str] | None = None,
         sections: list[str] | None = None,
-        mode: str = "brief",
-        rerank: str = "rrf",
+        mode: PassageMode = "brief",
+        rerank: RerankMode = "rrf",
         limit: int = 8,
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
     ) -> dict[str, Any]:
         """Retrieve ranked passages from publication full text for a query (RAG).
 

--- a/mcp/src/hnf1b_mcp/tools/publications.py
+++ b/mcp/src/hnf1b_mcp/tools/publications.py
@@ -11,7 +11,7 @@ from hnf1b_mcp.services import publications as publications_service
 from hnf1b_mcp.services.dataclass import DataClass
 from hnf1b_mcp.services.publications import PublicationSort
 from hnf1b_mcp.services.safe_tool import run_tool
-from hnf1b_mcp.services.shaping import resolve_mode
+from hnf1b_mcp.services.shaping import ResponseMode, resolve_mode
 
 
 def register(mcp: FastMCP, client: ApiClient | None) -> None:
@@ -40,7 +40,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         sort: PublicationSort | None = None,
         citing_pmid: str | None = None,
         include_citing_individuals: bool = False,
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
     ) -> dict[str, Any]:
         """Browse and search the local HNF1B publication cache.
 

--- a/mcp/src/hnf1b_mcp/tools/publications.py
+++ b/mcp/src/hnf1b_mcp/tools/publications.py
@@ -29,6 +29,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Get HNF1B Publications",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )

--- a/mcp/src/hnf1b_mcp/tools/reference.py
+++ b/mcp/src/hnf1b_mcp/tools/reference.py
@@ -29,6 +29,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Get HNF1B Gene Context",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )

--- a/mcp/src/hnf1b_mcp/tools/reference.py
+++ b/mcp/src/hnf1b_mcp/tools/reference.py
@@ -9,8 +9,9 @@ from fastmcp import FastMCP
 from hnf1b_mcp.client.api_client import ApiClient
 from hnf1b_mcp.services import reference as reference_service
 from hnf1b_mcp.services.dataclass import DataClass
+from hnf1b_mcp.services.reference import GenomeBuild
 from hnf1b_mcp.services.safe_tool import run_tool
-from hnf1b_mcp.services.shaping import resolve_mode
+from hnf1b_mcp.services.shaping import ResponseMode, resolve_mode
 
 
 def register(mcp: FastMCP, client: ApiClient | None) -> None:
@@ -33,11 +34,11 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
     )
     async def hnf1b_get_gene_context(
         gene_symbol: str = "HNF1B",
-        genome_build: str = "GRCh38",
+        genome_build: GenomeBuild = "GRCh38",
         include_transcripts: bool = True,
         include_domains: bool = True,
         include_exons: bool = False,
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
     ) -> dict[str, Any]:
         """Return gene reference data including transcripts and protein domains.
 

--- a/mcp/src/hnf1b_mcp/tools/search.py
+++ b/mcp/src/hnf1b_mcp/tools/search.py
@@ -10,7 +10,7 @@ from hnf1b_mcp.client.api_client import ApiClient
 from hnf1b_mcp.services import search as search_service
 from hnf1b_mcp.services.dataclass import DataClass
 from hnf1b_mcp.services.safe_tool import run_tool
-from hnf1b_mcp.services.shaping import resolve_mode
+from hnf1b_mcp.services.shaping import ResponseMode, resolve_mode
 
 
 def register(mcp: FastMCP, client: ApiClient | None) -> None:
@@ -35,7 +35,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         query: str,
         types: list[str] | None = None,
         limit: int = 10,
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
     ) -> dict[str, Any]:
         """Unified discovery search — returns typed ID hits.
 

--- a/mcp/src/hnf1b_mcp/tools/search.py
+++ b/mcp/src/hnf1b_mcp/tools/search.py
@@ -28,6 +28,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Search HNF1B-db (Discovery)",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )
@@ -51,8 +52,12 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
                 ``individual``, ``variant``, ``publication``, ``gene``.
                 Defaults to ``["individual", "variant", "publication"]``.
             limit: Maximum number of results to return (≥ 1).  Defaults to 10.
-            response_mode: Response verbosity — one of ``minimal``,
-                ``compact``, ``standard``, ``full``.  Defaults to ``compact``.
+                This is the control for response size — use it to widen/narrow
+                the hit list.
+            response_mode: Accepted for interface consistency with the other
+                tools, but it does NOT change this tool's output — search hits are
+                already minimal ``{type, id, label, uri, score}`` records. Use
+                ``limit`` to control how many are returned.
 
         Returns:
             A dict with keys ``query``, ``hits``, ``counts``, ``guidance``,

--- a/mcp/src/hnf1b_mcp/tools/statistics.py
+++ b/mcp/src/hnf1b_mcp/tools/statistics.py
@@ -10,7 +10,7 @@ from hnf1b_mcp.client.api_client import ApiClient
 from hnf1b_mcp.services import statistics as statistics_service
 from hnf1b_mcp.services.dataclass import DataClass
 from hnf1b_mcp.services.safe_tool import run_tool
-from hnf1b_mcp.services.shaping import resolve_mode
+from hnf1b_mcp.services.shaping import ResponseMode, resolve_mode
 
 
 def register(mcp: FastMCP, client: ApiClient | None) -> None:
@@ -53,7 +53,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         | None = None,
         count_mode: Literal["all", "unique"] | None = None,
         dry_run: bool = False,
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
         max_response_chars: int | None = None,
     ) -> dict[str, Any]:
         """Fetch aggregate statistics for the HNF1B phenopacket cohort.

--- a/mcp/src/hnf1b_mcp/tools/statistics.py
+++ b/mcp/src/hnf1b_mcp/tools/statistics.py
@@ -28,6 +28,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Get HNF1B Cohort Statistics",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )

--- a/mcp/src/hnf1b_mcp/tools/terms.py
+++ b/mcp/src/hnf1b_mcp/tools/terms.py
@@ -28,6 +28,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Resolve HPO / Vocabulary Terms",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )

--- a/mcp/src/hnf1b_mcp/tools/terms.py
+++ b/mcp/src/hnf1b_mcp/tools/terms.py
@@ -10,7 +10,7 @@ from hnf1b_mcp.client.api_client import ApiClient
 from hnf1b_mcp.services import terms as terms_service
 from hnf1b_mcp.services.dataclass import DataClass
 from hnf1b_mcp.services.safe_tool import run_tool
-from hnf1b_mcp.services.shaping import resolve_mode
+from hnf1b_mcp.services.shaping import ResponseMode, resolve_mode
 
 
 def register(mcp: FastMCP, client: ApiClient | None) -> None:
@@ -42,7 +42,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
             "evidence-code",
         ] = "hpo",
         limit: int = 10,
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
     ) -> dict[str, Any]:
         """Resolve ontology or controlled-vocabulary terms against the HNF1B-db API.
 

--- a/mcp/src/hnf1b_mcp/tools/variants.py
+++ b/mcp/src/hnf1b_mcp/tools/variants.py
@@ -15,7 +15,7 @@ from hnf1b_mcp.contract import (
 from hnf1b_mcp.services import variants as variants_service
 from hnf1b_mcp.services.dataclass import DataClass
 from hnf1b_mcp.services.safe_tool import run_tool
-from hnf1b_mcp.services.shaping import resolve_mode
+from hnf1b_mcp.services.shaping import ResponseMode, resolve_mode
 from hnf1b_mcp.services.variants import VariantSort
 
 
@@ -47,7 +47,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         page: int = 1,
         page_size: int = 25,
         sort: VariantSort | None = None,
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
     ) -> dict[str, Any]:
         """Browse HNF1B variant records with optional filters.
 
@@ -125,7 +125,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
     )
     async def hnf1b_get_variant(
         variant_id: str,
-        response_mode: str | None = None,
+        response_mode: ResponseMode | None = None,
         include_carriers: bool = False,
     ) -> dict[str, Any]:
         """Fetch the full authoritative record for a single HNF1B variant.

--- a/mcp/src/hnf1b_mcp/tools/variants.py
+++ b/mcp/src/hnf1b_mcp/tools/variants.py
@@ -34,6 +34,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Search HNF1B Variants",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )
@@ -120,6 +121,7 @@ def register(mcp: FastMCP, client: ApiClient | None) -> None:
         annotations={
             "title": "Get HNF1B Variant",
             "readOnlyHint": True,
+            "idempotentHint": True,
             "openWorldHint": False,
         },
     )

--- a/mcp/tests/test_capabilities.py
+++ b/mcp/tests/test_capabilities.py
@@ -1,5 +1,10 @@
 """Tests for capabilities and resources services."""
 
+import hashlib
+import json
+import re
+from pathlib import Path
+
 from hnf1b_mcp.contract import (
     MOLECULAR_CONSEQUENCE_VALUES,
     PROTEIN_DOMAIN_VALUES,
@@ -11,12 +16,49 @@ from hnf1b_mcp.services.publications import PUBLICATION_SORT_FIELDS
 from hnf1b_mcp.services.resources import RESOURCE_URIS, load_resource
 from hnf1b_mcp.services.variants import VARIANT_SORT_FIELDS
 
+TOOL_GUIDE_URI = "hnf1b://schema/tool-guide"
+
 
 def test_capabilities_version_present_and_deterministic():
     """A content hash is exposed and stable across calls (warm-client skip)."""
     cap = get_capabilities()
     assert cap["capabilities_version"].startswith("sha256:")
     assert cap["capabilities_version"] == get_capabilities()["capabilities_version"]
+
+
+def test_capabilities_descriptor_chars_is_computed_size():
+    cap = get_capabilities()
+    descriptor_chars = cap["descriptor_chars"]
+    descriptor_without_size = dict(cap)
+    descriptor_without_size.pop("descriptor_chars")
+    expected = len(json.dumps(descriptor_without_size, sort_keys=True, default=str))
+    assert descriptor_chars == expected
+
+
+def test_tool_guide_version_is_content_hash_and_advertised():
+    cap = get_capabilities()
+    guide_body = load_resource(TOOL_GUIDE_URI)
+    expected = hashlib.sha256(guide_body.encode("utf-8")).hexdigest()[:16]
+    expected_version = f"sha256:{expected}"
+    assert cap["tool_guide_version"] == expected_version
+    assert cap["resources"]["tool_guide"] == {
+        "uri": TOOL_GUIDE_URI,
+        "version": expected_version,
+    }
+
+
+def test_capabilities_descriptor_size_is_not_hardcoded_in_source():
+    source_root = Path(__file__).resolve().parents[1] / "src" / "hnf1b_mcp"
+    stale_size = re.compile(r"~(?:9|11)k(?:[- ]?chars?)?", re.IGNORECASE)
+    offenders: list[str] = []
+    for path in source_root.rglob("*.py"):
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            if stale_size.search(line):
+                rel = path.relative_to(source_root)
+                offenders.append(f"{rel}:{line_number}: {line.strip()}")
+    assert offenders == []
 
 
 def test_capabilities_citation_contract_scoped_to_publications():
@@ -168,5 +210,5 @@ def test_capabilities_workflows_use_real_param_names():
 
 def test_resource_uris_and_load():
     assert "hnf1b://schema/overview" in RESOURCE_URIS
-    assert "hnf1b://schema/tool-guide" in RESOURCE_URIS
+    assert TOOL_GUIDE_URI in RESOURCE_URIS
     assert len(load_resource("hnf1b://schema/overview")) > 100

--- a/mcp/tests/test_compare.py
+++ b/mcp/tests/test_compare.py
@@ -1,4 +1,9 @@
-"""Tests for hnf1b_mcp.services.compare — cross-variant phenotype comparison."""
+"""Tests for hnf1b_mcp.services.compare — cross-variant phenotype comparison.
+
+Covers the reshaped contract: shared variant-id resolution + unmatched signal
+(B2/Rec3), alias-keyed tuple cells (Rec1), observed_rate / annotation_completeness
+(Rec2), response_mode char budget (NEW-1), and exploratory Fisher stats (Rec4).
+"""
 
 from __future__ import annotations
 
@@ -25,10 +30,31 @@ def _carrier(pp_id: str, features: list[tuple[str, str, bool]]) -> dict:
     }
 
 
+def _mock_all_variants(variants: list[tuple[str, str]]) -> None:
+    """Mock the all-variants aggregate endpoint with ``(variant_id, simple_id)`` rows."""
+    respx.get(f"{BASE}/phenopackets/aggregate/all-variants").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [
+                    {"variant_id": vid, "simple_id": sid, "label": f"label {sid}"}
+                    for vid, sid in variants
+                ],
+                "meta": {"page": {"totalRecords": len(variants)}},
+            },
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path — alias-keyed tuple cells (Rec1) + rates (Rec2).
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 @respx.mock
-async def test_compare_phenotypes_tabulates_by_group():
-    """observed/excluded/unknown are tabulated per variant group."""
+async def test_compare_tabulates_with_alias_tuple_cells():
+    _mock_all_variants([("ga4gh:VA.A", "Var1"), ("ga4gh:VA.B", "Var2")])
     respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.A").mock(
         return_value=httpx.Response(
             200,
@@ -39,57 +65,238 @@ async def test_compare_phenotypes_tabulates_by_group():
         )
     )
     respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.B").mock(
-        return_value=httpx.Response(
-            200,
-            json=[_carrier("p3", [("HP:2", "DM", False)])],
-        )
+        return_value=httpx.Response(200, json=[_carrier("p3", [("HP:2", "DM", False)])])
     )
     c = ApiClient(base_url=BASE)
     result = await compare_phenotypes(c, ["ga4gh:VA.A", "ga4gh:VA.B"], top_n=10)
     await c.aclose()
 
-    groups = {g["variant_id"]: g["n"] for g in result["groups"]}
-    assert groups == {"ga4gh:VA.A": 2, "ga4gh:VA.B": 1}
+    # Groups carry alias + canonical id + simple_id + n.
+    by_alias = {g["alias"]: g for g in result["groups"]}
+    assert by_alias["g0"]["variant_id"] == "ga4gh:VA.A"
+    assert by_alias["g0"]["simple_id"] == "Var1"
+    assert by_alias["g0"]["n"] == 2
+    assert by_alias["g1"]["n"] == 1
+    assert result["group_aliases"] == {"g0": "ga4gh:VA.A", "g1": "ga4gh:VA.B"}
+    assert result["unmatched_variant_ids"] == []
 
     feats = {f["hpo_id"]: f for f in result["features"]}
-    # HP:1 observed in 2/2 of group A, absent (unknown) in group B.
-    hp1 = feats["HP:1"]["by_group"]
-    assert hp1["ga4gh:VA.A"] == {"observed": 2, "excluded": 0, "unknown": 0}
-    assert hp1["ga4gh:VA.B"] == {"observed": 0, "excluded": 0, "unknown": 1}
-    # HP:2: excluded once in A (1 unknown), observed once in B.
-    hp2 = feats["HP:2"]["by_group"]
-    assert hp2["ga4gh:VA.A"] == {"observed": 0, "excluded": 1, "unknown": 1}
-    assert hp2["ga4gh:VA.B"] == {"observed": 1, "excluded": 0, "unknown": 0}
-    # ranked by total observed (HP:1 total 2 > HP:2 total 1)
+    # by_group keyed by ALIAS; cell = [observed, excluded, unknown, rate].
+    # HP:1 observed in 2/2 of g0 (rate 1.0), unknown in g1 (rate None).
+    assert feats["HP:1"]["by_group"]["g0"] == [2, 0, 0, 1.0]
+    assert feats["HP:1"]["by_group"]["g1"] == [0, 0, 1, None]
+    # HP:2 excluded once in g0 (rate 0.0), observed once in g1 (rate 1.0).
+    assert feats["HP:2"]["by_group"]["g0"] == [0, 1, 1, 0.0]
+    assert feats["HP:2"]["by_group"]["g1"] == [1, 0, 0, 1.0]
+    # Ranked by total observed (HP:1 total 2 > HP:2 total 1).
     assert result["features"][0]["hpo_id"] == "HP:1"
-    # full result set fit within top_n=10, so nothing is hidden.
     assert result["total_distinct_features"] == 2
-    assert result["returned_features"] == 2
-    assert result["top_n"] == 10
     assert result["has_more"] is False
+    assert "by_group_format" in result["_meta"]
+
+
+# ---------------------------------------------------------------------------
+# B2 / Rec3 — unmatched vs real-zero-carrier; simple_id acceptance.
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_compare_phenotypes_truncation_is_transparent():
-    """top_n smaller than the distinct-feature count exposes has_more, not a silent cut."""
+async def test_compare_unknown_variant_id_reported_as_unmatched():
+    _mock_all_variants([("ga4gh:VA.A", "Var1")])
     respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.A").mock(
+        return_value=httpx.Response(200, json=[_carrier("p1", [("HP:1", "F", False)])])
+    )
+    c = ApiClient(base_url=BASE)
+    result = await compare_phenotypes(c, ["ga4gh:VA.A", "ga4gh:VA.TYPO"], top_n=10)
+    await c.aclose()
+
+    assert result["unmatched_variant_ids"] == ["ga4gh:VA.TYPO"]
+    assert [g["variant_id"] for g in result["groups"]] == ["ga4gh:VA.A"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_compare_real_variant_zero_carriers_not_unmatched():
+    """A real variant with no phenotyped carriers stays in groups with n:0."""
+    _mock_all_variants([("ga4gh:VA.A", "Var1"), ("ga4gh:VA.EMPTY", "Var9")])
+    respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.A").mock(
+        return_value=httpx.Response(200, json=[_carrier("p1", [("HP:1", "F", False)])])
+    )
+    respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.EMPTY").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    c = ApiClient(base_url=BASE)
+    result = await compare_phenotypes(c, ["ga4gh:VA.A", "ga4gh:VA.EMPTY"], top_n=10)
+    await c.aclose()
+
+    assert result["unmatched_variant_ids"] == []
+    n_by_id = {g["variant_id"]: g["n"] for g in result["groups"]}
+    assert n_by_id == {"ga4gh:VA.A": 1, "ga4gh:VA.EMPTY": 0}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_compare_accepts_simple_id_resolves_to_canonical():
+    _mock_all_variants([("ga4gh:VA.A", "Var1")])
+    route = respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.A").mock(
+        return_value=httpx.Response(200, json=[_carrier("p1", [("HP:1", "F", False)])])
+    )
+    c = ApiClient(base_url=BASE)
+    result = await compare_phenotypes(c, ["Var1"], top_n=10)
+    await c.aclose()
+
+    # The by-variant fetch used the CANONICAL id, not the friendly simple_id.
+    assert route.called
+    assert result["groups"][0]["variant_id"] == "ga4gh:VA.A"
+    assert result["groups"][0]["n"] == 1
+    assert result["unmatched_variant_ids"] == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_compare_all_unmatched_returns_empty_no_raise():
+    _mock_all_variants([("ga4gh:VA.A", "Var1")])
+    c = ApiClient(base_url=BASE)
+    result = await compare_phenotypes(c, ["nope1", "nope2"], top_n=10)
+    await c.aclose()
+    assert result["groups"] == []
+    assert result["features"] == []
+    assert result["unmatched_variant_ids"] == ["nope1", "nope2"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_compare_dedupes_same_variant_supplied_twice():
+    _mock_all_variants([("ga4gh:VA.A", "Var1")])
+    respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.A").mock(
+        return_value=httpx.Response(200, json=[_carrier("p1", [("HP:1", "F", False)])])
+    )
+    c = ApiClient(base_url=BASE)
+    # canonical id AND its simple_id name the same variant -> one group.
+    result = await compare_phenotypes(c, ["ga4gh:VA.A", "Var1"], top_n=10)
+    await c.aclose()
+    assert len(result["groups"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Rec2 — observed_rate_among_recorded + annotation_completeness.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_compare_annotation_completeness_reflects_assessment_depth():
+    _mock_all_variants([("ga4gh:VA.DENSE", "Var1"), ("ga4gh:VA.SPARSE", "Var2")])
+    # Dense group: both carriers assess both features. Sparse: one carrier, one feature.
+    respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.DENSE").mock(
         return_value=httpx.Response(
             200,
             json=[
-                _carrier("p1", [("HP:1", "F1", False), ("HP:2", "F2", False)]),
+                _carrier("p1", [("HP:1", "F1", False), ("HP:2", "F2", True)]),
+                _carrier("p2", [("HP:1", "F1", False), ("HP:2", "F2", False)]),
             ],
         )
     )
+    respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.SPARSE").mock(
+        return_value=httpx.Response(200, json=[_carrier("p3", [("HP:1", "F1", False)])])
+    )
     c = ApiClient(base_url=BASE)
-    result = await compare_phenotypes(c, ["ga4gh:VA.A"], top_n=1)
+    result = await compare_phenotypes(
+        c, ["ga4gh:VA.DENSE", "ga4gh:VA.SPARSE"], top_n=10
+    )
     await c.aclose()
 
-    assert result["total_distinct_features"] == 2
-    assert result["returned_features"] == 1
-    assert result["top_n"] == 1
-    assert result["has_more"] is True
-    assert len(result["features"]) == 1
+    comp = {g["alias"]: g["annotation_completeness"] for g in result["groups"]}
+    # g0 assessed both features in both carriers => 1.0; g1 assessed 1 of 2 => 0.5.
+    assert comp["g0"] == 1.0
+    assert comp["g1"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# NEW-1 — response_mode threads through and bounds the payload.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_compare_response_mode_enforces_char_budget():
+    _mock_all_variants([("ga4gh:VA.A", "Var1")])
+    many = [(f"HP:{i:07d}", f"Feature {i}", False) for i in range(120)]
+    respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.A").mock(
+        return_value=httpx.Response(200, json=[_carrier("p1", many)])
+    )
+    c = ApiClient(base_url=BASE)
+    minimal = await compare_phenotypes(
+        c, ["ga4gh:VA.A"], top_n=100, response_mode="minimal"
+    )
+    full = await compare_phenotypes(c, ["ga4gh:VA.A"], top_n=100, response_mode="full")
+    await c.aclose()
+
+    import json
+
+    assert len(json.dumps(minimal)) <= 4000
+    assert minimal["_dropped"]["dropped_records"] > 0
+    assert minimal["has_more"] is True
+    assert minimal["returned_features"] == len(minimal["features"])
+    # keep_min=1: never empty when matches exist.
+    assert len(minimal["features"]) >= 1
+    # A wider mode returns strictly more features than the trimmed minimal one.
+    assert len(full["features"]) > len(minimal["features"])
+
+
+# ---------------------------------------------------------------------------
+# Rec4 — exploratory Fisher stats (two groups only).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_compare_include_stats_two_groups():
+    _mock_all_variants([("ga4gh:VA.A", "Var1"), ("ga4gh:VA.B", "Var2")])
+    # HP:1 strongly enriched in g0 (5/5 present) vs g1 (0/5, all excluded).
+    respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.A").mock(
+        return_value=httpx.Response(
+            200, json=[_carrier(f"a{i}", [("HP:1", "F", False)]) for i in range(5)]
+        )
+    )
+    respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.B").mock(
+        return_value=httpx.Response(
+            200, json=[_carrier(f"b{i}", [("HP:1", "F", True)]) for i in range(5)]
+        )
+    )
+    c = ApiClient(base_url=BASE)
+    result = await compare_phenotypes(
+        c, ["ga4gh:VA.A", "ga4gh:VA.B"], top_n=10, include_stats=True
+    )
+    await c.aclose()
+
+    hp1 = next(f for f in result["features"] if f["hpo_id"] == "HP:1")
+    assert "stats" in hp1
+    assert hp1["stats"]["fisher_p"] is not None
+    assert hp1["stats"]["fisher_p"] < 0.05  # 5/5 vs 0/5 is significant
+    assert hp1["stats"]["effect_direction"] == "higher_in_g0"
+    assert "stats_note" in result["_meta"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_compare_include_stats_requires_exactly_two_groups():
+    _mock_all_variants([("ga4gh:VA.A", "Var1")])
+    respx.get(f"{BASE}/phenopackets/by-variant/ga4gh:VA.A").mock(
+        return_value=httpx.Response(200, json=[_carrier("p1", [("HP:1", "F", False)])])
+    )
+    c = ApiClient(base_url=BASE)
+    result = await compare_phenotypes(c, ["ga4gh:VA.A"], include_stats=True)
+    await c.aclose()
+    # Single group -> no per-feature stats, but a note explains why.
+    assert "stats" not in result["features"][0]
+    assert "require exactly" in result["_meta"]["stats_note"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation (unchanged).
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -108,3 +315,11 @@ async def test_compare_phenotypes_rejects_too_many():
         await compare_phenotypes(c, [f"v{i}" for i in range(11)])
     await c.aclose()
     assert exc.value.code == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_compare_phenotypes_rejects_bad_top_n():
+    c = ApiClient(base_url=BASE)
+    with pytest.raises(McpToolError):
+        await compare_phenotypes(c, ["v1"], top_n=0)
+    await c.aclose()

--- a/mcp/tests/test_individuals.py
+++ b/mcp/tests/test_individuals.py
@@ -888,3 +888,41 @@ async def test_get_individuals_batch_budget_enforced() -> None:
     # Trimmed to fit the budget → fewer than 80 returned, with a drop signal.
     assert len(result["individuals"]) < 80
     assert result["_dropped"]["dropped_records"] > 0
+
+
+# ---------------------------------------------------------------------------
+# B4: batch results follow the caller's requested id order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_individuals_batch_preserves_request_order():
+    """The batch endpoint's own order is normalized to the requested ids order."""
+    item_a = {"phenopacket_id": "A", "phenopacket": _PHENOPACKET_A["phenopacket"]}
+    item_b = {"phenopacket_id": "B", "phenopacket": _PHENOPACKET_B["phenopacket"]}
+    item_c = {"phenopacket_id": "C", "phenopacket": _PHENOPACKET_A["phenopacket"]}
+    # Backend returns a DIFFERENT order than requested.
+    respx.get(f"{BASE}/phenopackets/batch").mock(
+        return_value=httpx.Response(200, json=[item_c, item_a, item_b])
+    )
+    c = ApiClient(base_url=BASE)
+    result = await get_individuals(c, ids=["A", "B", "C"])
+    await c.aclose()
+    assert [i["phenopacket_id"] for i in result["individuals"]] == ["A", "B", "C"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_individuals_batch_order_with_not_found():
+    item_a = {"phenopacket_id": "A", "phenopacket": _PHENOPACKET_A["phenopacket"]}
+    item_b = {"phenopacket_id": "B", "phenopacket": _PHENOPACKET_B["phenopacket"]}
+    # MISSING is requested but not returned; A/B come back reversed.
+    respx.get(f"{BASE}/phenopackets/batch").mock(
+        return_value=httpx.Response(200, json=[item_b, item_a])
+    )
+    c = ApiClient(base_url=BASE)
+    result = await get_individuals(c, ids=["A", "MISSING", "B"])
+    await c.aclose()
+    assert [i["phenopacket_id"] for i in result["individuals"]] == ["A", "B"]
+    assert result["not_found"] == ["MISSING"]

--- a/mcp/tests/test_register_all.py
+++ b/mcp/tests/test_register_all.py
@@ -25,4 +25,8 @@ async def test_all_tools_registered():
     }
     assert expected <= names
     for t in tools:
+        # Every tool is a read-only, idempotent, closed-world query: safe to
+        # retry and to cache (Anthropic/MCP tool-annotation best practice).
         assert t.annotations.readOnlyHint is True
+        assert t.annotations.idempotentHint is True
+        assert t.annotations.openWorldHint is False

--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -8,6 +8,7 @@ from hnf1b_mcp.server import (
     build_http_app,
     is_origin_allowed,
 )
+from hnf1b_mcp.services.resources import load_resource
 
 
 def test_instructions_have_safety():
@@ -21,7 +22,7 @@ def test_instructions_capabilities_is_advisory_not_mandatory():
 
     The server ships a `capabilities_version` content hash (warm-skip) and every
     tool advertises its filterable-field enums, so a client can build valid calls
-    without a mandatory ~11k-char capabilities fetch. Lock that the primer says so.
+    without a mandatory full capabilities fetch. Lock that the primer says so.
     """
     s = SERVER_INSTRUCTIONS.lower()
     # Advisory framing: recommended/optional, not "call first" prescriptively.
@@ -30,6 +31,7 @@ def test_instructions_capabilities_is_advisory_not_mandatory():
     assert "call `hnf1b_get_capabilities` first" not in s
     # The warm-skip affordance must be surfaced, alongside the per-tool enums.
     assert "capabilities_version" in s
+    assert "descriptor_chars" in s
     assert "filterable_fields" in s
 
 
@@ -40,6 +42,15 @@ async def test_app_exposes_tools_and_resources():
     assert "hnf1b_get_capabilities" in names
     resources = await mcp.list_resources()
     assert any("schema/overview" in str(r.uri) for r in resources)
+
+
+@pytest.mark.asyncio
+async def test_tool_guide_has_section_for_each_registered_tool():
+    mcp = build_app()
+    names = {t.name for t in await mcp.list_tools()}
+    guide = load_resource("hnf1b://schema/tool-guide")
+    missing = sorted(name for name in names if f"### `{name}`" not in guide)
+    assert missing == []
 
 
 def test_origin_helper():

--- a/mcp/tests/test_statistics.py
+++ b/mcp/tests/test_statistics.py
@@ -327,3 +327,193 @@ async def test_count_mode_ignored_for_non_variant_metric_signals():
     result = await get_statistics(c, metric="summary", count_mode="unique")
     await c.aclose()
     assert "count_mode" in result["_meta"]["ignored_params"]
+
+
+# ---------------------------------------------------------------------------
+# B3: by_feature prevalence derived from details + annotation-share unit_note
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_by_feature_adds_prevalence_from_details():
+    """Percentage is annotation-share; prevalence is derived from row details."""
+    respx.get(f"{BASE}/phenopackets/aggregate/by-feature").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "label": "Renal cysts",
+                    "count": 100,
+                    "percentage": 11.9,
+                    "hpo_id": "HP:0000107",
+                    "details": {
+                        "hpo_id": "HP:0000107",
+                        "present_count": 100,
+                        "absent_count": 24,
+                        "not_reported_count": 100,
+                    },
+                }
+            ],
+        )
+    )
+    c = ApiClient(base_url=BASE)
+    result = await get_statistics(c, metric="by_feature", response_mode="full")
+    await c.aclose()
+
+    row = result["result"]["raw"][0]
+    # prevalence_among_cohort = 100/(100+24+100) = 44.64 (the clinically correct figure)
+    assert row["prevalence_among_cohort"] == 44.64
+    # prevalence_among_reported = 100/(100+24)
+    assert row["prevalence_among_reported"] == round(100 / 124 * 100, 2)
+    # percentage (annotation-share) is left untouched (no breaking rename).
+    assert row["percentage"] == 11.9
+    assert result["unit"] == "annotation_share_pct"
+    assert "prevalence_among_cohort" in result["unit_note"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_by_feature_missing_details_no_prevalence_no_crash():
+    respx.get(f"{BASE}/phenopackets/aggregate/by-feature").mock(
+        return_value=httpx.Response(
+            200, json=[{"label": "X", "count": 5, "percentage": 1.0, "hpo_id": "HP:1"}]
+        )
+    )
+    c = ApiClient(base_url=BASE)
+    result = await get_statistics(c, metric="by_feature", response_mode="full")
+    await c.aclose()
+    row = result["result"]["raw"][0]
+    assert "prevalence_among_cohort" not in row
+
+
+# ---------------------------------------------------------------------------
+# B5: publications_timeline unit_note reconciling cumulative > total
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_publications_timeline_has_unit_note():
+    respx.get(f"{BASE}/phenopackets/aggregate/publications-timeline").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "year": 2018,
+                    "count": 400,
+                    "cumulative": 400,
+                    "publications": ["PMID:1"],
+                },
+                {
+                    "year": 2019,
+                    "count": 491,
+                    "cumulative": 891,
+                    "publications": ["PMID:2"],
+                },
+            ],
+        )
+    )
+    c = ApiClient(base_url=BASE)
+    result = await get_statistics(c, metric="publications_timeline")
+    await c.aclose()
+    assert result["unit"] == "phenopackets_per_publication_year"
+    assert "cumulative" in result["unit_note"]
+    # the unbounded PMID array is still replaced by a count
+    row = result["result"]["raw"][1]
+    assert row["publication_count"] == 1
+    assert "publications" not in row
+    # raw cumulative is preserved (just explained)
+    assert row["cumulative"] == 891
+
+
+# ---------------------------------------------------------------------------
+# B1: kidney_stages empty result emits guidance instead of a silent dead end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_kidney_stages_empty_emits_guidance_meta():
+    respx.get(f"{BASE}/phenopackets/aggregate/kidney-stages").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    c = ApiClient(base_url=BASE)
+    result = await get_statistics(c, metric="kidney_stages")
+    await c.aclose()
+    assert result["result"]["raw"] == []
+    assert "empty_result" in result["_meta"]
+    assert "by_feature" in result["_meta"]["empty_result"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_kidney_stages_nonempty_no_guidance():
+    respx.get(f"{BASE}/phenopackets/aggregate/kidney-stages").mock(
+        return_value=httpx.Response(
+            200, json=[{"label": "Stage 3", "count": 116, "percentage": 30.0}]
+        )
+    )
+    c = ApiClient(base_url=BASE)
+    result = await get_statistics(c, metric="kidney_stages")
+    await c.aclose()
+    assert result["result"]["raw"][0]["count"] == 116
+    assert "empty_result" not in result.get("_meta", {})
+
+
+# ---------------------------------------------------------------------------
+# B6: degenerate Kaplan-Meier terminal CI is nulled MCP-side (defense-in-depth)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_survival_nulls_degenerate_terminal_ci():
+    respx.get(f"{BASE}/phenopackets/aggregate/survival-data").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "groups": [
+                    {
+                        "name": "P/LP",
+                        "survival_data": [
+                            {
+                                "time": 0.0,
+                                "survival_probability": 1.0,
+                                "ci_lower": 1.0,
+                                "ci_upper": 1.0,
+                                "at_risk": 10,
+                            },
+                            {
+                                "time": 30.0,
+                                "survival_probability": 0.5,
+                                "ci_lower": 0.2,
+                                "ci_upper": 0.8,
+                                "at_risk": 4,
+                            },
+                            {
+                                "time": 94.0,
+                                "survival_probability": 0.0,
+                                "ci_lower": 1.0,
+                                "ci_upper": 1.0,
+                                "at_risk": 1,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+    )
+    c = ApiClient(base_url=BASE)
+    result = await get_statistics(c, metric="survival", comparison="pathogenicity")
+    await c.aclose()
+
+    points = result["result"]["groups"][0]["survival_data"]
+    # The legitimate S=1.0 anchor keeps its [1,1] interval.
+    assert points[0]["ci_lower"] == 1.0 and points[0]["ci_upper"] == 1.0
+    # A healthy interior point is untouched.
+    assert points[1]["ci_lower"] == 0.2
+    # The degenerate terminal point (S=0 with [1,1]) is nulled.
+    assert points[-1]["survival_probability"] == 0.0
+    assert points[-1]["ci_lower"] is None and points[-1]["ci_upper"] is None
+    assert "ci_note" in result["result"]

--- a/mcp/tests/test_tool_enums.py
+++ b/mcp/tests/test_tool_enums.py
@@ -1,0 +1,112 @@
+"""B7: schema-visible Literal enums for response_mode / mode / rerank / genome_build.
+
+Two guarantees:
+  1. Each tool-facing Literal stays in lockstep with the runtime tuple it
+     mirrors (drift guards), so adding a value in one place fails loudly until
+     the other is updated.
+  2. The Literals actually surface as ``enum`` in the generated JSON input
+     schema for every tool that takes them — the whole point of B7 (a client/
+     agent can see the allowed values instead of an opaque ``string``).
+"""
+
+from typing import get_args
+
+import pytest
+from fastmcp import FastMCP
+
+from hnf1b_mcp.services.errors import McpToolError
+from hnf1b_mcp.services.publication_passages import (
+    API_MODES,
+    RERANK_MODES,
+    PassageMode,
+    RerankMode,
+)
+from hnf1b_mcp.services.reference import GENOME_BUILDS, GenomeBuild, get_gene_context
+from hnf1b_mcp.services.shaping import MODES, ResponseMode
+from hnf1b_mcp.tools import register_all
+
+# ---------------------------------------------------------------------------
+# Drift guards: Literal members must equal the runtime-validated tuple.
+# ---------------------------------------------------------------------------
+
+
+def test_response_mode_literal_matches_modes():
+    assert set(get_args(ResponseMode)) == set(MODES)
+
+
+def test_passage_mode_literal_matches_api_modes():
+    assert set(get_args(PassageMode)) == set(API_MODES)
+
+
+def test_rerank_mode_literal_matches_rerank_modes():
+    assert set(get_args(RerankMode)) == set(RERANK_MODES)
+
+
+def test_genome_build_literal_matches_builds():
+    assert set(get_args(GenomeBuild)) == set(GENOME_BUILDS)
+
+
+# ---------------------------------------------------------------------------
+# Schema introspection: the enums are visible in the JSON input schema.
+# ---------------------------------------------------------------------------
+
+
+def _enum_values(schema: dict) -> set[str] | None:
+    """Extract the enum value set from a param schema (direct or under anyOf)."""
+    if "enum" in schema:
+        return set(schema["enum"])
+    for branch in schema.get("anyOf", []):
+        if "enum" in branch:
+            return set(branch["enum"])
+    return None
+
+
+async def _tool_params() -> dict[str, dict]:
+    mcp = FastMCP("enum-test")
+    register_all(mcp, client=None)
+    tools = await mcp.list_tools()
+    return {t.name: (getattr(t, "parameters", None) or {}) for t in tools}
+
+
+@pytest.mark.asyncio
+async def test_response_mode_is_enum_on_every_tool_that_takes_it():
+    params = await _tool_params()
+    seen = 0
+    for name, schema in params.items():
+        props = schema.get("properties", {})
+        if "response_mode" in props:
+            seen += 1
+            assert _enum_values(props["response_mode"]) == set(MODES), name
+    # All but get_capabilities expose response_mode; guard against a silent drop.
+    assert seen >= 10
+
+
+@pytest.mark.asyncio
+async def test_passages_mode_rerank_are_enums():
+    params = await _tool_params()
+    props = params["hnf1b_get_publication_passages"]["properties"]
+    assert _enum_values(props["mode"]) == set(API_MODES)
+    assert _enum_values(props["rerank"]) == set(RERANK_MODES)
+
+
+@pytest.mark.asyncio
+async def test_genome_build_is_enum_on_gene_context():
+    params = await _tool_params()
+    props = params["hnf1b_get_gene_context"]["properties"]
+    assert _enum_values(props["genome_build"]) == set(GENOME_BUILDS)
+
+
+# ---------------------------------------------------------------------------
+# genome_build was the one true silent passthrough — now it rejects typos.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_genome_build_rejects_unknown_value():
+    # Validation precedes any HTTP call, so a client is never needed.
+    with pytest.raises(McpToolError) as excinfo:
+        await get_gene_context(client=None, genome_build="hg38")  # type: ignore[arg-type]
+    err = excinfo.value
+    assert err.code == "invalid_input"
+    assert err.details.get("argument") == "genome_build"
+    assert "GRCh38" in err.details.get("choices", [])

--- a/mcp/tests/test_tool_publication_passages.py
+++ b/mcp/tests/test_tool_publication_passages.py
@@ -239,16 +239,46 @@ async def test_params_forwarded() -> None:
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_invalid_mode_returns_error_envelope() -> None:
+async def test_invalid_mode_rejected_by_schema_enum() -> None:
+    """B7: ``mode`` is a Literal, so a typo is rejected at the schema boundary.
+
+    The PassageMode enum makes FastMCP reject an out-of-set value during input
+    validation (naming the allowed values), instead of forwarding it to the
+    service guard — the whole point of promoting the param to an enum.
+    """
+    import pydantic_core
+
     _mock_both()
     mcp, client = _make_mcp_and_client()
-    r = await mcp.call_tool(
-        "hnf1b_get_publication_passages", {"query": "x", "mode": "bogus"}
-    )
+    with pytest.raises(pydantic_core.ValidationError) as excinfo:
+        await mcp.call_tool(
+            "hnf1b_get_publication_passages", {"query": "x", "mode": "bogus"}
+        )
     await client.aclose()
-    sc = r.structured_content
-    assert sc.get("is_error") is True
-    assert sc["error"]["code"] == "invalid_input"
+    # The validation error advertises the allowed values so a caller self-corrects.
+    assert "brief" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_invalid_mode_service_guard_still_returns_envelope() -> None:
+    """Defense-in-depth: the runtime guard still yields the invalid_input envelope.
+
+    A client that does not validate against the schema (or a direct service
+    call) is still protected by the service-level check — Literal is a ``str``
+    subtype, so the two compose.
+    """
+    from hnf1b_mcp.services import publication_passages as passages_service
+    from hnf1b_mcp.services.errors import McpToolError
+
+    _mock_both()
+    mcp, client = _make_mcp_and_client()
+    with pytest.raises(McpToolError) as excinfo:
+        await passages_service.get_publication_passages(
+            client, query="x", mode="bogus"
+        )
+    await client.aclose()
+    assert excinfo.value.code == "invalid_input"
 
 
 @pytest.mark.asyncio

--- a/mcp/tests/test_tool_publication_passages.py
+++ b/mcp/tests/test_tool_publication_passages.py
@@ -274,9 +274,7 @@ async def test_invalid_mode_service_guard_still_returns_envelope() -> None:
     _mock_both()
     mcp, client = _make_mcp_and_client()
     with pytest.raises(McpToolError) as excinfo:
-        await passages_service.get_publication_passages(
-            client, query="x", mode="bogus"
-        )
+        await passages_service.get_publication_passages(client, query="x", mode="bogus")
     await client.aclose()
     assert excinfo.value.code == "invalid_input"
 


### PR DESCRIPTION
## Summary

- Hardens the HNF1B MCP and backend against the QA findings B1-B7, Rec1-5, and workflow NEW-1..NEW-3.
- Fixes backend aggregate/statistics correctness at source where needed and preserves REST/frontend compatibility by keeping existing fields additive-only.
- Adds capability descriptor sizing as data and tool-guide cache-skip metadata, with tests guarding stale hardcoded size prose and registered-tool guide coverage.

## Fix Map

- B1: rewrote kidney-stage aggregation SQL at the backend source and added MCP-side empty-result guidance.
- B2: shared variant resolver for `compare_phenotypes`/`get_variant`, with `unmatched_variant_ids` for unresolved inputs.
- B3: added honest prevalence fields (`prevalence_*`) while keeping existing `percentage` untouched.
- B4: preserved requested ID order in `hnf1b_get_individuals` batch responses.
- B5: added `unit_note` to publications timeline statistics.
- B6: collapsed degenerate Kaplan-Meier CI at `S=0` in backend survival code and scrubbed MCP payloads defensively.
- B7: made MCP enum choices schema-visible with `Literal` parameters.
- Rec1: reshaped `compare_phenotypes` cells to alias + `[observed, excluded, unknown, rate]` tuples.
- Rec2: added `observed_rate_among_recorded` and `annotation_completeness` signals.
- Rec3: added shared variant ID/simple ID resolution and unmatched-ID reporting.
- Rec4: added gated pure-Python Fisher exact testing via `include_stats`.
- Rec5: added `hnf1b://schema/tool-guide` cache-skip infrastructure through `tool_guide_version = sha256(body)[:16]`, advertised in capabilities.
- NEW-1: added `response_mode`/budget shaping to `compare_phenotypes`.
- NEW-2: added computed `descriptor_chars`, removed stale hardcoded capability-size prose, and added a grep guard.
- NEW-3: added `idempotentHint` to all tools and documented that `hnf1b_search.response_mode` is currently inert.

## Deferrals

- Rec5 aggressive docstring trim is intentionally deferred. The current tool docstrings still carry chaining/truncation field names (`resolve_with`, `carriers_truncated`, `unmatched_variant_ids`, etc.) that agents parse at runtime, so this low-severity token-saving change should be handled separately.
- Authored `outputSchema` definitions for high-traffic chained tools are deferred to a follow-up. The change is valuable but separable and larger than the QA-fix branch.

## Verification

- `cd mcp && uv run ruff format .`
- `cd mcp && uv run ruff check .` -> all checks passed
- `cd mcp && uv run mypy src/` -> success, 40 source files checked
- `cd mcp && uv run pytest -n auto -q -m "not smoke and not live"` -> 436 passed
- `cd backend && uv run ruff format app/phenopackets/routers/aggregations/diseases.py app/phenopackets/survival_analysis.py tests/test_aggregations_endpoints.py tests/test_survival_analysis.py` -> unchanged
- `cd backend && uv run ruff check app/phenopackets/routers/aggregations/diseases.py app/phenopackets/survival_analysis.py tests/test_aggregations_endpoints.py tests/test_survival_analysis.py` -> all checks passed
- `cd backend && uv run pytest tests/test_survival_analysis.py tests/test_aggregations_endpoints.py -q` -> 50 passed
- `cd mcp && uv run python scripts/gen_contract.py && git diff --exit-code -- src/hnf1b_mcp/contract/_generated_paths.py src/hnf1b_mcp/contract/_generated_enums.py` -> no gated contract drift
