### PR TITLE
feat(api): track authenticated user in /all-variants audit log (#140)

### DIFF
--- a/backend/app/phenopackets/routers/aggregations/all_variants.py
+++ b/backend/app/phenopackets/routers/aggregations/all_variants.py
@@ -10,9 +10,11 @@ from fastapi import APIRouter, Depends, Query, Request, Response
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.dependencies import get_optional_user
 from app.database import get_db
 from app.middleware.rate_limiter import check_rate_limit, get_client_ip
 from app.models.json_api import JsonApiResponse
+from app.models.user import User
 from app.phenopackets.molecular_consequence import compute_molecular_consequence
 from app.phenopackets.variant_search_validation import (
     validate_classification,
@@ -91,6 +93,7 @@ async def aggregate_all_variants(
         None, description="Sort field with optional '-' prefix for descending"
     ),
     db: AsyncSession = Depends(get_db),
+    user: Optional[User] = Depends(get_optional_user),
 ):
     """Search and filter variants with offset pagination.
 
@@ -237,7 +240,7 @@ async def aggregate_all_variants(
     # Audit logging (GDPR compliance)
     log_variant_search(
         client_ip=get_client_ip(request),
-        user_id=None,
+        user_id=user.email if user else None,
         query=validated_query,
         variant_type=validated_variant_type,
         classification=validated_classification,

--- a/backend/tests/test_variant_search.py
+++ b/backend/tests/test_variant_search.py
@@ -5,6 +5,8 @@ capabilities, including security validation, HGVS notation search, and molecular
 consequence filtering.
 """
 
+import logging
+
 import pytest
 from fastapi import HTTPException
 
@@ -537,3 +539,38 @@ class TestAllVariantsConsequenceFilter:
         assert "consq-var-missense" not in ids
         assert "consq-var-nonsense" not in ids
         assert body["meta"]["page"]["totalRecords"] == len(rows)
+
+
+def _variant_search_records(caplog) -> list:
+    """Audit records emitted by the all-variants endpoint."""
+    return [r for r in caplog.records if r.getMessage() == "VARIANT_SEARCH"]
+
+
+@pytest.mark.asyncio
+class TestAllVariantsAuditUser:
+    """Issue #140: the /all-variants audit log records the authenticated user.
+
+    Previously ``user_id`` was hardcoded to ``None`` (always ``"anonymous"``).
+    The endpoint now resolves the optional user and logs their email, while
+    unauthenticated requests still log ``"anonymous"``.
+    """
+
+    async def test_authenticated_request_logs_user_email(
+        self, async_client, admin_headers, caplog
+    ):
+        """An authenticated request records the caller's email in the audit log."""
+        with caplog.at_level(logging.INFO, logger="audit"):
+            resp = await async_client.get(ALL_VARIANTS_PATH, headers=admin_headers)
+        assert resp.status_code == 200, resp.text
+        records = _variant_search_records(caplog)
+        assert records, "expected a VARIANT_SEARCH audit record"
+        assert records[-1].user_id == "testadmin@example.com"
+
+    async def test_anonymous_request_logs_anonymous(self, async_client, caplog):
+        """An unauthenticated request still records ``anonymous`` (no PII leak)."""
+        with caplog.at_level(logging.INFO, logger="audit"):
+            resp = await async_client.get(ALL_VARIANTS_PATH)
+        assert resp.status_code == 200, resp.text
+        records = _variant_search_records(caplog)
+        assert records, "expected a VARIANT_SEARCH audit record"
+        assert records[-1].user_id == "anonymous"


### PR DESCRIPTION
## Summary

Closes #140.

The `/all-variants` aggregation endpoint hardcoded `user_id=None` in its GDPR audit-log call (`all_variants.py:240`), so **every** variant search was recorded as `"anonymous"` — even for authenticated callers. The issue's premise that this needs new audit-logging infrastructure is stale: the logging function (`log_variant_search`) and an optional-auth dependency (`get_optional_user`) already exist and are used by sibling phenopackets routers. This is the small wiring change that was always intended.

## Changes

- Inject the existing `get_optional_user` dependency into `aggregate_all_variants` (mirrors the `search.py` pattern).
- Log `user.email if user else None` — `user.email` matches `log_variant_search`'s `Optional[str]` contract, its docstring example, and its existing test; `None` is still coerced to `"anonymous"`.
- Add endpoint-level tests asserting an authenticated request logs the caller's email and an anonymous request logs `"anonymous"`.

## Why `user.email` (not `str(user.id)`)

The logging function, its docstring, and `test_audit_logging.py` already encode the audit identifier as an email string. Following the established, tested interface avoids signature churn and a contract break. Anonymous traffic still logs `"anonymous"`, so there's no PII change for unauthenticated requests and no API response change.

## Verification (local, against migrated test DB)

- `tests/test_variant_search.py` (incl. new `TestAllVariantsAuditUser`), `tests/test_audit_logging.py`, `tests/test_openapi_contract.py` → **48 passed** (OpenAPI contract unaffected — no `_generated_models` drift).
- `tests/test_aggregations_endpoints.py`, `tests/test_aggregations_common.py` → **29 passed**.
- `ruff format` clean · `ruff check` passes · `mypy` success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)