### PR TITLE
refactor(frontend): split ProteinStructure3D into sub-components (#133)

### DIFF
--- a/frontend/src/components/gene/ProteinStructure3D.vue
+++ b/frontend/src/components/gene/ProteinStructure3D.vue
@@ -1,5 +1,6 @@
 <!-- 3D Protein Structure Viewer using NGL.js -->
 <!-- Supports two modes: single variant (detail page) or all variants with panel (homepage) -->
+<!-- Smart container: owns UI/derived state, lays out the 4 sub-components, props-down/emits-up. -->
 <template>
   <v-card class="protein-3d-card">
     <v-card-title class="text-h6 bg-grey-lighten-4">
@@ -46,242 +47,76 @@
         Variants outside this region cannot be visualized in 3D.
       </v-alert>
 
-      <!-- Loading state -->
-      <div v-if="loading" class="text-center py-8">
-        <v-progress-circular indeterminate color="primary" size="48" />
-        <div class="mt-2 text-grey">Loading 3D structure...</div>
-      </div>
-
-      <!-- Error state -->
-      <v-alert v-else-if="error" type="error" density="compact" class="mb-3">
-        <v-icon size="small" class="mr-1"> mdi-alert </v-icon>
-        {{ error }}
-      </v-alert>
-
       <!-- Main Content: 3D Viewport + Optional Variant Panel -->
-      <v-row v-show="!loading && !error" no-gutters>
+      <v-row no-gutters>
         <!-- 3D Viewport Column — full width on mobile, 8/12 alongside the
              variant panel from md up so the panel stacks below on phones. -->
         <v-col cols="12" :md="showAllVariants ? 8 : 12">
-          <div ref="nglContainer" class="ngl-viewport" />
+          <StructureViewer
+            ref="viewer"
+            :active-variant="activeVariant"
+            :active-variant-a-a-position="activeVariantAAPosition"
+            :active-variant-in-structure="activeVariantInStructure"
+            :representation="representation"
+            :show-d-n-a="showDNA"
+            :color-by-domain="colorByDomain"
+            :show-distance-line="showDistanceLine"
+            :variants="variants"
+            :show-all-variants="showAllVariants"
+            @loading="loading = $event"
+            @loaded="structureLoaded = true"
+            @error="error = $event"
+            @distance-info="currentVariantDistanceInfo = $event"
+            @distances-calculated="variantDistanceCache = $event"
+            @reset-distance-line="showDistanceLine = false"
+          />
         </v-col>
 
         <!-- Variant List Panel (only in showAllVariants mode) -->
-        <v-col v-if="showAllVariants" cols="12" md="4">
-          <div class="variant-panel">
-            <div class="variant-panel-header">
-              <span class="text-subtitle-2">Variants in Structure</span>
-              <v-chip size="x-small" color="primary" class="ml-2">
-                {{ filteredAndSortedVariants.length }}
-                <template v-if="filteredAndSortedVariants.length !== variantsInStructure.length">
-                  / {{ variantsInStructure.length }}
-                </template>
-              </v-chip>
-            </div>
-
-            <!-- Filter and Sort Controls -->
-            <div class="variant-panel-controls">
-              <!-- Sort Control -->
-              <v-select
-                v-model="sortBy"
-                :items="sortOptions"
-                label="Sort by"
-                density="compact"
-                hide-details
-                variant="outlined"
-                class="sort-select"
-              />
-
-              <!-- Pathogenicity Filter -->
-              <v-select
-                v-model="filterPathogenicity"
-                :items="pathogenicityOptions"
-                label="Pathogenicity"
-                density="compact"
-                hide-details
-                variant="outlined"
-                clearable
-                class="filter-select"
-              />
-
-              <!-- Distance Filter -->
-              <v-select
-                v-model="filterDistance"
-                :items="distanceOptions"
-                label="DNA Distance"
-                density="compact"
-                hide-details
-                variant="outlined"
-                clearable
-                class="filter-select"
-              />
-            </div>
-
-            <v-list density="compact" class="variant-list">
-              <v-list-item
-                v-for="variant in filteredAndSortedVariants"
-                :key="variant.variant_id"
-                :class="{
-                  'variant-item-active': selectedVariantId === variant.variant_id,
-                  'variant-item-hover': hoveredVariantId === variant.variant_id,
-                }"
-                @click="selectVariant(variant)"
-                @mouseenter="hoverVariant(variant)"
-                @mouseleave="unhoverVariant()"
-              >
-                <template #prepend>
-                  <v-avatar :color="getVariantChipColor(variant)" size="28">
-                    <span class="text-white text-caption">{{ extractAAPosition(variant) }}</span>
-                  </v-avatar>
-                </template>
-                <v-list-item-title class="text-body-2">
-                  {{ getVariantLabel(variant) }}
-                </v-list-item-title>
-                <v-list-item-subtitle class="text-caption d-flex align-center">
-                  <span>{{ variant.classificationVerdict || 'Unknown' }}</span>
-                  <v-chip
-                    v-if="getVariantDistanceCategory(variant)"
-                    size="x-small"
-                    :color="getDistanceChipColor(getVariantDistanceCategory(variant))"
-                    class="ml-2"
-                  >
-                    {{ getVariantDistanceFormatted(variant) }}
-                  </v-chip>
-                </v-list-item-subtitle>
-              </v-list-item>
-            </v-list>
-            <div v-if="filteredAndSortedVariants.length === 0" class="text-center py-4 text-grey">
-              <v-icon size="large" color="grey-lighten-1">mdi-alert-circle-outline</v-icon>
-              <div class="text-caption mt-1">
-                {{
-                  variantsInStructure.length === 0
-                    ? 'No variants in structure range'
-                    : 'No variants match filters'
-                }}
-              </div>
-              <v-btn
-                v-if="variantsInStructure.length > 0 && (filterPathogenicity || filterDistance)"
-                size="x-small"
-                variant="text"
-                color="primary"
-                class="mt-2"
-                @click="clearFilters"
-              >
-                Clear Filters
-              </v-btn>
-            </div>
-          </div>
+        <v-col v-if="showAllVariants" v-show="!loading && !error" cols="12" md="4">
+          <VariantPanel
+            :variants="filteredAndSortedVariants"
+            :total-in-structure="variantsInStructure.length"
+            :selected-variant-id="selectedVariantId"
+            :hovered-variant-id="hoveredVariantId"
+            :sort-by="sortBy"
+            :filter-pathogenicity="filterPathogenicity"
+            :filter-distance="filterDistance"
+            @select="selectVariant"
+            @hover="hoverVariant"
+            @unhover="unhoverVariant"
+            @clear-filters="clearFilters"
+            @update:sort-by="sortBy = $event"
+            @update:filter-pathogenicity="filterPathogenicity = $event"
+            @update:filter-distance="filterDistance = $event"
+          />
         </v-col>
       </v-row>
 
       <!-- Controls Row -->
-      <v-row v-if="!loading && !error" class="mt-3">
-        <!-- Representation Controls -->
-        <v-col cols="12" sm="6" md="5">
-          <v-btn-toggle v-model="representation" mandatory density="compact" color="primary">
-            <v-btn value="cartoon" size="small">
-              <v-icon left size="small"> mdi-waves </v-icon>
-              Cartoon
-            </v-btn>
-            <v-btn value="surface" size="small">
-              <v-icon left size="small"> mdi-circle </v-icon>
-              Surface
-            </v-btn>
-            <v-btn value="ball+stick" size="small">
-              <v-icon left size="small"> mdi-atom </v-icon>
-              Ball+Stick
-            </v-btn>
-          </v-btn-toggle>
-        </v-col>
+      <StructureControls
+        v-if="!loading && !error"
+        :representation="representation"
+        :show-d-n-a="showDNA"
+        :color-by-domain="colorByDomain"
+        :show-distance-line="showDistanceLine"
+        :structure-loaded="structureLoaded"
+        :has-active-variant-in-structure="activeVariantInStructure"
+        :active-variant-distance-info="activeVariantDistanceInfo"
+        @update:representation="representation = $event"
+        @update:show-d-n-a="showDNA = $event"
+        @update:color-by-domain="colorByDomain = $event"
+        @reset="onReset"
+        @toggle-distance-line="toggleDistanceLine"
+      />
 
-        <!-- DNA Toggle -->
-        <v-col cols="6" sm="3" md="2">
-          <v-switch
-            v-model="showDNA"
-            label="Show DNA"
-            density="compact"
-            hide-details
-            color="primary"
-          />
-        </v-col>
-
-        <!-- Domain Coloring Toggle -->
-        <v-col cols="6" sm="3" md="2">
-          <v-switch
-            v-model="colorByDomain"
-            label="Domain Colors"
-            density="compact"
-            hide-details
-            color="secondary"
-          />
-        </v-col>
-
-        <!-- Action Buttons -->
-        <v-col cols="12" sm="3" md="4" class="text-right">
-          <v-btn size="small" variant="outlined" class="mr-2" @click="resetView">
-            <v-icon left size="small"> mdi-refresh </v-icon>
-            Reset View
-          </v-btn>
-          <v-btn
-            v-if="activeVariantInStructure && activeVariantDistanceInfo"
-            size="small"
-            variant="outlined"
-            :color="showDistanceLine ? 'primary' : 'default'"
-            @click="toggleDistanceLine"
-          >
-            <v-icon left size="small"> mdi-ruler </v-icon>
-            {{ activeVariantDistanceInfo.distanceFormatted }} &Aring;
-          </v-btn>
-        </v-col>
-      </v-row>
-
-      <!-- Active Variant Distance Info -->
-      <v-alert
-        v-if="!loading && !error && activeVariantInStructure && activeVariantDistanceInfo"
-        :type="getDistanceAlertType(activeVariantDistanceInfo.category)"
-        density="compact"
-        variant="tonal"
-        class="mt-3"
-      >
-        <v-icon size="small" class="mr-1"> mdi-ruler </v-icon>
-        <strong>Distance to DNA:</strong>
-        {{ activeVariantDistanceInfo.distanceFormatted }} &Aring; ({{
-          getDistanceCategoryLabel(activeVariantDistanceInfo.category)
-        }})
-        <span class="text-caption ml-2">
-          Closest DNA atom: {{ activeVariantDistanceInfo.closestDNAAtom?.label }}
-        </span>
-      </v-alert>
-
-      <!-- Legend Row -->
-      <v-row v-if="!loading && !error" class="mt-2">
-        <v-col cols="12">
-          <div class="legend-container">
-            <span class="text-caption text-grey mr-2">Pathogenicity:</span>
-            <v-chip size="x-small" color="red-lighten-1" class="mr-1"> Pathogenic </v-chip>
-            <v-chip size="x-small" color="orange-lighten-1" class="mr-1">
-              Likely Pathogenic
-            </v-chip>
-            <v-chip size="x-small" color="yellow-darken-1" class="mr-1"> VUS </v-chip>
-            <v-chip size="x-small" color="light-green-lighten-1" class="mr-1">
-              Likely Benign
-            </v-chip>
-            <v-chip size="x-small" color="grey-lighten-1"> Unknown </v-chip>
-          </div>
-          <!-- Domain Legend (shown when domain coloring is enabled) -->
-          <div v-if="colorByDomain" class="legend-container mt-2">
-            <span class="text-caption text-grey mr-2">Domains:</span>
-            <v-chip size="x-small" style="background-color: #ab47bc; color: white" class="mr-1">
-              POU-S (90-173)
-            </v-chip>
-            <v-chip size="x-small" style="background-color: #26a69a; color: white" class="mr-1">
-              POU-H (232-305)
-            </v-chip>
-            <v-chip size="x-small" style="background-color: #9e9e9e" class="mr-1"> Linker </v-chip>
-            <span class="text-caption text-grey-darken-1 ml-2"> (Gap: 187-230 not resolved) </span>
-          </div>
-        </v-col>
-      </v-row>
+      <!-- Active Variant Distance Info + Legend -->
+      <DistanceStatsCard
+        v-if="!loading && !error"
+        :active-variant-distance-info="activeVariantInStructure ? activeVariantDistanceInfo : null"
+        :protein-domains="proteinDomains"
+        :color-by-domain="colorByDomain"
+      />
 
       <!-- Current variant not in structure warning (single variant mode) -->
       <v-alert
@@ -329,33 +164,56 @@
 </template>
 
 <script>
-import * as NGL from 'ngl';
-import { markRaw } from 'vue';
+import { STRUCTURE_START, STRUCTURE_END } from '@/utils/dnaDistanceCalculator';
+import { getPathogenicityColor, getPathogenicityScore } from '@/utils/colors';
 import { extractPNotation } from '@/utils/hgvs';
-import {
-  DNADistanceCalculator,
-  STRUCTURE_START,
-  STRUCTURE_END,
-} from '@/utils/dnaDistanceCalculator';
-import {
-  getPathogenicityColor,
-  getPathogenicityScore,
-  getPathogenicityHexColor,
-} from '@/utils/colors';
 import { extractAAPosition as extractAAPositionUtil } from '@/utils/proteinDomains';
+import StructureViewer from '@/components/gene/protein-structure/StructureViewer.vue';
+import StructureControls from '@/components/gene/protein-structure/StructureControls.vue';
+import VariantPanel from '@/components/gene/protein-structure/VariantPanel.vue';
+import DistanceStatsCard from '@/components/gene/protein-structure/DistanceStatsCard.vue';
 
-// Store NGL objects outside Vue's reactivity system
-// This prevents Vue 3 Proxy conflicts with Three.js internal properties
-let nglStage = null;
-let nglStructureComponent = null;
-let nglVariantRepresentation = null;
-let nglVariantBallStickRepresentation = null;
-let nglLabelRepresentation = null;
-let nglDistanceShape = null;
-let distanceCalculator = null;
+// HNF1B protein domains (from UniProt P35680)
+// Note: PDB 2H8R only covers residues 90-308 (with gap 187-230)
+const PROTEIN_DOMAINS = [
+  {
+    name: 'Dimerization',
+    shortName: 'Dim',
+    start: 1,
+    end: 31,
+    color: 0xffb74d, // Orange - not visible in structure (before res 90)
+  },
+  {
+    name: 'POU-Specific',
+    shortName: 'POU-S',
+    start: 88,
+    end: 173,
+    color: 0xab47bc, // Purple - partially visible (90-173)
+  },
+  {
+    name: 'POU-Homeodomain',
+    shortName: 'POU-H',
+    start: 232,
+    end: 305,
+    color: 0x26a69a, // Teal - fully visible
+  },
+  {
+    name: 'Transactivation',
+    shortName: 'TAD',
+    start: 314,
+    end: 557,
+    color: 0x81c784, // Green - not visible in structure (after res 308)
+  },
+];
 
 export default {
   name: 'ProteinStructure3D',
+  components: {
+    StructureViewer,
+    StructureControls,
+    VariantPanel,
+    DistanceStatsCard,
+  },
   props: {
     variants: {
       type: Array,
@@ -381,40 +239,7 @@ export default {
       showDistanceLine: false,
       colorByDomain: false,
       currentVariantDistanceInfo: null,
-      // HNF1B protein domains (from UniProt P35680)
-      // Note: PDB 2H8R only covers residues 90-308 (with gap 187-230)
-      proteinDomains: [
-        {
-          name: 'Dimerization',
-          shortName: 'Dim',
-          start: 1,
-          end: 31,
-          color: 0xffb74d, // Orange - not visible in structure (before res 90)
-        },
-        {
-          name: 'POU-Specific',
-          shortName: 'POU-S',
-          start: 88,
-          end: 173,
-          color: 0xab47bc, // Purple - partially visible (90-173)
-        },
-        {
-          name: 'POU-Homeodomain',
-          shortName: 'POU-H',
-          start: 232,
-          end: 305,
-          color: 0x26a69a, // Teal - fully visible
-        },
-        {
-          name: 'Transactivation',
-          shortName: 'TAD',
-          start: 314,
-          end: 557,
-          color: 0x81c784, // Green - not visible in structure (after res 308)
-        },
-      ],
-      // Color for linker regions (between domains)
-      linkerColor: 0x9e9e9e, // Grey
+      proteinDomains: PROTEIN_DOMAINS,
       // For showAllVariants mode
       selectedVariantId: null,
       hoveredVariantId: null,
@@ -422,26 +247,8 @@ export default {
       sortBy: 'position',
       filterPathogenicity: null,
       filterDistance: null,
-      // Cache for variant distances
+      // Cache for variant distances (built by the viewer, keyed by variant_id)
       variantDistanceCache: {},
-      // Options for selects
-      sortOptions: [
-        { title: 'Position', value: 'position' },
-        { title: 'Distance to DNA', value: 'distance' },
-        { title: 'Pathogenicity', value: 'pathogenicity' },
-      ],
-      pathogenicityOptions: [
-        { title: 'Pathogenic', value: 'PATHOGENIC' },
-        { title: 'Likely Pathogenic', value: 'LIKELY_PATHOGENIC' },
-        { title: 'VUS', value: 'VUS' },
-        { title: 'Likely Benign', value: 'LIKELY_BENIGN' },
-        { title: 'Benign', value: 'BENIGN' },
-      ],
-      distanceOptions: [
-        { title: 'Close (<5 Å)', value: 'close' },
-        { title: 'Medium (5-10 Å)', value: 'medium' },
-        { title: 'Far (>10 Å)', value: 'far' },
-      ],
     };
   },
   computed: {
@@ -498,9 +305,14 @@ export default {
     activeVariantDistanceInfo() {
       return this.currentVariantDistanceInfo;
     },
-    // Filtered and sorted variants for display in panel
+    // Filtered and sorted variants for display in panel.
+    // Each variant carries a resolved `_distanceInfo` (from the viewer's cache)
+    // so the presentational panel needs no NGL access.
     filteredAndSortedVariants() {
-      let variants = [...this.variantsInStructure];
+      let variants = this.variantsInStructure.map((v) => ({
+        ...v,
+        _distanceInfo: this.variantDistanceCache[v.variant_id] || null,
+      }));
 
       // Apply pathogenicity filter
       if (this.filterPathogenicity) {
@@ -516,7 +328,7 @@ export default {
       // Apply distance filter
       if (this.filterDistance) {
         variants = variants.filter((v) => {
-          const category = this.getVariantDistanceCategory(v);
+          const category = v._distanceInfo ? v._distanceInfo.category : null;
           return category === this.filterDistance;
         });
       }
@@ -527,8 +339,8 @@ export default {
           return (this.extractAAPosition(a) || 0) - (this.extractAAPosition(b) || 0);
         }
         if (this.sortBy === 'distance') {
-          const distA = this.getVariantDistanceValue(a);
-          const distB = this.getVariantDistanceValue(b);
+          const distA = a._distanceInfo ? a._distanceInfo.distance : Infinity;
+          const distB = b._distanceInfo ? b._distanceInfo.distance : Infinity;
           return distA - distB;
         }
         if (this.sortBy === 'pathogenicity') {
@@ -540,343 +352,26 @@ export default {
       return variants;
     },
   },
-  watch: {
-    representation() {
-      this.updateRepresentation();
-    },
-    showDNA() {
-      this.updateRepresentation();
-    },
-    colorByDomain() {
-      this.updateRepresentation();
-    },
-    currentVariantId() {
-      if (!this.showAllVariants) {
-        this.highlightActiveVariant();
-        this.calculateActiveVariantDistance();
-      }
-    },
-    selectedVariantId() {
-      if (this.showAllVariants) {
-        this.highlightActiveVariant();
-        this.calculateActiveVariantDistance();
-      }
-    },
-    showAllVariants: {
-      handler() {
-        this.updateRepresentation();
-        // In showAllVariants mode, we don't auto-highlight anything
-        // User selects from the panel to highlight
-        if (!this.showAllVariants) {
-          this.highlightActiveVariant();
-        }
-      },
-      immediate: false,
-    },
-  },
-  mounted() {
-    this.initializeNGL();
-    window.addEventListener('resize', this.handleResize);
-  },
-  beforeUnmount() {
-    window.removeEventListener('resize', this.handleResize);
-    if (nglStage) {
-      nglStage.dispose();
-      nglStage = null;
-      nglStructureComponent = null;
-      nglVariantRepresentation = null;
-      nglLabelRepresentation = null;
-      nglDistanceShape = null;
-      distanceCalculator = null;
-    }
-  },
   methods: {
-    async initializeNGL() {
-      try {
-        this.loading = true;
-        this.error = null;
-
-        // Wait for container to be rendered
-        await this.$nextTick();
-
-        if (!this.$refs.nglContainer) {
-          throw new Error('NGL container not found');
-        }
-
-        // Clean up any existing stage first to prevent Timer warnings
-        // This can happen when component remounts (e.g., tab switching)
-        if (nglStage) {
-          nglStage.dispose();
-          nglStage = null;
-          nglStructureComponent = null;
-          nglVariantRepresentation = null;
-          nglLabelRepresentation = null;
-          nglDistanceShape = null;
-          distanceCalculator = null;
-        }
-
-        // Initialize NGL Stage
-        // Temporarily suppress Three.js useLegacyLights deprecation warning
-        // This is a known issue in NGL library (v2.4.0) that hasn't been fixed upstream
-        const originalWarn = console.warn;
-        console.warn = (...args) => {
-          if (args[0]?.includes?.('useLegacyLights')) return;
-          originalWarn.apply(console, args);
-        };
-
-        nglStage = markRaw(
-          new NGL.Stage(this.$refs.nglContainer, {
-            backgroundColor: 'white',
-            quality: 'medium',
-            impostor: true,
-            workerDefault: true,
-          })
-        );
-
-        // Restore original console.warn
-        console.warn = originalWarn;
-
-        // Load PDB structure 2H8R (HNF1B DNA-binding domain)
-        // Served locally to reduce network dependency and improve load times
-        window.logService.info('Loading PDB structure 2H8R');
-        nglStructureComponent = markRaw(
-          await nglStage.loadFile('/2h8r.cif', {
-            defaultRepresentation: false,
-            ext: 'cif',
-          })
-        );
-
-        this.structureLoaded = true;
-
-        // Initialize distance calculator
-        distanceCalculator = new DNADistanceCalculator();
-        distanceCalculator.initialize(nglStructureComponent);
-
-        // Add initial representation
-        this.updateRepresentation();
-
-        // Highlight active variant if in single variant mode
-        // In showAllVariants mode, user selects from the panel
-        if (!this.showAllVariants) {
-          this.highlightActiveVariant();
-          this.calculateActiveVariantDistance();
-        }
-
-        // Pre-calculate distances for all variants (for filtering/sorting)
-        if (this.showAllVariants) {
-          this.calculateAllVariantDistances();
-        }
-
-        // Handle resize after a short delay
-        setTimeout(() => {
-          if (nglStage) {
-            nglStage.handleResize();
-            nglStage.autoView();
-          }
-        }, 100);
-
-        window.logService.info('3D structure loaded successfully', { pdb: '2H8R' });
-      } catch (err) {
-        window.logService.error('Failed to load 3D structure', { error: err.message });
-        this.error = `Failed to load 3D structure: ${err.message}`;
-      } finally {
-        this.loading = false;
-      }
+    extractAAPosition(variant) {
+      return extractAAPositionUtil(variant);
     },
 
-    updateRepresentation() {
-      if (!nglStructureComponent) return;
-
-      // Remove existing representations
-      nglStructureComponent.removeAllRepresentations();
-      nglVariantRepresentation = null;
-      nglLabelRepresentation = null;
-      this.removeDistanceLine();
-
-      // Determine coloring approach
-      if (this.colorByDomain) {
-        // Add domain-colored representations
-        this.addDomainColoredRepresentations();
-      } else {
-        // Add protein representation with chain coloring
-        const proteinParams = {
-          sele: 'protein',
-          color: 'chainid',
-        };
-
-        if (this.representation === 'cartoon') {
-          nglStructureComponent.addRepresentation('cartoon', {
-            ...proteinParams,
-            aspectRatio: 5,
-            smoothSheet: true,
-          });
-        } else if (this.representation === 'surface') {
-          nglStructureComponent.addRepresentation('surface', {
-            ...proteinParams,
-            opacity: 0.7,
-            surfaceType: 'ms',
-          });
-        } else if (this.representation === 'ball+stick') {
-          nglStructureComponent.addRepresentation('ball+stick', {
-            ...proteinParams,
-            multipleBond: 'symmetric',
-          });
-        }
-      }
-
-      // Add DNA representation if enabled
-      if (this.showDNA) {
-        nglStructureComponent.addRepresentation('cartoon', {
-          sele: 'nucleic',
-          color: 0x1976d2,
-          aspectRatio: 2.0,
-          radiusScale: 1.5,
-        });
-
-        nglStructureComponent.addRepresentation('base', {
-          sele: 'nucleic',
-          color: 'resname',
-          colorScale: ['#A5D6A7', '#EF9A9A', '#90CAF9', '#FFCC80'],
-        });
-      }
-
-      // Re-highlight active variant
-      this.highlightActiveVariant();
+    isPositionInStructure(aaPosition) {
+      return aaPosition >= STRUCTURE_START && aaPosition <= STRUCTURE_END;
     },
 
-    addDomainColoredRepresentations() {
-      // PDB 2H8R covers residues 90-308 (with gap at 187-230)
-      // Define residue ranges for each domain visible in the structure
-      const domainRanges = [
-        // POU-Specific Domain (POU-S): residues 88-173 - visible as 90-173
-        { sele: 'protein and 90-173', color: 0xab47bc, name: 'POU-S' },
-        // Linker region: 174-186 (between POU-S and gap)
-        { sele: 'protein and 174-186', color: this.linkerColor, name: 'Linker1' },
-        // Note: Gap 187-230 is not resolved in structure
-        // Linker region: 231 (between gap and POU-H)
-        { sele: 'protein and 231', color: this.linkerColor, name: 'Linker2' },
-        // POU-Homeodomain (POU-H): residues 232-305
-        { sele: 'protein and 232-305', color: 0x26a69a, name: 'POU-H' },
-        // After POU-H: 306-308 (small tail visible in structure)
-        { sele: 'protein and 306-308', color: this.linkerColor, name: 'C-tail' },
-      ];
-
-      // Common parameters based on representation type
-      const getRepParams = (sele, color) => {
-        const base = { sele, color };
-        if (this.representation === 'cartoon') {
-          return { ...base, aspectRatio: 5, smoothSheet: true };
-        } else if (this.representation === 'surface') {
-          return { ...base, opacity: 0.7, surfaceType: 'ms' };
-        } else if (this.representation === 'ball+stick') {
-          return { ...base, multipleBond: 'symmetric' };
-        }
-        return base;
-      };
-
-      // Add representation for each domain/region
-      domainRanges.forEach((range) => {
-        const params = getRepParams(range.sele, range.color);
-        nglStructureComponent.addRepresentation(this.representation, params);
-      });
-
-      window.logService.debug('Domain coloring applied', {
-        domains: domainRanges.map((d) => d.name),
-      });
+    getVariantChipColor(variant) {
+      return getPathogenicityColor(variant.classificationVerdict);
     },
 
-    highlightActiveVariant() {
-      if (!nglStructureComponent || !nglStage) return;
-
-      // Remove existing variant representations
-      if (nglVariantRepresentation) {
-        nglStructureComponent.removeRepresentation(nglVariantRepresentation);
-        nglVariantRepresentation = null;
-      }
-      if (nglVariantBallStickRepresentation) {
-        nglStructureComponent.removeRepresentation(nglVariantBallStickRepresentation);
-        nglVariantBallStickRepresentation = null;
-      }
-      if (nglLabelRepresentation) {
-        nglStructureComponent.removeRepresentation(nglLabelRepresentation);
-        nglLabelRepresentation = null;
-      }
-
-      // If no active variant or not in structure, just show the structure
-      if (!this.activeVariant || !this.activeVariantInStructure) {
-        return;
-      }
-
-      const pdbPosition = this.activeVariantAAPosition;
-      const color = this.getVariantColor(this.activeVariant);
-      const selection = `${pdbPosition}`;
-
-      // Add ball+stick representation first (underneath)
-      nglVariantBallStickRepresentation = nglStructureComponent.addRepresentation('ball+stick', {
-        sele: selection,
-        colorScheme: 'element',
-        aspectRatio: 1.5,
-        bondScale: 0.3,
-        bondSpacing: 1.0,
-      });
-
-      // Add semi-transparent spacefill representation on top
-      nglVariantRepresentation = nglStructureComponent.addRepresentation('spacefill', {
-        sele: selection,
-        color: color,
-        opacity: 0.4,
-        scale: 1.2,
-      });
-
-      // Add label using format string for better reliability
-      const variantLabel = this.getVariantLabel(this.activeVariant);
-      nglLabelRepresentation = nglStructureComponent.addRepresentation('label', {
-        sele: `${pdbPosition} and .CA`,
-        labelType: 'format',
-        labelFormat: variantLabel,
-        labelGrouping: 'residue',
-        color: 0x000000,
-        fontFamily: 'sans-serif',
-        fontWeight: 'bold',
-        fontSize: 16,
-        xOffset: 0,
-        yOffset: 3,
-        zOffset: 0,
-        fixedSize: true,
-        attachment: 'middle-center',
-        showBackground: true,
-        backgroundColor: 0xffffff,
-        backgroundOpacity: 0.9,
-        backgroundMargin: 4,
-        borderColor: 0x000000,
-        borderWidth: 1,
-      });
-
-      // Focus on the variant
-      nglStructureComponent.autoView(`${pdbPosition}`, 1000);
+    getVariantLabel(variant) {
+      const pNotation = extractPNotation(variant.protein);
+      return pNotation || variant.simple_id || variant.variant_id;
     },
 
-    calculateActiveVariantDistance() {
-      if (!distanceCalculator || !this.structureLoaded) {
-        this.currentVariantDistanceInfo = null;
-        return;
-      }
-
-      if (!this.activeVariantInStructure) {
-        this.currentVariantDistanceInfo = null;
-        return;
-      }
-
-      const distanceInfo = distanceCalculator.calculateResidueToHelixDistance(
-        this.activeVariantAAPosition,
-        true
-      );
-
-      this.currentVariantDistanceInfo = distanceInfo;
-
-      // Reset distance line when variant changes
-      this.showDistanceLine = false;
-      this.removeDistanceLine();
+    getPathogenicityScoreValue(variant) {
+      return getPathogenicityScore(variant.classificationVerdict);
     },
 
     // Variant selection methods for showAllVariants mode
@@ -896,167 +391,19 @@ export default {
       this.$emit('variant-clicked', variant);
     },
 
-    toggleDistanceLine() {
-      if (this.showDistanceLine) {
-        this.removeDistanceLine();
-        this.showDistanceLine = false;
-      } else {
-        this.addDistanceLine();
-        this.showDistanceLine = true;
-      }
-    },
-
-    addDistanceLine() {
-      if (!nglStage || !this.currentVariantDistanceInfo) return;
-
-      const lineCoords = distanceCalculator.getDistanceLineCoordinates(
-        this.activeVariantAAPosition,
-        true
-      );
-      if (!lineCoords) return;
-
-      // Create distance line using shape
-      const shape = new NGL.Shape('distance-line');
-
-      // Convert hex color string to RGB array
-      const colorHex = lineCoords.color.replace('#', '');
-      const r = parseInt(colorHex.substring(0, 2), 16) / 255;
-      const g = parseInt(colorHex.substring(2, 4), 16) / 255;
-      const b = parseInt(colorHex.substring(4, 6), 16) / 255;
-
-      // Add cylinder for the line
-      shape.addCylinder(
-        [lineCoords.start.x, lineCoords.start.y, lineCoords.start.z],
-        [lineCoords.end.x, lineCoords.end.y, lineCoords.end.z],
-        [r, g, b],
-        0.15
-      );
-
-      // Add label at midpoint
-      const midX = (lineCoords.start.x + lineCoords.end.x) / 2;
-      const midY = (lineCoords.start.y + lineCoords.end.y) / 2;
-      const midZ = (lineCoords.start.z + lineCoords.end.z) / 2;
-
-      shape.addText([midX, midY + 1, midZ], [0, 0, 0], 2, `${lineCoords.distanceFormatted} Å`);
-
-      nglDistanceShape = nglStage.addComponentFromObject(shape);
-      nglDistanceShape.addRepresentation('buffer');
-    },
-
-    removeDistanceLine() {
-      if (nglDistanceShape && nglStage) {
-        nglStage.removeComponent(nglDistanceShape);
-        nglDistanceShape = null;
-      }
-    },
-
-    resetView() {
-      if (nglStage) {
-        nglStage.autoView(1000);
-      }
-    },
-
-    handleResize() {
-      if (nglStage) {
-        nglStage.handleResize();
-      }
-    },
-
-    extractAAPosition(variant) {
-      return extractAAPositionUtil(variant);
-    },
-
-    isPositionInStructure(aaPosition) {
-      return aaPosition >= STRUCTURE_START && aaPosition <= STRUCTURE_END;
-    },
-
-    getVariantColor(variant) {
-      // Convert hex color string to NGL-compatible hex number
-      const hexString = getPathogenicityHexColor(variant.classificationVerdict);
-      return parseInt(hexString.replace('#', ''), 16);
-    },
-
-    getVariantChipColor(variant) {
-      return getPathogenicityColor(variant.classificationVerdict);
-    },
-
-    getVariantLabel(variant) {
-      const pNotation = extractPNotation(variant.protein);
-      return pNotation || variant.simple_id || variant.variant_id;
-    },
-
-    getDistanceAlertType(category) {
-      if (category === 'close') return 'error';
-      if (category === 'medium') return 'warning';
-      return 'success';
-    },
-
-    getDistanceCategoryLabel(category) {
-      if (category === 'close') return 'Close to DNA - likely functional impact';
-      if (category === 'medium') return 'Medium distance';
-      return 'Far from DNA';
-    },
-
-    // Helper methods for filtering and sorting
-    getVariantDistanceCategory(variant) {
-      const info = this.calculateVariantDistance(variant);
-      return info ? info.category : null;
-    },
-
-    getVariantDistanceValue(variant) {
-      const info = this.calculateVariantDistance(variant);
-      return info ? info.distance : Infinity;
-    },
-
-    getVariantDistanceFormatted(variant) {
-      const info = this.calculateVariantDistance(variant);
-      return info ? `${info.distanceFormatted} Å` : null;
-    },
-
-    calculateVariantDistance(variant) {
-      // Use cached value if available
-      if (this.variantDistanceCache[variant.variant_id]) {
-        return this.variantDistanceCache[variant.variant_id];
-      }
-
-      // Calculate distance using the distance calculator
-      if (!distanceCalculator || !nglStructureComponent) return null;
-
-      const position = this.extractAAPosition(variant);
-      if (!position || !this.isPositionInStructure(position)) return null;
-
-      // Use position directly - dnaDistanceCalculator uses auth_seq_id which matches UniProt numbering
-      const info = distanceCalculator.calculateResidueToHelixDistance(position);
-
-      if (info) {
-        this.variantDistanceCache[variant.variant_id] = info;
-      }
-
-      return info;
-    },
-
-    getPathogenicityScoreValue(variant) {
-      return getPathogenicityScore(variant.classificationVerdict);
-    },
-
-    getDistanceChipColor(category) {
-      if (category === 'close') return 'error';
-      if (category === 'medium') return 'warning';
-      return 'success';
-    },
-
     clearFilters() {
       this.filterPathogenicity = null;
       this.filterDistance = null;
     },
 
-    // Calculate distances for all variants when structure loads
-    calculateAllVariantDistances() {
-      if (!distanceCalculator || !nglStructureComponent) return;
+    onReset() {
+      if (this.$refs.viewer) {
+        this.$refs.viewer.resetView();
+      }
+    },
 
-      this.variantsInStructure.forEach((variant) => {
-        this.calculateVariantDistance(variant);
-      });
+    toggleDistanceLine() {
+      this.showDistanceLine = !this.showDistanceLine;
     },
   },
 };
@@ -1065,68 +412,5 @@ export default {
 <style scoped>
 .protein-3d-card {
   margin-bottom: 16px;
-}
-
-.ngl-viewport {
-  width: 100%;
-  height: 500px;
-  border: 1px solid #e0e0e0;
-  border-radius: 4px;
-  background-color: white;
-}
-
-.legend-container {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 4px;
-}
-
-/* Variant panel styles */
-.variant-panel {
-  height: 500px;
-  border: 1px solid #e0e0e0;
-  border-left: none;
-  border-radius: 0 4px 4px 0;
-  background-color: #fafafa;
-  display: flex;
-  flex-direction: column;
-}
-
-.variant-panel-header {
-  padding: 12px;
-  background-color: #f5f5f5;
-  border-bottom: 1px solid #e0e0e0;
-  display: flex;
-  align-items: center;
-}
-
-.variant-panel-controls {
-  padding: 8px 12px;
-  background-color: #f5f5f5;
-  border-bottom: 1px solid #e0e0e0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.sort-select,
-.filter-select {
-  font-size: 12px;
-}
-
-.variant-list {
-  flex: 1;
-  overflow-y: auto;
-  background-color: transparent;
-}
-
-.variant-item-active {
-  background-color: #e3f2fd !important;
-  border-left: 3px solid #1976d2;
-}
-
-.variant-item-hover {
-  background-color: #f5f5f5;
 }
 </style>

--- a/frontend/src/components/gene/protein-structure/DistanceStatsCard.vue
+++ b/frontend/src/components/gene/protein-structure/DistanceStatsCard.vue
@@ -1,0 +1,123 @@
+<!-- Presentational: active-variant distance-to-DNA alert + pathogenicity/domain legend. -->
+<template>
+  <div>
+    <!-- Active Variant Distance Info -->
+    <v-alert
+      v-if="activeVariantDistanceInfo"
+      :type="getDistanceAlertType(activeVariantDistanceInfo.category)"
+      density="compact"
+      variant="tonal"
+      class="mt-3"
+    >
+      <v-icon size="small" class="mr-1"> mdi-ruler </v-icon>
+      <strong>Distance to DNA:</strong>
+      {{ activeVariantDistanceInfo.distanceFormatted }} &Aring; ({{
+        getDistanceCategoryLabel(activeVariantDistanceInfo.category)
+      }})
+      <span class="text-caption ml-2">
+        Closest DNA atom: {{ activeVariantDistanceInfo.closestDNAAtom?.label }}
+      </span>
+    </v-alert>
+
+    <!-- Legend Row -->
+    <v-row class="mt-2">
+      <v-col cols="12">
+        <div class="legend-container">
+          <span class="text-caption text-grey mr-2">Pathogenicity:</span>
+          <v-chip size="x-small" color="red-lighten-1" class="mr-1"> Pathogenic </v-chip>
+          <v-chip size="x-small" color="orange-lighten-1" class="mr-1"> Likely Pathogenic </v-chip>
+          <v-chip size="x-small" color="yellow-darken-1" class="mr-1"> VUS </v-chip>
+          <v-chip size="x-small" color="light-green-lighten-1" class="mr-1"> Likely Benign </v-chip>
+          <v-chip size="x-small" color="grey-lighten-1"> Unknown </v-chip>
+        </div>
+        <!-- Domain Legend (shown when domain coloring is enabled) -->
+        <div v-if="colorByDomain" class="legend-container mt-2">
+          <span class="text-caption text-grey mr-2">Domains:</span>
+          <v-chip size="x-small" style="background-color: #ab47bc; color: white" class="mr-1">
+            POU-S (90-173)
+          </v-chip>
+          <v-chip size="x-small" style="background-color: #26a69a; color: white" class="mr-1">
+            POU-H (232-305)
+          </v-chip>
+          <v-chip size="x-small" style="background-color: #9e9e9e" class="mr-1"> Linker </v-chip>
+          <span class="text-caption text-grey-darken-1 ml-2"> (Gap: 187-230 not resolved) </span>
+        </div>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script>
+// HNF1B protein domains (from UniProt P35680)
+// Note: PDB 2H8R only covers residues 90-308 (with gap 187-230)
+const PROTEIN_DOMAINS = [
+  {
+    name: 'Dimerization',
+    shortName: 'Dim',
+    start: 1,
+    end: 31,
+    color: 0xffb74d, // Orange - not visible in structure (before res 90)
+  },
+  {
+    name: 'POU-Specific',
+    shortName: 'POU-S',
+    start: 88,
+    end: 173,
+    color: 0xab47bc, // Purple - partially visible (90-173)
+  },
+  {
+    name: 'POU-Homeodomain',
+    shortName: 'POU-H',
+    start: 232,
+    end: 305,
+    color: 0x26a69a, // Teal - fully visible
+  },
+  {
+    name: 'Transactivation',
+    shortName: 'TAD',
+    start: 314,
+    end: 557,
+    color: 0x81c784, // Green - not visible in structure (after res 308)
+  },
+];
+
+export default {
+  name: 'DistanceStatsCard',
+  props: {
+    activeVariantDistanceInfo: {
+      type: Object,
+      default: null,
+    },
+    proteinDomains: {
+      type: Array,
+      default: () => PROTEIN_DOMAINS,
+    },
+    colorByDomain: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  methods: {
+    getDistanceAlertType(category) {
+      if (category === 'close') return 'error';
+      if (category === 'medium') return 'warning';
+      return 'success';
+    },
+
+    getDistanceCategoryLabel(category) {
+      if (category === 'close') return 'Close to DNA - likely functional impact';
+      if (category === 'medium') return 'Medium distance';
+      return 'Far from DNA';
+    },
+  },
+};
+</script>
+
+<style scoped>
+.legend-container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+</style>

--- a/frontend/src/components/gene/protein-structure/StructureControls.vue
+++ b/frontend/src/components/gene/protein-structure/StructureControls.vue
@@ -1,0 +1,114 @@
+<!-- Presentational controls for the 3D structure viewer. -->
+<!-- Representation toggle, DNA/domain switches, reset + distance-line buttons. -->
+<template>
+  <v-row class="mt-3">
+    <!-- Representation Controls -->
+    <v-col cols="12" sm="6" md="5">
+      <v-btn-toggle
+        :model-value="representation"
+        mandatory
+        density="compact"
+        color="primary"
+        @update:model-value="$emit('update:representation', $event)"
+      >
+        <v-btn value="cartoon" size="small">
+          <v-icon left size="small"> mdi-waves </v-icon>
+          Cartoon
+        </v-btn>
+        <v-btn value="surface" size="small">
+          <v-icon left size="small"> mdi-circle </v-icon>
+          Surface
+        </v-btn>
+        <v-btn value="ball+stick" size="small">
+          <v-icon left size="small"> mdi-atom </v-icon>
+          Ball+Stick
+        </v-btn>
+      </v-btn-toggle>
+    </v-col>
+
+    <!-- DNA Toggle -->
+    <v-col cols="6" sm="3" md="2">
+      <v-switch
+        :model-value="showDNA"
+        label="Show DNA"
+        density="compact"
+        hide-details
+        color="primary"
+        @update:model-value="$emit('update:showDNA', $event)"
+      />
+    </v-col>
+
+    <!-- Domain Coloring Toggle -->
+    <v-col cols="6" sm="3" md="2">
+      <v-switch
+        :model-value="colorByDomain"
+        label="Domain Colors"
+        density="compact"
+        hide-details
+        color="secondary"
+        @update:model-value="$emit('update:colorByDomain', $event)"
+      />
+    </v-col>
+
+    <!-- Action Buttons -->
+    <v-col cols="12" sm="3" md="4" class="text-right">
+      <v-btn size="small" variant="outlined" class="mr-2" @click="$emit('reset')">
+        <v-icon left size="small"> mdi-refresh </v-icon>
+        Reset View
+      </v-btn>
+      <v-btn
+        v-if="hasActiveVariantInStructure && activeVariantDistanceInfo"
+        size="small"
+        variant="outlined"
+        :color="showDistanceLine ? 'primary' : 'default'"
+        @click="$emit('toggle-distance-line')"
+      >
+        <v-icon left size="small"> mdi-ruler </v-icon>
+        {{ activeVariantDistanceInfo.distanceFormatted }} &Aring;
+      </v-btn>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+export default {
+  name: 'StructureControls',
+  props: {
+    representation: {
+      type: String,
+      default: 'cartoon',
+    },
+    showDNA: {
+      type: Boolean,
+      default: true,
+    },
+    colorByDomain: {
+      type: Boolean,
+      default: false,
+    },
+    showDistanceLine: {
+      type: Boolean,
+      default: false,
+    },
+    structureLoaded: {
+      type: Boolean,
+      default: false,
+    },
+    hasActiveVariantInStructure: {
+      type: Boolean,
+      default: false,
+    },
+    activeVariantDistanceInfo: {
+      type: Object,
+      default: null,
+    },
+  },
+  emits: [
+    'update:representation',
+    'update:showDNA',
+    'update:colorByDomain',
+    'reset',
+    'toggle-distance-line',
+  ],
+};
+</script>

--- a/frontend/src/components/gene/protein-structure/StructureViewer.vue
+++ b/frontend/src/components/gene/protein-structure/StructureViewer.vue
@@ -1,0 +1,568 @@
+<!-- The single NGL.js owner: holds the canvas + ALL imperative NGL logic. -->
+<!-- NGL handles live in module-level vars (kept out of Vue reactivity via markRaw). -->
+<template>
+  <div>
+    <!-- Loading state -->
+    <div v-if="loading" class="text-center py-8">
+      <v-progress-circular indeterminate color="primary" size="48" />
+      <div class="mt-2 text-grey">Loading 3D structure...</div>
+    </div>
+
+    <!-- Error state -->
+    <v-alert v-else-if="error" type="error" density="compact" class="mb-3">
+      <v-icon size="small" class="mr-1"> mdi-alert </v-icon>
+      {{ error }}
+    </v-alert>
+
+    <!-- NGL viewport (always present so the ref exists for initialization). -->
+    <div v-show="!loading && !error" ref="nglContainer" class="ngl-viewport" />
+  </div>
+</template>
+
+<script>
+import * as NGL from 'ngl';
+import { markRaw } from 'vue';
+import {
+  DNADistanceCalculator,
+  STRUCTURE_START,
+  STRUCTURE_END,
+} from '@/utils/dnaDistanceCalculator';
+import { getPathogenicityHexColor } from '@/utils/colors';
+import { extractPNotation } from '@/utils/hgvs';
+import { extractAAPosition as extractAAPositionUtil } from '@/utils/proteinDomains';
+
+// Store NGL objects outside Vue's reactivity system
+// This prevents Vue 3 Proxy conflicts with Three.js internal properties
+let nglStage = null;
+let nglStructureComponent = null;
+let nglVariantRepresentation = null;
+let nglVariantBallStickRepresentation = null;
+let nglLabelRepresentation = null;
+let nglDistanceShape = null;
+let distanceCalculator = null;
+
+// Color for linker regions (between domains)
+const LINKER_COLOR = 0x9e9e9e; // Grey
+
+export default {
+  name: 'StructureViewer',
+  props: {
+    activeVariant: {
+      type: Object,
+      default: null,
+    },
+    activeVariantAAPosition: {
+      type: Number,
+      default: null,
+    },
+    activeVariantInStructure: {
+      type: Boolean,
+      default: false,
+    },
+    representation: {
+      type: String,
+      default: 'cartoon',
+    },
+    showDNA: {
+      type: Boolean,
+      default: true,
+    },
+    colorByDomain: {
+      type: Boolean,
+      default: false,
+    },
+    showDistanceLine: {
+      type: Boolean,
+      default: false,
+    },
+    variants: {
+      type: Array,
+      default: () => [],
+    },
+    showAllVariants: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: [
+    'loading',
+    'loaded',
+    'error',
+    'distance-info',
+    'distances-calculated',
+    'reset-distance-line',
+  ],
+  data() {
+    return {
+      loading: true,
+      error: null,
+      structureLoaded: false,
+    };
+  },
+  watch: {
+    representation() {
+      this.updateRepresentation();
+    },
+    showDNA() {
+      this.updateRepresentation();
+    },
+    colorByDomain() {
+      this.updateRepresentation();
+    },
+    activeVariant() {
+      this.highlightActiveVariant();
+      this.calculateActiveVariantDistance();
+    },
+    showDistanceLine(value) {
+      if (value) {
+        this.addDistanceLine();
+      } else {
+        this.removeDistanceLine();
+      }
+    },
+    showAllVariants() {
+      this.updateRepresentation();
+      if (!this.showAllVariants) {
+        this.highlightActiveVariant();
+      }
+    },
+  },
+  mounted() {
+    this.initializeNGL();
+    window.addEventListener('resize', this.handleResize);
+  },
+  beforeUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+    if (nglStage) {
+      nglStage.dispose();
+      nglStage = null;
+      nglStructureComponent = null;
+      nglVariantRepresentation = null;
+      nglLabelRepresentation = null;
+      nglDistanceShape = null;
+      distanceCalculator = null;
+    }
+  },
+  methods: {
+    setLoading(value) {
+      this.loading = value;
+      this.$emit('loading', value);
+    },
+
+    setError(value) {
+      this.error = value;
+      this.$emit('error', value);
+    },
+
+    async initializeNGL() {
+      try {
+        this.setLoading(true);
+        this.setError(null);
+
+        // Wait for container to be rendered
+        await this.$nextTick();
+
+        if (!this.$refs.nglContainer) {
+          throw new Error('NGL container not found');
+        }
+
+        // Clean up any existing stage first to prevent Timer warnings
+        // This can happen when component remounts (e.g., tab switching)
+        if (nglStage) {
+          nglStage.dispose();
+          nglStage = null;
+          nglStructureComponent = null;
+          nglVariantRepresentation = null;
+          nglLabelRepresentation = null;
+          nglDistanceShape = null;
+          distanceCalculator = null;
+        }
+
+        // Initialize NGL Stage
+        // Temporarily suppress Three.js useLegacyLights deprecation warning
+        // This is a known issue in NGL library (v2.4.0) that hasn't been fixed upstream
+        const originalWarn = console.warn;
+        console.warn = (...args) => {
+          if (args[0]?.includes?.('useLegacyLights')) return;
+          originalWarn.apply(console, args);
+        };
+
+        nglStage = markRaw(
+          new NGL.Stage(this.$refs.nglContainer, {
+            backgroundColor: 'white',
+            quality: 'medium',
+            impostor: true,
+            workerDefault: true,
+          })
+        );
+
+        // Restore original console.warn
+        console.warn = originalWarn;
+
+        // Load PDB structure 2H8R (HNF1B DNA-binding domain)
+        // Served locally to reduce network dependency and improve load times
+        window.logService.info('Loading PDB structure 2H8R');
+        nglStructureComponent = markRaw(
+          await nglStage.loadFile('/2h8r.cif', {
+            defaultRepresentation: false,
+            ext: 'cif',
+          })
+        );
+
+        this.structureLoaded = true;
+        this.$emit('loaded');
+
+        // Initialize distance calculator
+        distanceCalculator = new DNADistanceCalculator();
+        distanceCalculator.initialize(nglStructureComponent);
+
+        // Add initial representation
+        this.updateRepresentation();
+
+        // Highlight active variant if in single variant mode
+        // In showAllVariants mode, user selects from the panel
+        if (!this.showAllVariants) {
+          this.highlightActiveVariant();
+          this.calculateActiveVariantDistance();
+        }
+
+        // Pre-calculate distances for all variants (for filtering/sorting)
+        if (this.showAllVariants) {
+          this.calculateAllVariantDistances();
+        }
+
+        // Handle resize after a short delay
+        setTimeout(() => {
+          if (nglStage) {
+            nglStage.handleResize();
+            nglStage.autoView();
+          }
+        }, 100);
+
+        window.logService.info('3D structure loaded successfully', { pdb: '2H8R' });
+      } catch (err) {
+        window.logService.error('Failed to load 3D structure', { error: err.message });
+        this.setError(`Failed to load 3D structure: ${err.message}`);
+      } finally {
+        this.setLoading(false);
+      }
+    },
+
+    updateRepresentation() {
+      if (!nglStructureComponent) return;
+
+      // Remove existing representations
+      nglStructureComponent.removeAllRepresentations();
+      nglVariantRepresentation = null;
+      nglLabelRepresentation = null;
+      this.removeDistanceLine();
+
+      // Determine coloring approach
+      if (this.colorByDomain) {
+        // Add domain-colored representations
+        this.addDomainColoredRepresentations();
+      } else {
+        // Add protein representation with chain coloring
+        const proteinParams = {
+          sele: 'protein',
+          color: 'chainid',
+        };
+
+        if (this.representation === 'cartoon') {
+          nglStructureComponent.addRepresentation('cartoon', {
+            ...proteinParams,
+            aspectRatio: 5,
+            smoothSheet: true,
+          });
+        } else if (this.representation === 'surface') {
+          nglStructureComponent.addRepresentation('surface', {
+            ...proteinParams,
+            opacity: 0.7,
+            surfaceType: 'ms',
+          });
+        } else if (this.representation === 'ball+stick') {
+          nglStructureComponent.addRepresentation('ball+stick', {
+            ...proteinParams,
+            multipleBond: 'symmetric',
+          });
+        }
+      }
+
+      // Add DNA representation if enabled
+      if (this.showDNA) {
+        nglStructureComponent.addRepresentation('cartoon', {
+          sele: 'nucleic',
+          color: 0x1976d2,
+          aspectRatio: 2.0,
+          radiusScale: 1.5,
+        });
+
+        nglStructureComponent.addRepresentation('base', {
+          sele: 'nucleic',
+          color: 'resname',
+          colorScale: ['#A5D6A7', '#EF9A9A', '#90CAF9', '#FFCC80'],
+        });
+      }
+
+      // Re-highlight active variant
+      this.highlightActiveVariant();
+    },
+
+    addDomainColoredRepresentations() {
+      // PDB 2H8R covers residues 90-308 (with gap at 187-230)
+      // Define residue ranges for each domain visible in the structure
+      const domainRanges = [
+        // POU-Specific Domain (POU-S): residues 88-173 - visible as 90-173
+        { sele: 'protein and 90-173', color: 0xab47bc, name: 'POU-S' },
+        // Linker region: 174-186 (between POU-S and gap)
+        { sele: 'protein and 174-186', color: LINKER_COLOR, name: 'Linker1' },
+        // Note: Gap 187-230 is not resolved in structure
+        // Linker region: 231 (between gap and POU-H)
+        { sele: 'protein and 231', color: LINKER_COLOR, name: 'Linker2' },
+        // POU-Homeodomain (POU-H): residues 232-305
+        { sele: 'protein and 232-305', color: 0x26a69a, name: 'POU-H' },
+        // After POU-H: 306-308 (small tail visible in structure)
+        { sele: 'protein and 306-308', color: LINKER_COLOR, name: 'C-tail' },
+      ];
+
+      // Common parameters based on representation type
+      const getRepParams = (sele, color) => {
+        const base = { sele, color };
+        if (this.representation === 'cartoon') {
+          return { ...base, aspectRatio: 5, smoothSheet: true };
+        } else if (this.representation === 'surface') {
+          return { ...base, opacity: 0.7, surfaceType: 'ms' };
+        } else if (this.representation === 'ball+stick') {
+          return { ...base, multipleBond: 'symmetric' };
+        }
+        return base;
+      };
+
+      // Add representation for each domain/region
+      domainRanges.forEach((range) => {
+        const params = getRepParams(range.sele, range.color);
+        nglStructureComponent.addRepresentation(this.representation, params);
+      });
+
+      window.logService.debug('Domain coloring applied', {
+        domains: domainRanges.map((d) => d.name),
+      });
+    },
+
+    highlightActiveVariant() {
+      if (!nglStructureComponent || !nglStage) return;
+
+      // Remove existing variant representations
+      if (nglVariantRepresentation) {
+        nglStructureComponent.removeRepresentation(nglVariantRepresentation);
+        nglVariantRepresentation = null;
+      }
+      if (nglVariantBallStickRepresentation) {
+        nglStructureComponent.removeRepresentation(nglVariantBallStickRepresentation);
+        nglVariantBallStickRepresentation = null;
+      }
+      if (nglLabelRepresentation) {
+        nglStructureComponent.removeRepresentation(nglLabelRepresentation);
+        nglLabelRepresentation = null;
+      }
+
+      // If no active variant or not in structure, just show the structure
+      if (!this.activeVariant || !this.activeVariantInStructure) {
+        return;
+      }
+
+      const pdbPosition = this.activeVariantAAPosition;
+      const color = this.getVariantColor(this.activeVariant);
+      const selection = `${pdbPosition}`;
+
+      // Add ball+stick representation first (underneath)
+      nglVariantBallStickRepresentation = nglStructureComponent.addRepresentation('ball+stick', {
+        sele: selection,
+        colorScheme: 'element',
+        aspectRatio: 1.5,
+        bondScale: 0.3,
+        bondSpacing: 1.0,
+      });
+
+      // Add semi-transparent spacefill representation on top
+      nglVariantRepresentation = nglStructureComponent.addRepresentation('spacefill', {
+        sele: selection,
+        color: color,
+        opacity: 0.4,
+        scale: 1.2,
+      });
+
+      // Add label using format string for better reliability
+      const variantLabel = this.getVariantLabel(this.activeVariant);
+      nglLabelRepresentation = nglStructureComponent.addRepresentation('label', {
+        sele: `${pdbPosition} and .CA`,
+        labelType: 'format',
+        labelFormat: variantLabel,
+        labelGrouping: 'residue',
+        color: 0x000000,
+        fontFamily: 'sans-serif',
+        fontWeight: 'bold',
+        fontSize: 16,
+        xOffset: 0,
+        yOffset: 3,
+        zOffset: 0,
+        fixedSize: true,
+        attachment: 'middle-center',
+        showBackground: true,
+        backgroundColor: 0xffffff,
+        backgroundOpacity: 0.9,
+        backgroundMargin: 4,
+        borderColor: 0x000000,
+        borderWidth: 1,
+      });
+
+      // Focus on the variant
+      nglStructureComponent.autoView(`${pdbPosition}`, 1000);
+    },
+
+    calculateActiveVariantDistance() {
+      if (!distanceCalculator || !this.structureLoaded) {
+        this.$emit('distance-info', null);
+        return;
+      }
+
+      if (!this.activeVariantInStructure) {
+        this.$emit('distance-info', null);
+        return;
+      }
+
+      const distanceInfo = distanceCalculator.calculateResidueToHelixDistance(
+        this.activeVariantAAPosition,
+        true
+      );
+
+      this.$emit('distance-info', distanceInfo);
+
+      // Reset distance line when variant changes
+      this.$emit('reset-distance-line');
+      this.removeDistanceLine();
+    },
+
+    toggleDistanceLine() {
+      if (this.showDistanceLine) {
+        this.removeDistanceLine();
+      } else {
+        this.addDistanceLine();
+      }
+    },
+
+    addDistanceLine() {
+      if (!nglStage || !distanceCalculator) return;
+
+      const lineCoords = distanceCalculator.getDistanceLineCoordinates(
+        this.activeVariantAAPosition,
+        true
+      );
+      if (!lineCoords) return;
+
+      // Create distance line using shape
+      const shape = new NGL.Shape('distance-line');
+
+      // Convert hex color string to RGB array
+      const colorHex = lineCoords.color.replace('#', '');
+      const r = parseInt(colorHex.substring(0, 2), 16) / 255;
+      const g = parseInt(colorHex.substring(2, 4), 16) / 255;
+      const b = parseInt(colorHex.substring(4, 6), 16) / 255;
+
+      // Add cylinder for the line
+      shape.addCylinder(
+        [lineCoords.start.x, lineCoords.start.y, lineCoords.start.z],
+        [lineCoords.end.x, lineCoords.end.y, lineCoords.end.z],
+        [r, g, b],
+        0.15
+      );
+
+      // Add label at midpoint
+      const midX = (lineCoords.start.x + lineCoords.end.x) / 2;
+      const midY = (lineCoords.start.y + lineCoords.end.y) / 2;
+      const midZ = (lineCoords.start.z + lineCoords.end.z) / 2;
+
+      shape.addText([midX, midY + 1, midZ], [0, 0, 0], 2, `${lineCoords.distanceFormatted} Å`);
+
+      nglDistanceShape = nglStage.addComponentFromObject(shape);
+      nglDistanceShape.addRepresentation('buffer');
+    },
+
+    removeDistanceLine() {
+      if (nglDistanceShape && nglStage) {
+        nglStage.removeComponent(nglDistanceShape);
+        nglDistanceShape = null;
+      }
+    },
+
+    resetView() {
+      if (nglStage) {
+        nglStage.autoView(1000);
+      }
+    },
+
+    handleResize() {
+      if (nglStage) {
+        nglStage.handleResize();
+      }
+    },
+
+    extractAAPosition(variant) {
+      return extractAAPositionUtil(variant);
+    },
+
+    isPositionInStructure(aaPosition) {
+      return aaPosition >= STRUCTURE_START && aaPosition <= STRUCTURE_END;
+    },
+
+    getVariantColor(variant) {
+      // Convert hex color string to NGL-compatible hex number
+      const hexString = getPathogenicityHexColor(variant.classificationVerdict);
+      return parseInt(hexString.replace('#', ''), 16);
+    },
+
+    getVariantLabel(variant) {
+      const pNotation = extractPNotation(variant.protein);
+      return pNotation || variant.simple_id || variant.variant_id;
+    },
+
+    calculateVariantDistance(variant) {
+      // Calculate distance using the distance calculator
+      if (!distanceCalculator || !nglStructureComponent) return null;
+
+      const position = this.extractAAPosition(variant);
+      if (!position || !this.isPositionInStructure(position)) return null;
+
+      // Use position directly - dnaDistanceCalculator uses auth_seq_id which matches UniProt numbering
+      return distanceCalculator.calculateResidueToHelixDistance(position);
+    },
+
+    // Calculate distances for all variants when structure loads, emitting a cache up.
+    calculateAllVariantDistances() {
+      if (!distanceCalculator || !nglStructureComponent) return;
+
+      const cache = {};
+      this.variants.forEach((variant) => {
+        const position = this.extractAAPosition(variant);
+        if (!position || !this.isPositionInStructure(position)) return;
+        const info = this.calculateVariantDistance(variant);
+        if (info) {
+          cache[variant.variant_id] = info;
+        }
+      });
+
+      this.$emit('distances-calculated', cache);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.ngl-viewport {
+  width: 100%;
+  height: 500px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  background-color: white;
+}
+</style>

--- a/frontend/src/components/gene/protein-structure/VariantPanel.vue
+++ b/frontend/src/components/gene/protein-structure/VariantPanel.vue
@@ -1,0 +1,259 @@
+<!-- Presentational variant list panel (all-variants mode). -->
+<!-- Filter/sort selects + variant v-list + empty state. -->
+<!-- Distances are resolved by the parent and attached to each variant as _distanceInfo. -->
+<template>
+  <div class="variant-panel">
+    <div class="variant-panel-header">
+      <span class="text-subtitle-2">Variants in Structure</span>
+      <v-chip size="x-small" color="primary" class="ml-2">
+        {{ variants.length }}
+        <template v-if="variants.length !== totalInStructure"> / {{ totalInStructure }} </template>
+      </v-chip>
+    </div>
+
+    <!-- Filter and Sort Controls -->
+    <div class="variant-panel-controls">
+      <!-- Sort Control -->
+      <v-select
+        :model-value="sortBy"
+        :items="sortOptions"
+        label="Sort by"
+        density="compact"
+        hide-details
+        variant="outlined"
+        class="sort-select"
+        @update:model-value="$emit('update:sortBy', $event)"
+      />
+
+      <!-- Pathogenicity Filter -->
+      <v-select
+        :model-value="filterPathogenicity"
+        :items="pathogenicityOptions"
+        label="Pathogenicity"
+        density="compact"
+        hide-details
+        variant="outlined"
+        clearable
+        class="filter-select"
+        @update:model-value="$emit('update:filterPathogenicity', $event)"
+      />
+
+      <!-- Distance Filter -->
+      <v-select
+        :model-value="filterDistance"
+        :items="distanceOptions"
+        label="DNA Distance"
+        density="compact"
+        hide-details
+        variant="outlined"
+        clearable
+        class="filter-select"
+        @update:model-value="$emit('update:filterDistance', $event)"
+      />
+    </div>
+
+    <v-list density="compact" class="variant-list">
+      <v-list-item
+        v-for="variant in variants"
+        :key="variant.variant_id"
+        :class="{
+          'variant-item-active': selectedVariantId === variant.variant_id,
+          'variant-item-hover': hoveredVariantId === variant.variant_id,
+        }"
+        @click="$emit('select', variant)"
+        @mouseenter="$emit('hover', variant)"
+        @mouseleave="$emit('unhover')"
+      >
+        <template #prepend>
+          <v-avatar :color="getVariantChipColor(variant)" size="28">
+            <span class="text-white text-caption">{{ extractAAPosition(variant) }}</span>
+          </v-avatar>
+        </template>
+        <v-list-item-title class="text-body-2">
+          {{ getVariantLabel(variant) }}
+        </v-list-item-title>
+        <v-list-item-subtitle class="text-caption d-flex align-center">
+          <span>{{ variant.classificationVerdict || 'Unknown' }}</span>
+          <v-chip
+            v-if="getVariantDistanceCategory(variant)"
+            size="x-small"
+            :color="getDistanceChipColor(getVariantDistanceCategory(variant))"
+            class="ml-2"
+          >
+            {{ getVariantDistanceFormatted(variant) }}
+          </v-chip>
+        </v-list-item-subtitle>
+      </v-list-item>
+    </v-list>
+    <div v-if="variants.length === 0" class="text-center py-4 text-grey">
+      <v-icon size="large" color="grey-lighten-1">mdi-alert-circle-outline</v-icon>
+      <div class="text-caption mt-1">
+        {{
+          totalInStructure === 0 ? 'No variants in structure range' : 'No variants match filters'
+        }}
+      </div>
+      <v-btn
+        v-if="totalInStructure > 0 && (filterPathogenicity || filterDistance)"
+        size="x-small"
+        variant="text"
+        color="primary"
+        class="mt-2"
+        @click="$emit('clear-filters')"
+      >
+        Clear Filters
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<script>
+import { extractPNotation } from '@/utils/hgvs';
+import { getPathogenicityColor } from '@/utils/colors';
+import { extractAAPosition as extractAAPositionUtil } from '@/utils/proteinDomains';
+
+export default {
+  name: 'VariantPanel',
+  props: {
+    // Already filtered + sorted variants, each carrying a resolved `_distanceInfo`.
+    variants: {
+      type: Array,
+      default: () => [],
+    },
+    // Total count of variants in the structure range (pre-filter), for the "n / m" chip.
+    totalInStructure: {
+      type: Number,
+      default: 0,
+    },
+    selectedVariantId: {
+      type: String,
+      default: null,
+    },
+    hoveredVariantId: {
+      type: String,
+      default: null,
+    },
+    sortBy: {
+      type: String,
+      default: 'position',
+    },
+    filterPathogenicity: {
+      type: String,
+      default: null,
+    },
+    filterDistance: {
+      type: String,
+      default: null,
+    },
+  },
+  emits: [
+    'select',
+    'hover',
+    'unhover',
+    'clear-filters',
+    'update:sortBy',
+    'update:filterPathogenicity',
+    'update:filterDistance',
+  ],
+  data() {
+    return {
+      sortOptions: [
+        { title: 'Position', value: 'position' },
+        { title: 'Distance to DNA', value: 'distance' },
+        { title: 'Pathogenicity', value: 'pathogenicity' },
+      ],
+      pathogenicityOptions: [
+        { title: 'Pathogenic', value: 'PATHOGENIC' },
+        { title: 'Likely Pathogenic', value: 'LIKELY_PATHOGENIC' },
+        { title: 'VUS', value: 'VUS' },
+        { title: 'Likely Benign', value: 'LIKELY_BENIGN' },
+        { title: 'Benign', value: 'BENIGN' },
+      ],
+      distanceOptions: [
+        { title: 'Close (<5 Å)', value: 'close' },
+        { title: 'Medium (5-10 Å)', value: 'medium' },
+        { title: 'Far (>10 Å)', value: 'far' },
+      ],
+    };
+  },
+  methods: {
+    extractAAPosition(variant) {
+      return extractAAPositionUtil(variant);
+    },
+
+    getVariantChipColor(variant) {
+      return getPathogenicityColor(variant.classificationVerdict);
+    },
+
+    getVariantLabel(variant) {
+      const pNotation = extractPNotation(variant.protein);
+      return pNotation || variant.simple_id || variant.variant_id;
+    },
+
+    getVariantDistanceCategory(variant) {
+      const info = variant._distanceInfo;
+      return info ? info.category : null;
+    },
+
+    getVariantDistanceFormatted(variant) {
+      const info = variant._distanceInfo;
+      return info ? `${info.distanceFormatted} Å` : null;
+    },
+
+    getDistanceChipColor(category) {
+      if (category === 'close') return 'error';
+      if (category === 'medium') return 'warning';
+      return 'success';
+    },
+  },
+};
+</script>
+
+<style scoped>
+/* Variant panel styles */
+.variant-panel {
+  height: 500px;
+  border: 1px solid #e0e0e0;
+  border-left: none;
+  border-radius: 0 4px 4px 0;
+  background-color: #fafafa;
+  display: flex;
+  flex-direction: column;
+}
+
+.variant-panel-header {
+  padding: 12px;
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #e0e0e0;
+  display: flex;
+  align-items: center;
+}
+
+.variant-panel-controls {
+  padding: 8px 12px;
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #e0e0e0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sort-select,
+.filter-select {
+  font-size: 12px;
+}
+
+.variant-list {
+  flex: 1;
+  overflow-y: auto;
+  background-color: transparent;
+}
+
+.variant-item-active {
+  background-color: #e3f2fd !important;
+  border-left: 3px solid #1976d2;
+}
+
+.variant-item-hover {
+  background-color: #f5f5f5;
+}
+</style>

--- a/frontend/tests/unit/components/gene/protein-structure/DistanceStatsCard.spec.js
+++ b/frontend/tests/unit/components/gene/protein-structure/DistanceStatsCard.spec.js
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for DistanceStatsCard.vue.
+ *
+ * Presentational sub-component of ProteinStructure3D. Renders the
+ * active-variant distance-to-DNA alert and the pathogenicity/domain
+ * legend. No NGL involvement — pure props.
+ */
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import DistanceStatsCard from '@/components/gene/protein-structure/DistanceStatsCard.vue';
+
+function mountCard(props = {}) {
+  const vuetify = createVuetify({ components, directives });
+  return mount(DistanceStatsCard, {
+    props: {
+      activeVariantDistanceInfo: null,
+      colorByDomain: false,
+      ...props,
+    },
+    global: { plugins: [vuetify] },
+  });
+}
+
+describe('DistanceStatsCard', () => {
+  it('always renders the pathogenicity legend', () => {
+    const wrapper = mountCard();
+    expect(wrapper.text()).toContain('Pathogenicity:');
+    expect(wrapper.text()).toContain('Pathogenic');
+    expect(wrapper.text()).toContain('VUS');
+  });
+
+  it('does not render the distance alert when there is no distance info', () => {
+    const wrapper = mountCard({ activeVariantDistanceInfo: null });
+    expect(wrapper.text()).not.toContain('Distance to DNA:');
+  });
+
+  it('renders the distance alert with the formatted distance and category label', () => {
+    const wrapper = mountCard({
+      activeVariantDistanceInfo: {
+        distanceFormatted: '3.5',
+        category: 'close',
+        closestDNAAtom: { label: 'DG12.N7' },
+      },
+    });
+    expect(wrapper.text()).toContain('Distance to DNA:');
+    expect(wrapper.text()).toContain('3.5');
+    expect(wrapper.text()).toContain('Close to DNA - likely functional impact');
+    expect(wrapper.text()).toContain('DG12.N7');
+  });
+
+  it('hides the domain legend unless colorByDomain is true', () => {
+    const hidden = mountCard({ colorByDomain: false });
+    expect(hidden.text()).not.toContain('Domains:');
+
+    const shown = mountCard({ colorByDomain: true });
+    expect(shown.text()).toContain('Domains:');
+    expect(shown.text()).toContain('POU-S (90-173)');
+    expect(shown.text()).toContain('POU-H (232-305)');
+  });
+
+  it('maps distance category to the correct alert type', () => {
+    const vm = mountCard().vm;
+    expect(vm.getDistanceAlertType('close')).toBe('error');
+    expect(vm.getDistanceAlertType('medium')).toBe('warning');
+    expect(vm.getDistanceAlertType('far')).toBe('success');
+  });
+});

--- a/frontend/tests/unit/components/gene/protein-structure/StructureControls.spec.js
+++ b/frontend/tests/unit/components/gene/protein-structure/StructureControls.spec.js
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for StructureControls.vue.
+ *
+ * Presentational sub-component of ProteinStructure3D. Renders the
+ * representation toggle, DNA/domain switches, reset button, and the
+ * optional distance-line button. No NGL involvement — pure props/emits.
+ */
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import StructureControls from '@/components/gene/protein-structure/StructureControls.vue';
+
+function mountControls(props = {}) {
+  const vuetify = createVuetify({ components, directives });
+  return mount(StructureControls, {
+    props: {
+      representation: 'cartoon',
+      showDNA: true,
+      colorByDomain: false,
+      showDistanceLine: false,
+      structureLoaded: true,
+      hasActiveVariantInStructure: false,
+      activeVariantDistanceInfo: null,
+      ...props,
+    },
+    global: { plugins: [vuetify] },
+  });
+}
+
+describe('StructureControls', () => {
+  it('renders the representation toggle with three options', () => {
+    const wrapper = mountControls();
+    expect(wrapper.text()).toContain('Cartoon');
+    expect(wrapper.text()).toContain('Surface');
+    expect(wrapper.text()).toContain('Ball+Stick');
+  });
+
+  it('emits reset when the Reset View button is clicked', async () => {
+    const wrapper = mountControls();
+    const resetBtn = wrapper.findAll('button').find((b) => b.text().includes('Reset View'));
+    expect(resetBtn).toBeTruthy();
+    await resetBtn.trigger('click');
+    expect(wrapper.emitted('reset')).toBeTruthy();
+  });
+
+  it('hides the distance-line button when no active variant distance info', () => {
+    const wrapper = mountControls({
+      hasActiveVariantInStructure: false,
+      activeVariantDistanceInfo: null,
+    });
+    expect(wrapper.text()).not.toContain('mdi-ruler');
+    // No button should carry the distance label.
+    const distBtn = wrapper.findAll('button').find((b) => b.text().includes('Å'));
+    expect(distBtn).toBeUndefined();
+  });
+
+  it('shows the distance-line button and emits toggle-distance-line on click', async () => {
+    const wrapper = mountControls({
+      hasActiveVariantInStructure: true,
+      activeVariantDistanceInfo: { distanceFormatted: '4.2', category: 'close' },
+    });
+    const distBtn = wrapper.findAll('button').find((b) => b.text().includes('4.2'));
+    expect(distBtn).toBeTruthy();
+    await distBtn.trigger('click');
+    expect(wrapper.emitted('toggle-distance-line')).toBeTruthy();
+  });
+});

--- a/frontend/tests/unit/components/gene/protein-structure/VariantPanel.spec.js
+++ b/frontend/tests/unit/components/gene/protein-structure/VariantPanel.spec.js
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for VariantPanel.vue.
+ *
+ * Presentational sub-component of ProteinStructure3D (all-variants mode).
+ * Renders the sort/filter selects, the variant list, and the empty state.
+ * Distances are pre-resolved by the parent and attached as `_distanceInfo`,
+ * so this component needs no NGL involvement — pure props/emits.
+ */
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import VariantPanel from '@/components/gene/protein-structure/VariantPanel.vue';
+
+const SAMPLE_VARIANTS = [
+  {
+    variant_id: 'V1',
+    protein: 'p.Arg100Gly',
+    classificationVerdict: 'Pathogenic',
+    _distanceInfo: { category: 'close', distance: 3.1, distanceFormatted: '3.1' },
+  },
+  {
+    variant_id: 'V2',
+    protein: 'p.Lys200Asn',
+    classificationVerdict: 'VUS',
+    _distanceInfo: null,
+  },
+];
+
+function mountPanel(props = {}) {
+  const vuetify = createVuetify({ components, directives });
+  return mount(VariantPanel, {
+    props: {
+      variants: SAMPLE_VARIANTS,
+      totalInStructure: 2,
+      selectedVariantId: null,
+      hoveredVariantId: null,
+      sortBy: 'position',
+      filterPathogenicity: null,
+      filterDistance: null,
+      ...props,
+    },
+    global: { plugins: [vuetify] },
+  });
+}
+
+describe('VariantPanel', () => {
+  it('renders a list item for each variant', () => {
+    const wrapper = mountPanel();
+    const items = wrapper.findAll('.v-list-item');
+    expect(items.length).toBe(2);
+    expect(wrapper.text()).toContain('p.Arg100Gly');
+    expect(wrapper.text()).toContain('p.Lys200Asn');
+  });
+
+  it('shows the resolved distance chip for variants that have distance info', () => {
+    const wrapper = mountPanel();
+    expect(wrapper.text()).toContain('3.1 Å');
+  });
+
+  it('emits select with the variant when a list item is clicked', async () => {
+    const wrapper = mountPanel();
+    await wrapper.findAll('.v-list-item')[0].trigger('click');
+    expect(wrapper.emitted('select')).toBeTruthy();
+    expect(wrapper.emitted('select')[0][0].variant_id).toBe('V1');
+  });
+
+  it('emits hover and unhover on mouse enter/leave', async () => {
+    const wrapper = mountPanel();
+    const item = wrapper.findAll('.v-list-item')[1];
+    await item.trigger('mouseenter');
+    await item.trigger('mouseleave');
+    expect(wrapper.emitted('hover')[0][0].variant_id).toBe('V2');
+    expect(wrapper.emitted('unhover')).toBeTruthy();
+  });
+
+  it('renders the empty state and a Clear Filters button when filters hide all variants', async () => {
+    const wrapper = mountPanel({
+      variants: [],
+      totalInStructure: 2,
+      filterPathogenicity: 'PATHOGENIC',
+    });
+    expect(wrapper.text()).toContain('No variants match filters');
+    const clearBtn = wrapper.findAll('button').find((b) => b.text().includes('Clear Filters'));
+    expect(clearBtn).toBeTruthy();
+    await clearBtn.trigger('click');
+    expect(wrapper.emitted('clear-filters')).toBeTruthy();
+  });
+
+  it('renders the no-variants-in-range empty state without a Clear Filters button', () => {
+    const wrapper = mountPanel({ variants: [], totalInStructure: 0 });
+    expect(wrapper.text()).toContain('No variants in structure range');
+    const clearBtn = wrapper.findAll('button').find((b) => b.text().includes('Clear Filters'));
+    expect(clearBtn).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #133.

`ProteinStructure3D.vue` was **1,132 lines** (>2× the 500-line guideline) with NGL lifecycle, variant highlighting, DNA-distance calc, controls, the variant panel, and distance stats all tangled together. This splits it into a slim smart container + four single-responsibility children, **preserving the exact public contract and all behavior**.

## Structure (parent 1,132 → **416** lines)

| File | Lines | Responsibility |
|---|---|---|
| `ProteinStructure3D.vue` | 416 | smart container: props/emits, UI state, computed, orchestration |
| `protein-structure/StructureViewer.vue` | ~568 | **single NGL owner** — canvas + all imperative NGL logic (stage, representations, distance calc, `markRaw`, `/2h8r.cif`, `useLegacyLights` suppression) |
| `protein-structure/StructureControls.vue` | ~114 | representation toggle, DNA/domain switches, reset + distance-line buttons |
| `protein-structure/VariantPanel.vue` | ~259 | filter/sort selects + variant list + empty state (all-variants) |
| `protein-structure/DistanceStatsCard.vue` | ~123 | distance-to-DNA alert + legend |

Wiring is pure **props-down / emits-up** (house pattern) — no provide/inject, no store. Per-variant DNA distances are computed once by the viewer and emitted up, so the panel/stats stay presentational.

## Contract preserved
- Parent public API unchanged: `props` = `variants` / `currentVariantId` / `showAllVariants`; `emits` = `['variant-clicked']`.
- Call sites untouched: `PageVariant.vue`, `Home.vue`.
- The existing characterization unit test (`ProteinStructure3D.spec.js`) stays green.

## Deviation from the issue
Dropped the proposed `StructureTooltip.vue` — there is **no hover tooltip** in the current code (the only `<v-tooltip>` is the static "View in RCSB PDB" link), so it would be net-new feature work, not extraction.

## Verification
- **Unit:** 479 tests pass — characterization spec + 16 new NGL-free child specs. `eslint`, `prettier --check`, `vite build` all clean.
- **Runtime (Playwright, against live API):** verified **both modes** with **zero console errors**:
  - *All-variants* (Home → 3D Structure): panel populated (107 variants) with DNA distances, variant select → highlight, distance-line toggle, Reset View, Ball+Stick, Domain Colors.
  - *Single-variant* (variant detail → 3D Structure): active variant chip, DistanceStatsCard with real NGL-computed distance ("10.85 Å, closest DNA atom DC:15.OP1"), controls, distance-line toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)