### PR TITLE
fix(docker): bind published ports to loopback by default

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -89,9 +89,14 @@ HNF1B_MCP_ALLOWED_ORIGINS=https://claude.ai,https://claude.com
 HNF1B_MCP_API_BASE_URL=http://hnf1b_api:8000/api/v2
 
 # ============================================
-# Development Ports (for local testing)
+# Host port publishing
 # ============================================
-# Only used when running docker/docker-compose.yml without NPM overlay
+# Interface the published ports below bind to. Defaults to loopback so
+# Postgres/Redis/API/MCP/frontend are NOT reachable on the host's public
+# interface (behind NPM, services talk over the proxy network by name, so
+# loopback does not affect routing). Set to 0.0.0.0 only to deliberately
+# expose these ports on all interfaces.
+HOST_BIND_IP=127.0.0.1
 API_PORT_HOST=8000
 FRONTEND_PORT_HOST=3000
 DB_PORT_HOST=5433

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,7 +26,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-hnf1b_pass}
       POSTGRES_DB: ${POSTGRES_DB:-hnf1b_phenopackets}
     ports:
-      - "${DB_PORT_HOST:-5433}:5432"
+      # Bind published ports to loopback by default so Postgres/Redis/app are
+      # not exposed on the host's public interface. Set HOST_BIND_IP=0.0.0.0 to
+      # opt back into direct external exposure. NPM reaches services over the
+      # shared proxy network by container name, so this does not affect routing.
+      - "${HOST_BIND_IP:-127.0.0.1}:${DB_PORT_HOST:-5433}:5432"
     volumes:
       - hnf1b_postgres_data:/var/lib/postgresql/data
     networks:
@@ -57,7 +61,7 @@ services:
       --appendonly yes
       --appendfsync everysec
     ports:
-      - "${REDIS_PORT_HOST:-6380}:6379"
+      - "${HOST_BIND_IP:-127.0.0.1}:${REDIS_PORT_HOST:-6380}:6379"
     volumes:
       - hnf1b_redis_data:/data
     networks:
@@ -110,7 +114,7 @@ services:
       # Data import (set ENABLE_DATA_IMPORT=true to import on first run)
       ENABLE_DATA_IMPORT: ${ENABLE_DATA_IMPORT:-false}
     ports:
-      - "${API_PORT_HOST:-8000}:8000"
+      - "${HOST_BIND_IP:-127.0.0.1}:${API_PORT_HOST:-8000}:8000"
     depends_on:
       hnf1b_db:
         condition: service_healthy
@@ -148,7 +152,7 @@ services:
       HNF1B_MCP_REDIS_URL: redis://hnf1b_cache:6379/1
       HNF1B_MCP_ALLOWED_ORIGINS: ${HNF1B_MCP_ALLOWED_ORIGINS:-https://claude.ai,https://claude.com}
     ports:
-      - "${MCP_PORT_HOST:-8788}:8788"
+      - "${HOST_BIND_IP:-127.0.0.1}:${MCP_PORT_HOST:-8788}:8788"
     depends_on:
       hnf1b_api:
         condition: service_healthy
@@ -179,7 +183,7 @@ services:
     container_name: hnf1b_frontend
     restart: unless-stopped
     ports:
-      - "${FRONTEND_PORT_HOST:-3000}:80"
+      - "${HOST_BIND_IP:-127.0.0.1}:${FRONTEND_PORT_HOST:-3000}:80"
     depends_on:
       hnf1b_api:
         condition: service_healthy


### PR DESCRIPTION
## Problem
The base `docker/docker-compose.yml` publishes Postgres (`5433`), Redis (`6380`), API (`8000`), MCP (`8788`) and the frontend (`3000`) on `0.0.0.0`. The NPM overlay attempts to drop these with `ports: []`, but Docker Compose v2.40 **concatenates** port lists across `-f` files rather than replacing them, so the base bindings survive in production. Verified on the live host (compose v2.40.3): all five resolve to `0.0.0.0` published ports — exposing the datastores on the public interface.

## Fix
Prefix every published port with `${HOST_BIND_IP:-127.0.0.1}` so they bind to loopback by default. NPM reaches each service over the shared `npm_proxy_network` by container name, so routing is unaffected. Set `HOST_BIND_IP=0.0.0.0` to opt back into direct external exposure.

- `docker/docker-compose.yml`: loopback-bind all 5 published ports
- `.env.docker.example`: document `HOST_BIND_IP`

🤖 Generated with [Claude Code](https://claude.com/claude-code)