### PR TITLE
fix(search): autocomplete returns real suggestions + modernize SearchCard

### DIFF
--- a/backend/app/search/repositories.py
+++ b/backend/app/search/repositories.py
@@ -187,29 +187,67 @@ class GlobalSearchRepository:
         query: str,
         limit: int = 10,
     ) -> list[dict[str, Any]]:
-        """Fast autocomplete using trigram + prefix matching.
+        """Typeahead suggestions over the same hybrid index as ``search()``.
 
-        Prioritizes:
-        1. Prefix matches (ILIKE 'query%')
-        2. High similarity matches (pg_trgm)
+        The previous implementation matched only labels that *start with* the
+        query (``ILIKE 'query%'``) or are trigram-similar *as a whole*. That
+        misses the way users actually type into a global search box: a word
+        *inside* a multi-word label (publication titles, descriptive individual
+        labels, and the disease / phenotype text folded into ``search_vector``)
+        must surface, as must a substring of an HGVS label
+        (``c.5`` -> ``HNF1B:c.544+1G>C``) and common typos. As a result queries
+        like ``diabetes`` or ``cyst`` returned nothing even though
+        ``/search/global`` matched hundreds of records.
+
+        This uses the materialized view's full-text ``search_vector`` (the same
+        signal ``search()`` relies on) plus substring and fuzzy fallbacks,
+        ranked by match quality (best first):
+
+        0. ``label`` starts with the query (classic typeahead, e.g. ``HNF1B``).
+        1. Whole-word full-text match on ``search_vector``
+           (e.g. ``diabetes`` -> "Renal cysts and diabetes syndrome").
+        2. ``label`` contains the query as a substring (e.g. ``c.5``).
+        3. Word-prefix full-text match (e.g. ``diab`` -> ``diabetes``).
+        4. Fuzzy word-similarity match for typos (e.g. ``diabetis``).
+
+        All four predicates are index-backed (GIN on ``search_vector`` and a
+        trigram GIN on ``label``), and the view is small, so this stays well
+        within typeahead latency budgets.
 
         Args:
-            query: Partial search term
-            limit: Maximum suggestions to return
+            query: Partial search term (>= 2 chars enforced at the router).
+            limit: Maximum suggestions to return.
 
         Returns:
-            List of autocomplete suggestions
+            List of autocomplete suggestion dictionaries.
         """
+        or_tsquery = self._build_or_tsquery(query)
         sql = text("""
-            SELECT id, label, type, subtype, extra_info,
-                   similarity(label, :query) as score
-            FROM global_search_index
-            WHERE label ILIKE :prefix
-               OR label % :query
-            ORDER BY
-                CASE WHEN label ILIKE :prefix THEN 0 ELSE 1 END,
-                score DESC,
-                label ASC
+            SELECT id, label, type, subtype, extra_info, score
+            FROM (
+                SELECT id, label, type, subtype, extra_info,
+                    CASE
+                        WHEN label ILIKE :prefix THEN 0
+                        WHEN search_vector @@ plainto_tsquery('simple', :query)
+                            THEN 1
+                        WHEN label ILIKE :contains THEN 2
+                        WHEN search_vector @@ to_tsquery('simple', :or_tsquery)
+                            THEN 3
+                        ELSE 4
+                    END AS match_priority,
+                    GREATEST(
+                        word_similarity(:query, label),
+                        ts_rank(
+                            search_vector, to_tsquery('simple', :or_tsquery)
+                        )
+                    ) AS score
+                FROM global_search_index
+                WHERE label ILIKE :contains
+                   OR search_vector @@ plainto_tsquery('simple', :query)
+                   OR search_vector @@ to_tsquery('simple', :or_tsquery)
+                   OR :query <% label
+            ) ranked
+            ORDER BY match_priority ASC, score DESC, label ASC
             LIMIT :limit
         """)
 
@@ -217,7 +255,9 @@ class GlobalSearchRepository:
             sql,
             {
                 "query": query,
+                "or_tsquery": or_tsquery,
                 "prefix": f"{query}%",
+                "contains": f"%{query}%",
                 "limit": limit,
             },
         )

--- a/backend/tests/test_global_search.py
+++ b/backend/tests/test_global_search.py
@@ -226,6 +226,75 @@ class TestGlobalSearchRepository:
 
         assert len(results) <= 2
 
+    @pytest.mark.asyncio
+    async def test_autocomplete_matches_word_inside_label(
+        self, db_session: AsyncSession, search_test_data
+    ):
+        """Autocomplete must surface a word that appears *inside* a label.
+
+        Regression: the previous prefix-only implementation matched solely
+        ``label ILIKE 'query%'`` or whole-label trigram, so a query for a word
+        embedded in a multi-word label (the real-world ``diabetes`` /
+        ``cyst`` case) returned nothing. ``mutation`` appears mid-title in the
+        fixture publication "SEARCHGENE mutation analysis study"; full-text
+        matching on ``search_vector`` must now find it.
+        """
+        repo = GlobalSearchRepository(db_session)
+        results = await repo.autocomplete("mutation", limit=10)
+
+        assert any(
+            r["label"] == "SEARCHGENE mutation analysis study" for r in results
+        ), results
+
+    @pytest.mark.asyncio
+    async def test_autocomplete_matches_substring_inside_label(
+        self, db_session: AsyncSession, search_test_data
+    ):
+        """Autocomplete must surface a *substring* that is not a token start.
+
+        Regression mirroring partial variant queries like ``c.5`` ->
+        ``HNF1B:c.544+1G>C``. ``nalysis`` is a substring of "analysis" in the
+        fixture publication title but is neither a label prefix nor a
+        full-text token, so only the substring tier can find it.
+        """
+        repo = GlobalSearchRepository(db_session)
+        results = await repo.autocomplete("nalysis", limit=10)
+
+        assert any(
+            r["label"] == "SEARCHGENE mutation analysis study" for r in results
+        ), results
+
+    @pytest.mark.asyncio
+    async def test_autocomplete_tolerates_typos(
+        self, db_session: AsyncSession, search_test_data
+    ):
+        """Autocomplete must tolerate a one-character typo via word similarity.
+
+        ``mutaton`` (missing the ``i`` of "mutation") must still surface the
+        fixture publication through the fuzzy ``word_similarity`` tier.
+        """
+        repo = GlobalSearchRepository(db_session)
+        results = await repo.autocomplete("mutaton", limit=10)
+
+        assert any(
+            r["label"] == "SEARCHGENE mutation analysis study" for r in results
+        ), results
+
+    @pytest.mark.asyncio
+    async def test_autocomplete_prefix_ranked_first(
+        self, db_session: AsyncSession, search_test_data
+    ):
+        """A label that starts with the query must outrank mid-label matches.
+
+        Classic typeahead expectation: typing the start of a label keeps that
+        label at the top even though the FTS/substring tiers also match.
+        """
+        repo = GlobalSearchRepository(db_session)
+        results = await repo.autocomplete("SEARCHGENE", limit=10)
+
+        assert results, results
+        assert results[0]["label"].upper().startswith("SEARCHGENE"), results
+
 
 # ============================================================================
 # PhenopacketSearchRepository Tests

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -8,8 +8,8 @@ help:  ## Show frontend commands
 install:  ## Install dependencies
 	npm install
 
-dev:  ## Start development server (http://localhost:5173)
-	npm run dev
+dev:  ## Start development server (http://localhost:3000)
+	npm run dev -- --port 3000 --strictPort
 
 build:  ## Build for production
 	npm run build

--- a/frontend/src/components/SearchCard.vue
+++ b/frontend/src/components/SearchCard.vue
@@ -15,31 +15,35 @@
       rounded
       full-width
       return-object
+      no-filter
       item-title="label"
       item-value="id"
+      :menu-props="{ maxHeight: 420 }"
+      aria-label="Search variants, phenotypes, and publications"
       @update:search="debouncedSearch"
       @update:model-value="onSelect"
       @keyup.enter="onEnter"
     >
       <template #item="{ props, item }">
-        <v-list-item v-bind="props" :title="item.raw.label">
+        <v-list-item v-bind="props" :title="null">
           <template #prepend>
-            <v-icon v-if="item.raw.type === 'Gene'" color="primary">mdi-dna</v-icon>
-            <v-icon v-else-if="item.raw.type === 'Gene Feature'" color="purple">
-              mdi-creation
+            <v-icon :color="iconFor(rawOf(item).type).color">
+              {{ iconFor(rawOf(item).type).icon }}
             </v-icon>
-            <v-icon v-else-if="item.raw.type === 'Variant'" color="error">mdi-flash</v-icon>
-            <v-icon v-else-if="item.raw.type === 'Phenopacket'" color="teal">mdi-account</v-icon>
-            <v-icon v-else-if="item.raw.type === 'Publication'" color="orange">
-              mdi-book-open-page-variant
-            </v-icon>
-            <v-icon v-else color="grey">mdi-magnify</v-icon>
           </template>
-          <v-list-item-subtitle>
-            {{ item.raw.type }}
-            <span v-if="item.raw.subtype"> · {{ item.raw.subtype }}</span>
-            <span v-if="item.raw.extra_info"> · {{ item.raw.extra_info }}</span>
-          </v-list-item-subtitle>
+          <template #title>
+            <span class="search-item-title">
+              <template v-for="(segment, i) in highlightSegments(rawOf(item).label)" :key="i">
+                <span v-if="segment.match" class="search-hl">{{ segment.text }}</span>
+                <template v-else>{{ segment.text }}</template>
+              </template>
+            </span>
+          </template>
+          <template #subtitle>
+            {{ rawOf(item).type }}
+            <span v-if="rawOf(item).subtype"> · {{ rawOf(item).subtype }}</span>
+            <span v-if="rawOf(item).extra_info"> · {{ rawOf(item).extra_info }}</span>
+          </template>
         </v-list-item>
       </template>
 
@@ -67,12 +71,51 @@
         </v-list-item>
         <v-divider />
       </template>
+
+      <!--
+        Helpful empty state. With `no-filter` the dropdown trusts the
+        server's (fuzzy/substring) results, so when it is empty we tell the
+        user why and offer to escalate to the full search-results page rather
+        than showing a bare "No data available".
+      -->
+      <template #no-data>
+        <div
+          v-if="noDataState !== 'recent'"
+          class="px-4 py-3 text-medium-emphasis search-no-data"
+          role="status"
+          aria-live="polite"
+        >
+          <template v-if="noDataState === 'loading'">
+            <v-progress-circular indeterminate size="16" width="2" class="mr-2" />
+            Searching…
+          </template>
+          <template v-else-if="noDataState === 'empty'">
+            Start typing to search variants, phenotypes, and publications.
+          </template>
+          <template v-else-if="noDataState === 'tooShort'">
+            Type at least 2 characters to see suggestions.
+          </template>
+          <template v-else>
+            <div class="mb-2">No quick matches for “{{ trimmedQuery }}”.</div>
+            <v-btn
+              size="small"
+              variant="tonal"
+              color="primary"
+              prepend-icon="mdi-magnify"
+              @mousedown.prevent
+              @click="searchEverything"
+            >
+              Search everything for “{{ trimmedQuery }}”
+            </v-btn>
+          </template>
+        </div>
+      </template>
     </v-autocomplete>
   </v-card>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { searchAutocomplete } from '@/api';
 import { addRecentSearch, getRecentSearches, clearRecentSearches } from '@/utils/searchHistory';
@@ -88,6 +131,21 @@ const recentSearches = ref([]);
 // Load recent searches on mount
 onMounted(() => {
   recentSearches.value = getRecentSearches();
+});
+
+const trimmedQuery = computed(() => (searchQuery.value ?? '').trim());
+
+/**
+ * Drives the #no-data slot so the dropdown explains itself instead of
+ * rendering Vuetify's default "No data available".
+ * @returns {'loading'|'recent'|'empty'|'tooShort'|'noMatch'}
+ */
+const noDataState = computed(() => {
+  if (loading.value) return 'loading';
+  const q = trimmedQuery.value;
+  if (q.length === 0) return recentSearches.value.length > 0 ? 'recent' : 'empty';
+  if (q.length < 2) return 'tooShort';
+  return 'noMatch';
 });
 
 const fetchSuggestions = async (query) => {
@@ -113,6 +171,57 @@ const fetchSuggestions = async (query) => {
 };
 
 const debouncedSearch = debounce(fetchSuggestions, 300);
+
+/** Map a result type to its suggestion icon + colour. */
+const TYPE_ICONS = {
+  Gene: { icon: 'mdi-dna', color: 'primary' },
+  'Gene Feature': { icon: 'mdi-creation', color: 'purple' },
+  Variant: { icon: 'mdi-flash', color: 'error' },
+  Phenopacket: { icon: 'mdi-account', color: 'teal' },
+  Publication: { icon: 'mdi-book-open-page-variant', color: 'orange' },
+};
+const iconFor = (type) => TYPE_ICONS[type] ?? { icon: 'mdi-magnify', color: 'grey' };
+
+/**
+ * Resolve the underlying suggestion object from an autocomplete item slot.
+ * Vuetify hands the raw suggestion object directly here, but tolerate the
+ * ``InternalItem`` ``{ raw }`` shape too so the template is robust to either.
+ * @param {object} item
+ * @returns {{ label?: string, type?: string, subtype?: string, extra_info?: string }}
+ */
+const rawOf = (item) => item?.raw ?? item ?? {};
+
+/**
+ * Split a label around the first case-insensitive occurrence of the current
+ * query so it can be rendered with the matched run emphasized. Returns the
+ * whole label as a single non-matching segment when the literal query is not
+ * present (e.g. fuzzy/typo matches), so it is always safe to render.
+ * @param {string} label
+ * @returns {Array<{ text: string, match: boolean }>}
+ */
+const highlightSegments = (label) => {
+  const text = label ?? '';
+  const q = trimmedQuery.value;
+  if (!q) return [{ text, match: false }];
+  const idx = text.toLowerCase().indexOf(q.toLowerCase());
+  if (idx === -1) return [{ text, match: false }];
+  return [
+    { text: text.slice(0, idx), match: false },
+    { text: text.slice(idx, idx + q.length), match: true },
+    { text: text.slice(idx + q.length), match: false },
+  ].filter((segment) => segment.text.length > 0);
+};
+
+/** Navigate to the full search-results page for a free-text term. */
+const goToFullSearch = (term) => {
+  const q = (term ?? '').trim();
+  if (!q) return;
+  addRecentSearch(q);
+  router.push({
+    name: 'SearchResults',
+    query: { q },
+  });
+};
 
 const onSelect = (item) => {
   if (!item) return;
@@ -148,22 +257,19 @@ const onSelect = (item) => {
 const onEnter = () => {
   if (selectedItem.value) {
     onSelect(selectedItem.value);
-  } else if (searchQuery.value) {
-    addRecentSearch(searchQuery.value);
-    router.push({
-      name: 'SearchResults',
-      query: { q: searchQuery.value },
-    });
+  } else {
+    goToFullSearch(searchQuery.value);
   }
+};
+
+/** "Search everything" affordance shown in the empty-state slot. */
+const searchEverything = () => {
+  goToFullSearch(searchQuery.value);
 };
 
 const searchFromRecent = (recentTerm) => {
   searchQuery.value = recentTerm;
-  addRecentSearch(recentTerm);
-  router.push({
-    name: 'SearchResults',
-    query: { q: recentTerm },
-  });
+  goToFullSearch(recentTerm);
 };
 
 const handleClearRecentSearches = () => {
@@ -184,5 +290,20 @@ const handleClearRecentSearches = () => {
 
 .mx-auto {
   margin: 0 auto;
+}
+
+/* Emphasize the matched run of text in a suggestion. Uses the theme primary
+   colour so it reads correctly in both light and dark themes. */
+.search-hl {
+  color: rgb(var(--v-theme-primary));
+  font-weight: 700;
+}
+
+.search-item-title {
+  white-space: normal;
+}
+
+.search-no-data {
+  font-size: 0.875rem;
 }
 </style>

--- a/frontend/tests/unit/components/SearchCard.spec.js
+++ b/frontend/tests/unit/components/SearchCard.spec.js
@@ -107,4 +107,28 @@ describe('SearchCard', () => {
       query: { q: 'NM_000458.4:c.826C>T' },
     });
   });
+
+  it('disables client-side filtering so server-driven suggestions are trusted', async () => {
+    // Server-driven async autocomplete must set `no-filter`; otherwise
+    // Vuetify re-filters fetched items against the literal typed string and
+    // silently drops fuzzy/substring/synonym matches the backend returned.
+    const { wrapper } = await mountCard();
+    const autocomplete = wrapper.findComponent({ name: 'VAutocomplete' });
+    expect(autocomplete.props('noFilter')).toBe(true);
+  });
+
+  it('escalates a free-text query to the full search page on Enter', async () => {
+    const { wrapper, router } = await mountCard();
+    const pushSpy = vi.spyOn(router, 'push');
+    const autocomplete = wrapper.findComponent({ name: 'VAutocomplete' });
+
+    // Type a phenotype phrase with no suggestion selected, then press Enter.
+    await autocomplete.vm.$emit('update:search', 'renal cysts');
+    await wrapper.find('input').trigger('keyup.enter');
+
+    expect(pushSpy).toHaveBeenCalledWith({
+      name: 'SearchResults',
+      query: { q: 'renal cysts' },
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The home-page global search **looked like it had no autocomplete**: typing the
most natural queries returned *"No data available."* Verified live (Playwright +
direct API) on the running stack:

| Query | `/search/global` (FTS) | `/search/autocomplete` (before) |
|---|---|---|
| `diabetes` | 913 results | **`[]`** |
| `cyst` | many | **`[]`** |
| `c.5` (partial HGVS) | — | **`[]`** |

### Root cause
`GlobalSearchRepository.autocomplete()` matched only `label ILIKE 'query%'`
(prefix) or whole-label trigram, **ignoring the materialized view's full-text
`search_vector`** that `/search/global` already uses. So a word *inside* a
multi-word label (publication titles, descriptive individual labels, folded
disease/phenotype text) or a substring of an HGVS label was never found.

A second, hidden bug: the `#item` slot receives the **raw suggestion object
directly**, but the template read `item.raw.label` / `item.raw.type` — so rows
rendered blank. It was invisible only because autocomplete almost never
returned results (the bug above).

## Changes

**Backend** — rewrite `autocomplete()` to the same hybrid signal as `search()`,
ranked for typeahead (best first): label-prefix → whole-word FTS → substring →
word-prefix FTS → fuzzy `word_similarity` (typos). All predicates use the
existing `GIN(search_vector)` and trigram `GIN(label)` indexes; the view is
small. + regression tests (word-inside-label, substring, typo, prefix ranking).

**Frontend** (`SearchCard.vue`, Vuetify 4 standards):
- `no-filter` — trust server (fuzzy/substring) results instead of re-filtering
  them away client-side.
- Helpful `#no-data` empty state: min-length hint, "Searching…", and a
  **"Search everything for <q>"** action escalating to the results page.
- Matched-text **highlighting** (theme-aware).
- Fix blank-row rendering (`item.raw ?? item`).
- + tests for `no-filter` and Enter-to-escalate.

## Verification
- Playwright on the running app: `diabetes`→publications (highlighted), `c.5`→
  variants (substring), min-length hint, no-match CTA + navigation — all work.
- Backend: 52/52 search tests pass, ruff format/lint + mypy clean.
- Frontend: 464/464 vitest pass, eslint + prettier clean, `vite build` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)