### PR TITLE
feat(viz): variant-type filtering + colour-by toggle for protein & gene plots

### DIFF
--- a/frontend/src/components/gene/HNF1BGeneVisualization.vue
+++ b/frontend/src/components/gene/HNF1BGeneVisualization.vue
@@ -85,7 +85,23 @@
         </v-col>
       </v-row>
 
-      <!-- Legend -->
+      <!-- Variant filter + colour-by controls (all-variants view only) -->
+      <v-row v-if="!currentVariantId" class="mb-1">
+        <v-col cols="12">
+          <VariantPlotControls v-model="filterState" :variants="variantsWithPositions" />
+          <div
+            v-if="displayVariants.length !== variantsWithPositions.length"
+            class="filter-indicator mt-1"
+          >
+            <v-icon size="small" color="primary" class="mr-1"> mdi-filter </v-icon>
+            <span class="text-body-2">
+              Showing {{ displayVariants.length }} of {{ variantsWithPositions.length }} variants
+            </span>
+          </div>
+        </v-col>
+      </v-row>
+
+      <!-- Legend (glyph shapes) -->
       <v-row class="mb-2">
         <v-col cols="12">
           <div class="legend-container">
@@ -97,17 +113,9 @@
               <v-icon left size="small"> mdi-minus </v-icon>
               Intron
             </v-chip>
-            <v-chip size="small" color="red-lighten-3">
+            <v-chip size="small" variant="tonal">
               <v-icon left size="small"> mdi-circle </v-icon>
-              Pathogenic
-            </v-chip>
-            <v-chip size="small" color="orange-lighten-3">
-              <v-icon left size="small"> mdi-circle </v-icon>
-              Likely Pathogenic
-            </v-chip>
-            <v-chip size="small" color="yellow-darken-1">
-              <v-icon left size="small"> mdi-circle </v-icon>
-              VUS
+              SNV
             </v-chip>
             <v-chip v-if="indelVariants.length > 0" size="small" color="deep-orange">
               <v-icon left size="small"> mdi-rectangle-outline </v-icon>
@@ -665,10 +673,16 @@ import {
   getIndelDetails as getIndelDetailsUtil,
 } from '@/utils/geneVisualization';
 import { calculateTooltipPosition } from '@/utils/tooltip';
-import { getPathogenicityHexColor } from '@/utils/colors';
+import {
+  createDefaultFilterState,
+  getVariantColorByMode,
+  isVariantVisibleByFilters,
+} from '@/utils/variantFilters';
+import VariantPlotControls from '@/components/gene/VariantPlotControls.vue';
 
 export default {
   name: 'HNF1BGeneVisualization',
+  components: { VariantPlotControls },
   props: {
     variants: {
       type: Array,
@@ -700,6 +714,8 @@ export default {
       zoomLevel: 1,
       zoomedExon: null,
       viewMode: 'gene',
+      // Filter state: pathogenicity + consequence multi-select + colour-by mode
+      filterState: createDefaultFilterState(),
       loading: false,
       apiError: null,
       chr17q12Region: { ...CHR17Q12_REGION_DEFAULT },
@@ -805,14 +821,25 @@ export default {
         }))
         .filter((v) => v.position !== null);
     },
+    // Position-valid variants after applying the pathogenicity + consequence
+    // filters. On a single-variant detail view (currentVariantId) the filters
+    // are bypassed so the focused variant is never hidden.
+    displayVariants() {
+      if (this.currentVariantId) {
+        return this.variantsWithPositions;
+      }
+      return this.variantsWithPositions.filter((v) =>
+        isVariantVisibleByFilters(v, this.filterState)
+      );
+    },
     snvVariants() {
-      return this.variantsWithPositions.filter((v) => !v.isCNV && !v.isIndel && !v.isSpliceVariant);
+      return this.displayVariants.filter((v) => !v.isCNV && !v.isIndel && !v.isSpliceVariant);
     },
     spliceVariants() {
-      return this.variantsWithPositions.filter((v) => v.isSpliceVariant);
+      return this.displayVariants.filter((v) => v.isSpliceVariant);
     },
     indelVariants() {
-      return this.variantsWithPositions
+      return this.displayVariants
         .filter((v) => v.isIndel)
         .map((v) => {
           const details = this.getIndelDetails(v);
@@ -826,7 +853,7 @@ export default {
         .filter((v) => v.start && v.end);
     },
     cnvVariants() {
-      const cnvsFromArray = this.variantsWithPositions
+      const cnvsFromArray = this.displayVariants
         .filter((v) => v.isCNV)
         .map((v) => {
           const cnvDetails = this.getCNVDetails(v);
@@ -1112,10 +1139,21 @@ export default {
       return getExonColorUtil(exon);
     },
     getVariantColor(variant) {
-      return getPathogenicityHexColor(variant.classificationVerdict);
+      // Mode-aware fill: ACMG classification ⇄ molecular-consequence (type).
+      return getVariantColorByMode(variant, this.filterState);
     },
     getCNVColor(cnv) {
-      return getCNVColorUtil(cnv.cnvType);
+      // In "Type" colour mode, fall back to the structural loss/gain palette
+      // when a CNV record lacks an explicit molecular_consequence so the bar is
+      // never an ambiguous grey; otherwise defer to the shared mode-aware logic.
+      if (
+        this.filterState.coloringMode === 'consequence' &&
+        !cnv.molecular_consequence &&
+        cnv.cnvType
+      ) {
+        return getCNVColorUtil(cnv.cnvType);
+      }
+      return getVariantColorByMode(cnv, this.filterState);
     },
     getCNVDisplayCoords(cnv) {
       // Clamp CNV coordinates to VISIBLE region (not fixed gene boundaries)
@@ -1302,6 +1340,12 @@ export default {
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
+}
+
+.filter-indicator {
+  display: flex;
+  align-items: center;
+  color: #1976d2;
 }
 
 .svg-container {

--- a/frontend/src/components/gene/HNF1BProteinVisualization.vue
+++ b/frontend/src/components/gene/HNF1BProteinVisualization.vue
@@ -29,113 +29,51 @@
     </v-card-title>
 
     <v-card-text>
-      <!-- Legend - Clickable filters -->
-      <v-row class="mb-2">
+      <!-- Variant filter + colour-by controls (all-variants view only) -->
+      <v-row v-if="!currentVariantId" class="mb-1">
         <v-col cols="12">
+          <VariantPlotControls v-model="filterState" :variants="snvVariants" class="mb-2" />
+
+          <!-- Domain filter chips (spatial filter, orthogonal to type/classification) -->
           <div class="legend-container">
-            <!-- Domain filters -->
+            <span class="filter-row-label text-caption text-medium-emphasis mr-1">Domain</span>
             <v-chip
+              v-for="d in domainFilterOptions"
+              :key="d.value"
               size="small"
-              color="orange-lighten-2"
-              :variant="activeFilter === 'domain:Dimerization' ? 'elevated' : 'tonal'"
+              label
+              :color="d.color"
+              :variant="activeDomain === d.value ? 'flat' : 'tonal'"
               class="legend-chip"
-              @click="toggleFilter('domain:Dimerization')"
+              :data-testid="`domain-chip-${d.value}`"
+              @click="toggleDomain(d.value)"
             >
-              <v-icon left size="small"> mdi-square </v-icon>
-              Dimerization
+              <v-icon start size="small"> mdi-square </v-icon>
+              {{ d.label }}
             </v-chip>
             <v-chip
-              size="small"
-              color="blue-lighten-2"
-              :variant="activeFilter === 'domain:POU-Specific' ? 'elevated' : 'tonal'"
-              class="legend-chip"
-              @click="toggleFilter('domain:POU-Specific')"
-            >
-              <v-icon left size="small"> mdi-square </v-icon>
-              POU-Specific
-            </v-chip>
-            <v-chip
-              size="small"
-              color="cyan-lighten-2"
-              :variant="activeFilter === 'domain:POU-Homeodomain' ? 'elevated' : 'tonal'"
-              class="legend-chip"
-              @click="toggleFilter('domain:POU-Homeodomain')"
-            >
-              <v-icon left size="small"> mdi-square </v-icon>
-              POU-Homeodomain
-            </v-chip>
-            <v-chip
-              size="small"
-              color="green-lighten-2"
-              :variant="activeFilter === 'domain:Transactivation' ? 'elevated' : 'tonal'"
-              class="legend-chip"
-              @click="toggleFilter('domain:Transactivation')"
-            >
-              <v-icon left size="small"> mdi-square </v-icon>
-              Transactivation
-            </v-chip>
-            <!-- Pathogenicity filters -->
-            <v-chip
-              size="small"
-              color="red-lighten-3"
-              :variant="activeFilter === 'pathogenicity:PATHOGENIC' ? 'elevated' : 'tonal'"
-              class="legend-chip"
-              @click="toggleFilter('pathogenicity:PATHOGENIC')"
-            >
-              <v-icon left size="small"> mdi-circle </v-icon>
-              Pathogenic
-            </v-chip>
-            <v-chip
-              size="small"
-              color="orange-lighten-3"
-              :variant="activeFilter === 'pathogenicity:LIKELY_PATHOGENIC' ? 'elevated' : 'tonal'"
-              class="legend-chip"
-              @click="toggleFilter('pathogenicity:LIKELY_PATHOGENIC')"
-            >
-              <v-icon left size="small"> mdi-circle </v-icon>
-              Likely Pathogenic
-            </v-chip>
-            <v-chip
-              size="small"
-              color="yellow-darken-1"
-              :variant="activeFilter === 'pathogenicity:VUS' ? 'elevated' : 'tonal'"
-              class="legend-chip"
-              @click="toggleFilter('pathogenicity:VUS')"
-            >
-              <v-icon left size="small"> mdi-circle </v-icon>
-              VUS
-            </v-chip>
-            <v-chip
-              size="small"
-              color="light-green-lighten-3"
-              :variant="activeFilter === 'pathogenicity:LIKELY_BENIGN' ? 'elevated' : 'tonal'"
-              class="legend-chip"
-              @click="toggleFilter('pathogenicity:LIKELY_BENIGN')"
-            >
-              <v-icon left size="small"> mdi-circle </v-icon>
-              Likely Benign
-            </v-chip>
-            <!-- Reset filter button -->
-            <v-chip
-              v-if="activeFilter"
+              v-if="activeDomain"
               size="small"
               color="grey"
               variant="outlined"
               class="legend-chip"
               closable
-              @click:close="clearFilter"
-              @click="clearFilter"
+              @click:close="activeDomain = null"
+              @click="activeDomain = null"
             >
-              <v-icon left size="small"> mdi-filter-off </v-icon>
-              Reset
+              <v-icon start size="small"> mdi-filter-off </v-icon>
+              Reset domain
             </v-chip>
           </div>
-          <!-- Active filter indicator -->
-          <div v-if="activeFilter" class="filter-indicator mt-2">
+
+          <!-- Filtered count indicator -->
+          <div
+            v-if="filteredSnvVariants.length !== snvVariants.length"
+            class="filter-indicator mt-2"
+          >
             <v-icon size="small" color="primary" class="mr-1"> mdi-filter </v-icon>
             <span class="text-body-2">
-              Showing {{ filteredSnvVariants.length }} of {{ snvVariants.length }} variants
-              <strong>({{ activeFilterLabel }})</strong>
+              Showing {{ filteredSnvVariants.length }} of {{ snvVariants.length }} SNVs
             </span>
           </div>
         </v-col>
@@ -393,16 +331,42 @@ import * as d3 from 'd3';
 import { extractCNotation, extractPNotation } from '@/utils/hgvs';
 import { getReferenceGeneDomains } from '@/api';
 import {
+  getConsequenceHexColor,
   getPathogenicityHexColor,
   getPathogenicityScore,
-  matchesPathogenicityCategory,
 } from '@/utils/colors';
+import {
+  COLORING_MODES,
+  createDefaultFilterState,
+  getVariantColorByMode,
+  isVariantVisibleByFilters,
+} from '@/utils/variantFilters';
 import { extractAAPosition as extractAAPositionUtil } from '@/utils/proteinDomains';
 import { calculateTooltipPosition } from '@/utils/tooltip';
 import { isVariantCNV } from '@/utils/geneVisualization';
+import VariantPlotControls from '@/components/gene/VariantPlotControls.vue';
+
+// Amino-acid boundaries used by the spatial "Domain" filter. Kept in sync with
+// the fallback domains in data() / UniProt P35680.
+const DOMAIN_BOUNDARIES = {
+  Dimerization: { start: 1, end: 31 },
+  'POU-Specific': { start: 8, end: 173 },
+  'POU-Homeodomain': { start: 232, end: 305 },
+  Transactivation: { start: 314, end: 557 },
+};
+
+// Maps the full domain names (used by the SVG domain rects) to the compact
+// filter values used by the domain chips / activeDomain state.
+const DOMAIN_NAME_TO_VALUE = {
+  'Dimerization Domain': 'Dimerization',
+  'POU-Specific Domain': 'POU-Specific',
+  'POU Homeodomain': 'POU-Homeodomain',
+  'Transactivation Domain': 'Transactivation',
+};
 
 export default {
   name: 'HNF1BProteinVisualization',
+  components: { VariantPlotControls },
   props: {
     variants: {
       type: Array,
@@ -429,8 +393,10 @@ export default {
       // Visible range for semantic zoom (amino acid positions)
       visibleStart: 1,
       visibleEnd: 557,
-      // Filter state
-      activeFilter: null, // Format: 'domain:DomainName' or 'pathogenicity:CLASS'
+      // Filter state: pathogenicity + consequence multi-select + colour-by mode
+      filterState: createDefaultFilterState(),
+      // Domain filter (spatial, single-select): null or a domain value
+      activeDomain: null,
       // D3 zoom properties (kept for panning support)
       d3Zoom: null, // D3 zoom behavior instance
       d3Transform: null, // Current D3 zoom transform
@@ -514,74 +480,32 @@ export default {
       return this.variantsWithPositions.filter((v) => v.isCNV);
     },
     filteredSnvVariants() {
-      // Apply active filter to SNV variants
-      if (!this.activeFilter) {
+      // On the single-variant detail view (currentVariantId set), snvVariants
+      // is already the single current variant — never hide it behind filters.
+      if (this.currentVariantId) {
         return this.snvVariants;
       }
 
-      const [filterType, filterValue] = this.activeFilter.split(':');
+      // AND-logic across pathogenicity + consequence (shared util), then the
+      // orthogonal spatial domain filter.
+      let result = this.snvVariants.filter((v) => isVariantVisibleByFilters(v, this.filterState));
 
-      if (filterType === 'pathogenicity') {
-        return this.snvVariants.filter((v) =>
-          matchesPathogenicityCategory(v.classificationVerdict, filterValue)
-        );
+      if (this.activeDomain) {
+        const bounds = DOMAIN_BOUNDARIES[this.activeDomain];
+        if (bounds) {
+          result = result.filter((v) => v.aaPosition >= bounds.start && v.aaPosition <= bounds.end);
+        }
       }
 
-      if (filterType === 'domain') {
-        return this.snvVariants.filter((v) => {
-          const pos = v.aaPosition;
-          // Find matching domain
-          const domain = this.domains.find((d) => {
-            const shortNameMatch =
-              d.shortName === filterValue ||
-              d.name.toLowerCase().includes(filterValue.toLowerCase());
-            // Map filter names to actual domain boundaries
-            const domainMap = {
-              Dimerization: { start: 1, end: 31 },
-              'POU-Specific': { start: 8, end: 173 },
-              'POU-Homeodomain': { start: 232, end: 305 },
-              Transactivation: { start: 314, end: 557 },
-            };
-            const mappedDomain = domainMap[filterValue];
-            if (mappedDomain) {
-              return pos >= mappedDomain.start && pos <= mappedDomain.end;
-            }
-            return shortNameMatch && pos >= d.start && pos <= d.end;
-          });
-          // For domain filter, check if position is within domain boundaries
-          const domainMap = {
-            Dimerization: { start: 1, end: 31 },
-            'POU-Specific': { start: 8, end: 173 },
-            'POU-Homeodomain': { start: 232, end: 305 },
-            Transactivation: { start: 314, end: 557 },
-          };
-          const mappedDomain = domainMap[filterValue];
-          if (mappedDomain) {
-            return pos >= mappedDomain.start && pos <= mappedDomain.end;
-          }
-          return domain !== undefined;
-        });
-      }
-
-      return this.snvVariants;
+      return result;
     },
-    activeFilterLabel() {
-      if (!this.activeFilter) return '';
-      const [filterType, filterValue] = this.activeFilter.split(':');
-      if (filterType === 'pathogenicity') {
-        const labels = {
-          PATHOGENIC: 'Pathogenic',
-          LIKELY_PATHOGENIC: 'Likely Pathogenic',
-          VUS: 'VUS',
-          LIKELY_BENIGN: 'Likely Benign',
-          BENIGN: 'Benign',
-        };
-        return labels[filterValue] || filterValue;
-      }
-      if (filterType === 'domain') {
-        return `${filterValue} domain`;
-      }
-      return filterValue;
+    domainFilterOptions() {
+      return [
+        { value: 'Dimerization', label: 'Dimerization', color: 'orange-lighten-2' },
+        { value: 'POU-Specific', label: 'POU-Specific', color: 'blue-lighten-2' },
+        { value: 'POU-Homeodomain', label: 'POU-Homeodomain', color: 'cyan-lighten-2' },
+        { value: 'Transactivation', label: 'Transactivation', color: 'green-lighten-2' },
+      ];
     },
     groupedVariants() {
       // Group filtered variants by amino acid position
@@ -630,41 +554,18 @@ export default {
     window.removeEventListener('keydown', this.handleKeyboardShortcuts);
   },
   methods: {
-    toggleFilter(filter) {
-      // Toggle filter: if same filter clicked, clear it; otherwise set it
-      if (this.activeFilter === filter) {
-        this.activeFilter = null;
-      } else {
-        this.activeFilter = filter;
-      }
-    },
-    clearFilter() {
-      this.activeFilter = null;
+    toggleDomain(value) {
+      // Single-select spatial filter: clicking the active domain clears it.
+      this.activeDomain = this.activeDomain === value ? null : value;
     },
     handleDomainClick(domain) {
-      // Map domain name to filter value
-      const domainFilterMap = {
-        'Dimerization Domain': 'Dimerization',
-        'POU-Specific Domain': 'POU-Specific',
-        'POU Homeodomain': 'POU-Homeodomain',
-        'Transactivation Domain': 'Transactivation',
-      };
-      const filterValue = domainFilterMap[domain.name] || domain.shortName;
-      this.toggleFilter(`domain:${filterValue}`);
+      const filterValue = DOMAIN_NAME_TO_VALUE[domain.name] || domain.shortName;
+      this.toggleDomain(filterValue);
     },
     isDomainActive(domain) {
-      if (!this.activeFilter) return false;
-      const [filterType, filterValue] = this.activeFilter.split(':');
-      if (filterType !== 'domain') return false;
-      // Check if this domain matches the filter
-      const domainFilterMap = {
-        'Dimerization Domain': 'Dimerization',
-        'POU-Specific Domain': 'POU-Specific',
-        'POU Homeodomain': 'POU-Homeodomain',
-        'Transactivation Domain': 'Transactivation',
-      };
-      const domainFilterValue = domainFilterMap[domain.name] || domain.shortName;
-      return filterValue === domainFilterValue;
+      if (!this.activeDomain) return false;
+      const filterValue = DOMAIN_NAME_TO_VALUE[domain.name] || domain.shortName;
+      return this.activeDomain === filterValue;
     },
     getBoundaryLabelOffset(domain, boundaryType) {
       // Check if this boundary label would overlap with an adjacent domain's label
@@ -773,11 +674,26 @@ export default {
       return baseHeight + (variantGroup.length - 1) * stackIncrement;
     },
     getGroupColor(variantGroup) {
-      // If any variant is current, use purple
+      // If any variant is current, use purple (highlight wins over colour mode).
       if (variantGroup.some((v) => v.isCurrentVariant)) {
         return '#9C27B0';
       }
-      // Otherwise use the most pathogenic variant's color
+      if (this.filterState.coloringMode === COLORING_MODES.CONSEQUENCE) {
+        // Colour the stem by the most frequent consequence in the stack.
+        const counts = {};
+        let representative = variantGroup[0];
+        let best = 0;
+        for (const v of variantGroup) {
+          const key = v.molecular_consequence || '';
+          counts[key] = (counts[key] || 0) + 1;
+          if (counts[key] > best) {
+            best = counts[key];
+            representative = v;
+          }
+        }
+        return getConsequenceHexColor(representative.molecular_consequence);
+      }
+      // Classification mode: use the most pathogenic variant's colour.
       const mostPathogenic = variantGroup.reduce((prev, curr) => {
         const prevScore = getPathogenicityScore(prev.classificationVerdict);
         const currScore = getPathogenicityScore(curr.classificationVerdict);
@@ -786,7 +702,10 @@ export default {
       return getPathogenicityHexColor(mostPathogenic.classificationVerdict);
     },
     getVariantColor(variant) {
-      return getPathogenicityHexColor(variant.classificationVerdict);
+      // Mode-aware fill (classification ⇄ consequence). The current-variant
+      // highlight is applied on the lollipop stem (getGroupColor), so the
+      // per-circle / tooltip chip colour stays true to the colour mode.
+      return getVariantColorByMode(variant, this.filterState);
     },
     // HGVS extraction functions imported from utils/hgvs
     extractCNotation,
@@ -982,6 +901,13 @@ export default {
   display: flex;
   align-items: center;
   color: #1976d2;
+}
+
+/* Align the "Domain" row label with the Classification/Type labels rendered
+   inside VariantPlotControls (whose .filter-row-label style is scoped). */
+.filter-row-label {
+  min-width: 86px;
+  font-weight: 600;
 }
 
 .svg-container {

--- a/frontend/src/components/gene/VariantPlotControls.vue
+++ b/frontend/src/components/gene/VariantPlotControls.vue
@@ -1,0 +1,242 @@
+<!--
+  VariantPlotControls — shared control bar for the variant visualizations.
+
+  Renders, for both the protein-lollipop and gene-structure plots:
+    • a "Colour by" toggle (ACMG Classification ⇄ molecular-consequence Type)
+    • a pathogenicity filter row (count-aware chips + per-chip "only" + "All")
+    • a consequence/type filter row (same affordances)
+
+  Filter state is owned by the parent and synced via `v-model`; this component
+  is purely presentational and delegates all state derivation to
+  `@/utils/variantFilters`. Categories with zero variants are never rendered,
+  so each plot only shows the chips that are meaningful for its data.
+-->
+<template>
+  <div class="variant-plot-controls">
+    <!-- Colour-by mode toggle -->
+    <div class="d-flex align-center flex-wrap ga-2 mb-2">
+      <span class="text-caption text-medium-emphasis font-weight-medium mr-1">Colour by:</span>
+      <v-btn-toggle
+        :model-value="modelValue.coloringMode"
+        mandatory
+        density="compact"
+        variant="outlined"
+        divided
+        color="primary"
+        aria-label="Variant colouring mode"
+        @update:model-value="setMode"
+      >
+        <v-btn value="classification" size="small" data-testid="colorby-classification">
+          <v-icon start size="small">mdi-medical-bag</v-icon>
+          Classification
+        </v-btn>
+        <v-btn value="consequence" size="small" data-testid="colorby-consequence">
+          <v-icon start size="small">mdi-dna</v-icon>
+          Type
+        </v-btn>
+      </v-btn-toggle>
+    </div>
+
+    <!-- Filter rows -->
+    <div
+      v-for="row in rows"
+      :key="row.dim"
+      class="filter-row d-flex align-center flex-wrap ga-1 mb-1"
+      :data-testid="`filter-row-${row.dim}`"
+    >
+      <span class="filter-row-label text-caption text-medium-emphasis mr-1">{{ row.label }}</span>
+      <span
+        v-for="item in row.items"
+        :key="item.key"
+        class="filter-group d-inline-flex align-center"
+      >
+        <v-chip
+          size="small"
+          label
+          :variant="item.visible ? 'flat' : 'outlined'"
+          class="filter-chip"
+          :class="{ 'filter-chip--hidden': !item.visible }"
+          :aria-pressed="item.visible"
+          :data-testid="`filter-chip-${row.dim}-${item.key}`"
+          @click="onToggle(row.dim, item.key)"
+        >
+          <span
+            class="filter-dot"
+            :style="{
+              backgroundColor: item.visible ? item.color : 'transparent',
+              borderColor: item.color,
+            }"
+          />
+          {{ item.label }}
+          <span class="filter-count">{{ item.count }}</span>
+        </v-chip>
+        <v-btn
+          class="only-btn"
+          size="x-small"
+          variant="text"
+          density="compact"
+          :title="`Show only ${item.label}`"
+          :aria-label="`Show only ${item.label}`"
+          :data-testid="`filter-only-${row.dim}-${item.key}`"
+          @click="onOnly(row.dim, item.key)"
+        >
+          only
+        </v-btn>
+      </span>
+      <v-btn
+        class="all-btn"
+        size="x-small"
+        variant="tonal"
+        density="compact"
+        :title="`Show all ${row.label.toLowerCase()} categories`"
+        :data-testid="`filter-all-${row.dim}`"
+        @click="onAll(row.dim)"
+      >
+        All
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<script>
+import {
+  buildConsequenceLegend,
+  buildPathogenicityLegend,
+  withAllConsequence,
+  withAllPathogenicity,
+  withColoringMode,
+  withOnlyConsequence,
+  withOnlyPathogenicity,
+  withToggledConsequence,
+  withToggledPathogenicity,
+} from '@/utils/variantFilters';
+
+export default {
+  name: 'VariantPlotControls',
+  props: {
+    /** Filter state object (see createDefaultFilterState). */
+    modelValue: {
+      type: Object,
+      required: true,
+    },
+    /** Variants used to derive per-category counts. */
+    variants: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  emits: ['update:modelValue'],
+  computed: {
+    rows() {
+      return [
+        {
+          dim: 'pathogenicity',
+          label: 'Classification',
+          items: buildPathogenicityLegend(this.variants, this.modelValue),
+        },
+        {
+          dim: 'consequence',
+          label: 'Type',
+          items: buildConsequenceLegend(this.variants, this.modelValue),
+        },
+      ].filter((row) => row.items.length > 0);
+    },
+  },
+  methods: {
+    setMode(mode) {
+      // v-btn-toggle is mandatory, but guard against a null update.
+      if (!mode) return;
+      this.$emit('update:modelValue', withColoringMode(this.modelValue, mode));
+    },
+    onToggle(dim, key) {
+      const next =
+        dim === 'pathogenicity'
+          ? withToggledPathogenicity(this.modelValue, key)
+          : withToggledConsequence(this.modelValue, key);
+      this.$emit('update:modelValue', next);
+    },
+    onOnly(dim, key) {
+      const next =
+        dim === 'pathogenicity'
+          ? withOnlyPathogenicity(this.modelValue, key)
+          : withOnlyConsequence(this.modelValue, key);
+      this.$emit('update:modelValue', next);
+    },
+    onAll(dim) {
+      const next =
+        dim === 'pathogenicity'
+          ? withAllPathogenicity(this.modelValue)
+          : withAllConsequence(this.modelValue);
+      this.$emit('update:modelValue', next);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.variant-plot-controls {
+  font-size: 0.8125rem;
+}
+
+.filter-row-label {
+  min-width: 86px;
+  font-weight: 600;
+}
+
+.filter-group {
+  /* Keep the chip and its "only" button visually grouped. */
+  margin-right: 2px;
+}
+
+.filter-chip {
+  cursor: pointer;
+  transition:
+    opacity 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.filter-chip:hover {
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
+}
+
+.filter-chip--hidden {
+  opacity: 0.5;
+}
+
+.filter-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1.5px solid;
+  margin-right: 6px;
+  flex: 0 0 auto;
+}
+
+.filter-count {
+  margin-left: 6px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  opacity: 0.85;
+}
+
+.only-btn {
+  min-width: 0;
+  padding: 0 4px;
+  font-size: 0.65rem;
+  letter-spacing: 0;
+  opacity: 0.55;
+  text-transform: lowercase;
+}
+
+.only-btn:hover {
+  opacity: 1;
+}
+
+.all-btn {
+  min-width: 0;
+  padding: 0 8px;
+  font-size: 0.7rem;
+  margin-left: 4px;
+}
+</style>

--- a/frontend/src/utils/colors.js
+++ b/frontend/src/utils/colors.js
@@ -62,6 +62,58 @@ const VARIANT_TYPE_COLORS = {
 };
 
 /**
+ * Molecular-consequence (variant-effect) taxonomy.
+ *
+ * Normalizes the curated `molecular_consequence` field (e.g. "Missense",
+ * "Copy Number Loss", "Splice Donor") into a small set of stable, colorable
+ * buckets used by the variant visualizations' "colour by type" mode and by the
+ * effect-type filter chips. The bucket keys, ordering, labels and colours are
+ * the single source of truth shared across the protein and gene plots.
+ *
+ * The palette is colourblind-aware and aligned with the SysNDD effect palette
+ * where the categories overlap (missense/frameshift/stop_gained/splice/etc.),
+ * extended with HNF1B-specific copy-number categories (loss/gain) and intronic.
+ */
+export const CONSEQUENCE_ORDER = [
+  'missense',
+  'nonsense',
+  'frameshift',
+  'splice',
+  'inframe_indel',
+  'synonymous',
+  'intronic',
+  'cnv_loss',
+  'cnv_gain',
+  'other',
+];
+
+const CONSEQUENCE_LABELS = {
+  missense: 'Missense',
+  nonsense: 'Nonsense',
+  frameshift: 'Frameshift',
+  splice: 'Splice',
+  inframe_indel: 'In-frame indel',
+  synonymous: 'Synonymous',
+  intronic: 'Intronic',
+  cnv_loss: 'CN Loss',
+  cnv_gain: 'CN Gain',
+  other: 'Other',
+};
+
+const CONSEQUENCE_HEX_COLORS = {
+  missense: '#1F77B4', // blue
+  nonsense: '#9467BD', // purple (stop-gained)
+  frameshift: '#D62728', // red
+  splice: '#FF7F0E', // orange
+  inframe_indel: '#2CA02C', // green
+  synonymous: '#7F7F7F', // gray
+  intronic: '#17BECF', // cyan
+  cnv_loss: '#B2182B', // dark red
+  cnv_gain: '#2166AC', // dark blue
+  other: '#BCBD22', // olive
+};
+
+/**
  * Normalize a classification string to a standard key.
  * Handles various input formats (spaces, underscores, mixed case).
  *
@@ -109,6 +161,19 @@ function normalizeClassification(classification) {
 export function getPathogenicityColor(pathogenicity) {
   const key = normalizeClassification(pathogenicity);
   return key ? PATHOGENICITY_VUETIFY_COLORS[key] : 'grey-lighten-1';
+}
+
+/**
+ * Normalize a pathogenicity/classification string to its canonical key.
+ * Exposes the internal normalizer for filter logic that needs to bucket a
+ * verdict into one of PATHOGENIC | LIKELY_PATHOGENIC | VUS | LIKELY_BENIGN |
+ * BENIGN.
+ *
+ * @param {string|null|undefined} pathogenicity - Classification string
+ * @returns {string|null} Canonical key, or null if unrecognized
+ */
+export function normalizePathogenicity(pathogenicity) {
+  return normalizeClassification(pathogenicity);
 }
 
 /**
@@ -191,4 +256,84 @@ export function getVariantTypeColor(variantType) {
  */
 export function getClassificationColor(classification) {
   return getPathogenicityColor(classification);
+}
+
+/**
+ * Normalize a raw molecular-consequence string into a stable taxonomy key.
+ *
+ * Accepts both the curated display values ("Missense", "Copy Number Loss",
+ * "Splice Donor", "In-frame Deletion", ...) and VEP-style tokens
+ * ("missense_variant", "stop_gained", "frameshift_variant",
+ * "splice_donor_variant", ...) so the same logic works regardless of source.
+ *
+ * @param {string|null|undefined} consequence - Raw molecular_consequence value
+ * @returns {string} One of {@link CONSEQUENCE_ORDER} (defaults to 'other')
+ */
+export function normalizeConsequence(consequence) {
+  if (!consequence) return 'other';
+
+  const n = String(consequence).toLowerCase();
+
+  // Copy-number first — "copy number loss/gain" must not fall through to other.
+  if (n.includes('copy number loss') || n.includes('copy_number_loss') || n.includes('cn loss')) {
+    return 'cnv_loss';
+  }
+  if (n.includes('copy number gain') || n.includes('copy_number_gain') || n.includes('cn gain')) {
+    return 'cnv_gain';
+  }
+  if (n.includes('missense')) return 'missense';
+  if (n.includes('frameshift') || n.includes('frame shift') || n.includes('frame_shift')) {
+    return 'frameshift';
+  }
+  if (n.includes('nonsense') || n.includes('stop_gained') || n.includes('stop gained')) {
+    return 'nonsense';
+  }
+  if (n.includes('splice')) return 'splice';
+  if (n.includes('inframe') || n.includes('in-frame') || n.includes('in frame')) {
+    return 'inframe_indel';
+  }
+  if (n.includes('synonymous')) return 'synonymous';
+  if (n.includes('intron')) return 'intronic';
+
+  return 'other';
+}
+
+/**
+ * Get the human-readable label for a molecular consequence.
+ *
+ * @param {string|null|undefined} consequence - Raw molecular_consequence value
+ * @returns {string} Display label (e.g. 'Missense', 'CN Loss')
+ */
+export function getConsequenceLabel(consequence) {
+  return CONSEQUENCE_LABELS[normalizeConsequence(consequence)];
+}
+
+/**
+ * Get the hex colour for a molecular consequence (for D3/SVG rendering).
+ *
+ * @param {string|null|undefined} consequence - Raw molecular_consequence value
+ * @returns {string} Hex colour code (defaults to grey for unknown input)
+ *
+ * @example
+ * getConsequenceHexColor('Missense')         // '#1F77B4'
+ * getConsequenceHexColor('Copy Number Loss') // '#B2182B'
+ * getConsequenceHexColor(null)               // '#BDBDBD'
+ */
+export function getConsequenceHexColor(consequence) {
+  if (!consequence) return '#BDBDBD';
+  return CONSEQUENCE_HEX_COLORS[normalizeConsequence(consequence)] ?? '#BDBDBD';
+}
+
+/**
+ * Ordered consequence taxonomy entries ({ key, label, color }), useful for
+ * building legends without re-deriving the order/label/colour mappings.
+ *
+ * @returns {Array<{key: string, label: string, color: string}>}
+ */
+export function getConsequenceTaxonomy() {
+  return CONSEQUENCE_ORDER.map((key) => ({
+    key,
+    label: CONSEQUENCE_LABELS[key],
+    color: CONSEQUENCE_HEX_COLORS[key],
+  }));
 }

--- a/frontend/src/utils/variantFilters.js
+++ b/frontend/src/utils/variantFilters.js
@@ -1,0 +1,219 @@
+/**
+ * Shared variant filtering + colour-by-mode logic for the variant
+ * visualizations (protein lollipop and gene-structure plots).
+ *
+ * Both plots historically coloured variants only by ACMG pathogenicity and
+ * offered (at most) a single-select pathogenicity filter. This module is the
+ * single source of truth for the richer, SysNDD-style controls:
+ *
+ *  - a colour-by toggle (ACMG classification ⇄ molecular consequence / type)
+ *  - independent multi-select filters for pathogenicity AND consequence
+ *  - AND-logic visibility (a variant must pass both dimensions)
+ *  - count-aware legend builders
+ *
+ * State is treated as immutable: every mutation helper returns a NEW filter
+ * state object so it can flow cleanly through `v-model` without prop mutation.
+ *
+ * @module utils/variantFilters
+ */
+
+import {
+  getConsequenceHexColor,
+  getConsequenceTaxonomy,
+  getPathogenicityHexColor,
+  normalizeConsequence,
+  normalizePathogenicity,
+} from './colors';
+
+/** Ordered consequence taxonomy keys (mirrors colors.CONSEQUENCE_ORDER). */
+const CONSEQUENCE_ORDER = getConsequenceTaxonomy().map((entry) => entry.key);
+
+/** Pathogenicity classes in canonical (most→least severe) display order. */
+export const PATHOGENICITY_ORDER = [
+  'PATHOGENIC',
+  'LIKELY_PATHOGENIC',
+  'VUS',
+  'LIKELY_BENIGN',
+  'BENIGN',
+];
+
+/** Human-readable labels for pathogenicity classes. */
+export const PATHOGENICITY_LABELS = {
+  PATHOGENIC: 'Pathogenic',
+  LIKELY_PATHOGENIC: 'Likely pathogenic',
+  VUS: 'VUS',
+  LIKELY_BENIGN: 'Likely benign',
+  BENIGN: 'Benign',
+};
+
+/** Colour-by modes for variant markers. */
+export const COLORING_MODES = Object.freeze({
+  CLASSIFICATION: 'classification',
+  CONSEQUENCE: 'consequence',
+});
+
+function allTrue(keys) {
+  return keys.reduce((acc, key) => {
+    acc[key] = true;
+    return acc;
+  }, {});
+}
+
+/**
+ * Build a fresh filter state with every category visible and colouring by
+ * ACMG classification (the established default for both plots).
+ *
+ * @returns {{coloringMode: string, pathogenicity: Object, consequence: Object}}
+ */
+export function createDefaultFilterState() {
+  return {
+    coloringMode: COLORING_MODES.CLASSIFICATION,
+    pathogenicity: allTrue(PATHOGENICITY_ORDER),
+    consequence: allTrue(CONSEQUENCE_ORDER),
+  };
+}
+
+/**
+ * Read the pathogenicity verdict from a variant, tolerating the two field
+ * names used across the app (`classificationVerdict` and `pathogenicity`).
+ */
+function variantVerdict(variant) {
+  return variant?.classificationVerdict ?? variant?.pathogenicity ?? null;
+}
+
+/**
+ * Whether a variant's pathogenicity passes the current filter.
+ * Unrecognized/absent classifications are always shown (never hidden).
+ */
+export function isPathogenicityVisible(variant, state) {
+  const key = normalizePathogenicity(variantVerdict(variant));
+  if (!key) return true;
+  return state?.pathogenicity?.[key] !== false;
+}
+
+/**
+ * Whether a variant's molecular consequence passes the current filter.
+ */
+export function isConsequenceVisible(variant, state) {
+  const key = normalizeConsequence(variant?.molecular_consequence);
+  return state?.consequence?.[key] !== false;
+}
+
+/**
+ * AND-logic visibility: a variant is shown only when it passes BOTH the
+ * pathogenicity and consequence filters.
+ */
+export function isVariantVisibleByFilters(variant, state) {
+  if (!state) return true;
+  return isPathogenicityVisible(variant, state) && isConsequenceVisible(variant, state);
+}
+
+/**
+ * Mode-aware marker colour for a variant.
+ * - classification mode → ACMG pathogenicity hex colour
+ * - consequence mode    → molecular-consequence hex colour
+ *
+ * @returns {string} Hex colour
+ */
+export function getVariantColorByMode(variant, state) {
+  if (state?.coloringMode === COLORING_MODES.CONSEQUENCE) {
+    return getConsequenceHexColor(variant?.molecular_consequence);
+  }
+  return getPathogenicityHexColor(variantVerdict(variant));
+}
+
+/**
+ * Build the pathogenicity legend/filter rows for a set of variants.
+ * Only categories actually present (count > 0) are returned, so plots never
+ * render dead chips (e.g. the gene has no benign curated variants).
+ *
+ * @returns {Array<{key,label,color,visible,count}>}
+ */
+export function buildPathogenicityLegend(variants, state) {
+  const counts = {};
+  for (const variant of variants) {
+    const key = normalizePathogenicity(variantVerdict(variant));
+    if (key) counts[key] = (counts[key] || 0) + 1;
+  }
+  return PATHOGENICITY_ORDER.filter((key) => counts[key] > 0).map((key) => ({
+    key,
+    label: PATHOGENICITY_LABELS[key],
+    color: getPathogenicityHexColor(key),
+    visible: state?.pathogenicity?.[key] !== false,
+    count: counts[key],
+  }));
+}
+
+/**
+ * Build the consequence (variant-type) legend/filter rows for a set of
+ * variants. Only present categories (count > 0) are returned and they follow
+ * the canonical taxonomy order.
+ *
+ * @returns {Array<{key,label,color,visible,count}>}
+ */
+export function buildConsequenceLegend(variants, state) {
+  const counts = {};
+  for (const variant of variants) {
+    const key = normalizeConsequence(variant?.molecular_consequence);
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  // Use the taxonomy entries directly (key → label/color) — passing a
+  // normalized key back through getConsequenceLabel/Color would re-normalize it
+  // and mislabel the copy-number buckets (e.g. 'cnv_loss' → 'other').
+  return getConsequenceTaxonomy()
+    .filter((entry) => counts[entry.key] > 0)
+    .map((entry) => ({
+      key: entry.key,
+      label: entry.label,
+      color: entry.color,
+      visible: state?.consequence?.[entry.key] !== false,
+      count: counts[entry.key],
+    }));
+}
+
+// --- Immutable mutation helpers (return a new state) -----------------------
+
+/** Return a new state with the colouring mode set. */
+export function withColoringMode(state, mode) {
+  return { ...state, coloringMode: mode };
+}
+
+/** Return a new state with one pathogenicity category toggled on/off. */
+export function withToggledPathogenicity(state, key) {
+  return {
+    ...state,
+    pathogenicity: { ...state.pathogenicity, [key]: state.pathogenicity?.[key] === false },
+  };
+}
+
+/** Return a new state with one consequence category toggled on/off. */
+export function withToggledConsequence(state, key) {
+  return {
+    ...state,
+    consequence: { ...state.consequence, [key]: state.consequence?.[key] === false },
+  };
+}
+
+/** Return a new state showing ONLY the given pathogenicity category. */
+export function withOnlyPathogenicity(state, key) {
+  const pathogenicity = {};
+  for (const k of PATHOGENICITY_ORDER) pathogenicity[k] = k === key;
+  return { ...state, pathogenicity };
+}
+
+/** Return a new state showing ONLY the given consequence category. */
+export function withOnlyConsequence(state, key) {
+  const consequence = {};
+  for (const k of CONSEQUENCE_ORDER) consequence[k] = k === key;
+  return { ...state, consequence };
+}
+
+/** Return a new state with all pathogenicity categories visible. */
+export function withAllPathogenicity(state) {
+  return { ...state, pathogenicity: allTrue(PATHOGENICITY_ORDER) };
+}
+
+/** Return a new state with all consequence categories visible. */
+export function withAllConsequence(state) {
+  return { ...state, consequence: allTrue(CONSEQUENCE_ORDER) };
+}

--- a/frontend/tests/unit/components/gene/VariantPlotControls.spec.js
+++ b/frontend/tests/unit/components/gene/VariantPlotControls.spec.js
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the shared VariantPlotControls control bar.
+ */
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import VariantPlotControls from '@/components/gene/VariantPlotControls.vue';
+import { createDefaultFilterState } from '@/utils/variantFilters';
+
+const variants = [
+  { classificationVerdict: 'PATHOGENIC', molecular_consequence: 'Missense' },
+  { classificationVerdict: 'VUS', molecular_consequence: 'Missense' },
+  { classificationVerdict: 'PATHOGENIC', molecular_consequence: 'Copy Number Loss' },
+];
+
+function makeWrapper(modelValue = createDefaultFilterState()) {
+  const vuetify = createVuetify({ components, directives });
+  return mount(VariantPlotControls, {
+    props: { modelValue, variants },
+    global: { plugins: [vuetify] },
+  });
+}
+
+describe('VariantPlotControls', () => {
+  it('renders a colour-by toggle and both filter rows', () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.find('[data-testid="colorby-classification"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="colorby-consequence"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="filter-row-pathogenicity"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="filter-row-consequence"]').exists()).toBe(true);
+  });
+
+  it('renders only the categories present in the data, with counts', () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.find('[data-testid="filter-chip-pathogenicity-PATHOGENIC"]').text()).toContain(
+      '2'
+    );
+    expect(wrapper.find('[data-testid="filter-chip-pathogenicity-VUS"]').text()).toContain('1');
+    // No benign/likely-benign variants -> those chips are absent.
+    expect(wrapper.find('[data-testid="filter-chip-pathogenicity-BENIGN"]').exists()).toBe(false);
+    // CNV bucket present and correctly labelled.
+    const cnv = wrapper.find('[data-testid="filter-chip-consequence-cnv_loss"]');
+    expect(cnv.exists()).toBe(true);
+    expect(cnv.text()).toContain('CN Loss');
+  });
+
+  it('emits update:modelValue when switching colour mode', async () => {
+    const wrapper = makeWrapper();
+    await wrapper.find('[data-testid="colorby-consequence"]').trigger('click');
+    const events = wrapper.emitted('update:modelValue');
+    expect(events).toBeTruthy();
+    expect(events.at(-1)[0].coloringMode).toBe('consequence');
+  });
+
+  it('emits a toggled-off state when a visible chip is clicked', async () => {
+    const wrapper = makeWrapper();
+    await wrapper.find('[data-testid="filter-chip-consequence-missense"]').trigger('click');
+    const next = wrapper.emitted('update:modelValue').at(-1)[0];
+    expect(next.consequence.missense).toBe(false);
+  });
+
+  it('emits an isolated state when "only" is clicked', async () => {
+    const wrapper = makeWrapper();
+    await wrapper.find('[data-testid="filter-only-pathogenicity-PATHOGENIC"]').trigger('click');
+    const next = wrapper.emitted('update:modelValue').at(-1)[0];
+    expect(next.pathogenicity.PATHOGENIC).toBe(true);
+    expect(next.pathogenicity.VUS).toBe(false);
+  });
+
+  it('emits an all-visible state when "All" is clicked', async () => {
+    const start = createDefaultFilterState();
+    start.consequence.missense = false;
+    const wrapper = makeWrapper(start);
+    await wrapper.find('[data-testid="filter-all-consequence"]').trigger('click');
+    const next = wrapper.emitted('update:modelValue').at(-1)[0];
+    expect(Object.values(next.consequence).every(Boolean)).toBe(true);
+  });
+});

--- a/frontend/tests/unit/utils/colors.consequence.spec.js
+++ b/frontend/tests/unit/utils/colors.consequence.spec.js
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the molecular-consequence taxonomy added to utils/colors.
+ *
+ * Guards the normalization (display values AND VEP-style tokens), the
+ * key→colour/label lookups, and — importantly — the copy-number buckets that
+ * a naive substring normalizer would drop into "other".
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  CONSEQUENCE_ORDER,
+  getConsequenceHexColor,
+  getConsequenceLabel,
+  getConsequenceTaxonomy,
+  normalizeConsequence,
+  normalizePathogenicity,
+} from '@/utils/colors';
+
+describe('normalizeConsequence', () => {
+  it('maps curated display values to taxonomy keys', () => {
+    expect(normalizeConsequence('Missense')).toBe('missense');
+    expect(normalizeConsequence('Nonsense')).toBe('nonsense');
+    expect(normalizeConsequence('Frameshift')).toBe('frameshift');
+    expect(normalizeConsequence('Splice Donor')).toBe('splice');
+    expect(normalizeConsequence('Splice Acceptor')).toBe('splice');
+    expect(normalizeConsequence('In-frame Deletion')).toBe('inframe_indel');
+    expect(normalizeConsequence('Synonymous')).toBe('synonymous');
+    expect(normalizeConsequence('Intronic Variant')).toBe('intronic');
+    expect(normalizeConsequence('Copy Number Loss')).toBe('cnv_loss');
+    expect(normalizeConsequence('Copy Number Gain')).toBe('cnv_gain');
+  });
+
+  it('maps VEP-style tokens to taxonomy keys', () => {
+    expect(normalizeConsequence('missense_variant')).toBe('missense');
+    expect(normalizeConsequence('stop_gained')).toBe('nonsense');
+    expect(normalizeConsequence('frameshift_variant')).toBe('frameshift');
+    expect(normalizeConsequence('splice_donor_variant')).toBe('splice');
+    expect(normalizeConsequence('inframe_deletion')).toBe('inframe_indel');
+  });
+
+  it('falls back to "other" for unknown/empty input', () => {
+    expect(normalizeConsequence('something weird')).toBe('other');
+    expect(normalizeConsequence('')).toBe('other');
+    expect(normalizeConsequence(null)).toBe('other');
+    expect(normalizeConsequence(undefined)).toBe('other');
+  });
+});
+
+describe('getConsequenceHexColor', () => {
+  it('returns distinct hex colours for the main categories', () => {
+    expect(getConsequenceHexColor('Missense')).toBe('#1F77B4');
+    expect(getConsequenceHexColor('Frameshift')).toBe('#D62728');
+    expect(getConsequenceHexColor('Copy Number Loss')).toBe('#B2182B');
+    expect(getConsequenceHexColor('Copy Number Gain')).toBe('#2166AC');
+  });
+
+  it('returns a neutral grey for null/unknown', () => {
+    expect(getConsequenceHexColor(null)).toBe('#BDBDBD');
+    expect(getConsequenceHexColor('nope')).toBe('#BCBD22'); // 'other' bucket colour
+  });
+});
+
+describe('getConsequenceTaxonomy', () => {
+  it('returns one entry per ordered key with label + colour', () => {
+    const taxonomy = getConsequenceTaxonomy();
+    expect(taxonomy.map((t) => t.key)).toEqual(CONSEQUENCE_ORDER);
+    taxonomy.forEach((entry) => {
+      expect(entry.label).toBeTruthy();
+      expect(entry.color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    });
+  });
+
+  it('labels the copy-number buckets correctly (regression)', () => {
+    const byKey = Object.fromEntries(getConsequenceTaxonomy().map((t) => [t.key, t]));
+    expect(byKey.cnv_loss.label).toBe('CN Loss');
+    expect(byKey.cnv_gain.label).toBe('CN Gain');
+    // getConsequenceLabel re-normalizes raw values; a normalized key must NOT
+    // round-trip back to "other".
+    expect(getConsequenceLabel('Copy Number Loss')).toBe('CN Loss');
+  });
+});
+
+describe('normalizePathogenicity', () => {
+  it('buckets verdicts into canonical keys', () => {
+    expect(normalizePathogenicity('Pathogenic')).toBe('PATHOGENIC');
+    expect(normalizePathogenicity('LIKELY_PATHOGENIC')).toBe('LIKELY_PATHOGENIC');
+    expect(normalizePathogenicity('Uncertain Significance')).toBe('VUS');
+    expect(normalizePathogenicity('VUS')).toBe('VUS');
+    expect(normalizePathogenicity('Likely Benign')).toBe('LIKELY_BENIGN');
+    expect(normalizePathogenicity('Benign')).toBe('BENIGN');
+    expect(normalizePathogenicity(null)).toBeNull();
+  });
+});

--- a/frontend/tests/unit/utils/variantFilters.spec.js
+++ b/frontend/tests/unit/utils/variantFilters.spec.js
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the shared variant filtering / colour-by-mode logic.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  COLORING_MODES,
+  PATHOGENICITY_ORDER,
+  buildConsequenceLegend,
+  buildPathogenicityLegend,
+  createDefaultFilterState,
+  getVariantColorByMode,
+  isVariantVisibleByFilters,
+  withAllConsequence,
+  withColoringMode,
+  withOnlyConsequence,
+  withOnlyPathogenicity,
+  withToggledConsequence,
+  withToggledPathogenicity,
+} from '@/utils/variantFilters';
+
+const variants = [
+  { classificationVerdict: 'PATHOGENIC', molecular_consequence: 'Missense' },
+  { classificationVerdict: 'LIKELY_PATHOGENIC', molecular_consequence: 'Frameshift' },
+  { classificationVerdict: 'VUS', molecular_consequence: 'Missense' },
+  { classificationVerdict: 'PATHOGENIC', molecular_consequence: 'Copy Number Loss' },
+  { classificationVerdict: 'PATHOGENIC', molecular_consequence: 'Copy Number Gain' },
+];
+
+describe('createDefaultFilterState', () => {
+  it('defaults to classification colouring with everything visible', () => {
+    const state = createDefaultFilterState();
+    expect(state.coloringMode).toBe(COLORING_MODES.CLASSIFICATION);
+    expect(PATHOGENICITY_ORDER.every((k) => state.pathogenicity[k] === true)).toBe(true);
+    expect(state.consequence.missense).toBe(true);
+    expect(state.consequence.cnv_loss).toBe(true);
+  });
+});
+
+describe('isVariantVisibleByFilters', () => {
+  it('is AND-logic across pathogenicity and consequence', () => {
+    const state = createDefaultFilterState();
+    expect(isVariantVisibleByFilters(variants[0], state)).toBe(true);
+
+    // Hide missense -> the missense/PATHOGENIC variant disappears...
+    const noMissense = withToggledConsequence(state, 'missense');
+    expect(isVariantVisibleByFilters(variants[0], noMissense)).toBe(false);
+    // ...but the frameshift one still shows.
+    expect(isVariantVisibleByFilters(variants[1], noMissense)).toBe(true);
+
+    // Hide VUS -> the VUS/missense variant disappears even though missense is on.
+    const noVus = withToggledPathogenicity(state, 'VUS');
+    expect(isVariantVisibleByFilters(variants[2], noVus)).toBe(false);
+    expect(isVariantVisibleByFilters(variants[0], noVus)).toBe(true);
+  });
+
+  it('shows variants with unknown classification/consequence (never hidden by default)', () => {
+    const state = createDefaultFilterState();
+    expect(isVariantVisibleByFilters({}, state)).toBe(true);
+  });
+});
+
+describe('getVariantColorByMode', () => {
+  it('colours by ACMG in classification mode', () => {
+    const state = createDefaultFilterState();
+    expect(getVariantColorByMode(variants[0], state)).toBe('#EF5350'); // PATHOGENIC
+  });
+
+  it('colours by consequence in type mode', () => {
+    const state = withColoringMode(createDefaultFilterState(), COLORING_MODES.CONSEQUENCE);
+    expect(getVariantColorByMode(variants[0], state)).toBe('#1F77B4'); // missense
+    expect(getVariantColorByMode(variants[3], state)).toBe('#B2182B'); // cnv_loss
+    expect(getVariantColorByMode(variants[4], state)).toBe('#2166AC'); // cnv_gain
+  });
+});
+
+describe('legend builders', () => {
+  it('builds pathogenicity legend with counts, only present categories', () => {
+    const legend = buildPathogenicityLegend(variants, createDefaultFilterState());
+    const byKey = Object.fromEntries(legend.map((l) => [l.key, l]));
+    expect(byKey.PATHOGENIC.count).toBe(3);
+    expect(byKey.LIKELY_PATHOGENIC.count).toBe(1);
+    expect(byKey.VUS.count).toBe(1);
+    expect(byKey.BENIGN).toBeUndefined(); // absent category not rendered
+    expect(legend.every((l) => l.visible)).toBe(true);
+  });
+
+  it('builds consequence legend with correct labels/colours incl. CNV buckets', () => {
+    const legend = buildConsequenceLegend(variants, createDefaultFilterState());
+    const byKey = Object.fromEntries(legend.map((l) => [l.key, l]));
+    expect(byKey.missense.count).toBe(2);
+    expect(byKey.cnv_loss).toMatchObject({ label: 'CN Loss', color: '#B2182B', count: 1 });
+    expect(byKey.cnv_gain).toMatchObject({ label: 'CN Gain', color: '#2166AC', count: 1 });
+  });
+
+  it('reflects visibility from filter state', () => {
+    const state = withToggledConsequence(createDefaultFilterState(), 'missense');
+    const legend = buildConsequenceLegend(variants, state);
+    const missense = legend.find((l) => l.key === 'missense');
+    expect(missense.visible).toBe(false);
+  });
+});
+
+describe('mutation helpers (immutable)', () => {
+  it('toggle returns a new object and flips one key', () => {
+    const state = createDefaultFilterState();
+    const next = withToggledPathogenicity(state, 'PATHOGENIC');
+    expect(next).not.toBe(state);
+    expect(next.pathogenicity.PATHOGENIC).toBe(false);
+    expect(state.pathogenicity.PATHOGENIC).toBe(true); // original untouched
+  });
+
+  it('only isolates a single category', () => {
+    const state = withOnlyConsequence(createDefaultFilterState(), 'frameshift');
+    expect(state.consequence.frameshift).toBe(true);
+    expect(state.consequence.missense).toBe(false);
+    expect(state.consequence.cnv_loss).toBe(false);
+  });
+
+  it('only + all round-trips back to fully visible', () => {
+    const only = withOnlyPathogenicity(createDefaultFilterState(), 'VUS');
+    expect(only.pathogenicity.PATHOGENIC).toBe(false);
+    const all = withAllConsequence(withColoringMode(only, COLORING_MODES.CLASSIFICATION));
+    expect(Object.values(all.consequence).every(Boolean)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the modernised **SysNDD** gene-page variant controls to the HNF1B **protein lollipop** and **gene-structure** visualizations. The user asked: the HNF1B plots were *missing the ability to filter by variant type and to colour by type or ACMG classification* — present in the more capable SysNDD `/Genes/:symbol` implementation. This closes that gap.

### Before
- **Protein view**: single-select pathogenicity/domain filter; coloured **only** by ACMG verdict.
- **Gene view**: **no filters at all** (informational legend only).

### After (both plots)
- **Colour by** toggle: ACMG **Classification** ⇄ molecular-consequence (**Type**).
- Independent **multi-select** filters for pathogenicity **and** consequence — count-aware chips, per-chip **only**, **All** reset, AND-logic.
- Live "showing N of M" indicator.
- Protein view keeps its orthogonal spatial **Domain** filter.
- Controls hide on single-variant detail pages so the focused variant is never filtered out.
- CNV bars colour by loss/gain in Type mode, pathogenicity in Classification mode.

## Implementation
- **`utils/colors.js`** — molecular-consequence taxonomy (normalize + hex colours + labels + order); colourblind-aware, aligned with the SysNDD effect palette and extended with HNF1B-specific **copy-number (loss/gain)** and **intronic** buckets. Adds `normalizePathogenicity`.
- **`utils/variantFilters.js`** — single source of truth for filter state, AND-logic visibility, mode-aware colouring, and count-aware legend builders. State is immutable (flows cleanly through `v-model`).
- **`components/gene/VariantPlotControls.vue`** — reusable Vuetify control bar shared by both plots (DRY, consistent UX).
- Protein & gene components refactored to consume the shared control + util.

## Design notes
- "Type" = `molecular_consequence` (richest dimension; the only one distinguishing CNV loss vs gain — central to HNF1B given 17q12 del/dup).
- Default colour mode = Classification (preserves prior clinical-priority behaviour); the toggle adds the new capability.
- Only categories present in the data render as chips, so each plot shows only meaningful controls.

## Testing
- New unit specs: consequence taxonomy, `variantFilters`, and the control component — including a regression for a `cnv_loss`/`cnv_gain` label/colour bug (a normalized key was re-normalized to `other`).
- **Full frontend gate green**: 504 vitest tests, eslint (0 errors), prettier (src+tests), build.
- **Playwright-verified** on the live dev app: protein view (toggle + filter + only + indicator), gene view, 17q12 CNV view (loss/gain colouring), and a variant detail page (controls correctly hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)