### PR TITLE
fix(docker): externally manage prod data volumes + internal network

### DIFF
--- a/docker/docker-compose.npm.yml
+++ b/docker/docker-compose.npm.yml
@@ -259,12 +259,25 @@ networks:
   npm_proxy_network:
     external: true
     name: ${NPM_SHARED_NETWORK_NAME:-npm_default}
+  # Production: the internal network is externally managed so compose never
+  # re-owns it under a shifting project name (silences the "network created for
+  # project ..." provenance warning). Fresh deploy: docker network create hnf1b_internal
+  hnf1b_internal:
+    external: true
+    name: hnf1b_internal
 
 # ============================================
-# Volumes (inherit from base)
+# Volumes (externally managed in production)
 # ============================================
+# The live Postgres/Redis data volumes are declared external so that a compose
+# project-name change (or an accidental `down -v`) can NEVER destroy them, and
+# so the stale-project-label provenance warning is silenced. They are created
+# once and persist independently of the compose project.
+# Fresh deploy: docker volume create hnf1b_postgres_data hnf1b_redis_data
 volumes:
   hnf1b_postgres_data:
+    external: true
     name: hnf1b_postgres_data
   hnf1b_redis_data:
+    external: true
     name: hnf1b_redis_data


### PR DESCRIPTION
## Problem
Production rebuilds log warnings:
```
volume "hnf1b_postgres_data" already exists but was created for project "hnf1b-db-npm" (expected "hnf1b-db")
volume "hnf1b_redis_data"   already exists but was created for project "hnf1b-db-npm" (expected "hnf1b-db")
network "hnf1b_internal"    exists but was not created for project "hnf1b-db"
```
The volumes/network use explicit `name:`, so data is **never actually orphaned** — but they carry a stale `com.docker.compose.project=hnf1b-db-npm` label from an earlier project name, which Docker can't rewrite in place, so the warning recurs on every deploy.

## Fix
Declare the data volumes and internal network `external: true` in the **production overlay** (`docker-compose.npm.yml`). That overlay is already external-network dependent (`npm_proxy_network`) and never runs in CI/local, so this is consistent with its design.

Benefits:
- Silences the stale-label provenance warnings.
- **Production Postgres/Redis data is now externally managed** → a compose project-name change or an accidental `down -v` can never destroy it.

Local dev (base `docker-compose.yml` only) is **unaffected** — volumes are still auto-created.

## Fresh-deploy note (documented in-file)
```
docker volume create hnf1b_postgres_data hnf1b_redis_data
docker network create hnf1b_internal
```

Validated with `docker compose -f docker-compose.yml -f docker-compose.npm.yml config --no-interpolate` → renders all three as external, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)