### PR TITLE
feat(viz): unify 3D structure with shared variant controls (missense-only default)

### DIFF
--- a/frontend/src/components/gene/ProteinStructure3D.vue
+++ b/frontend/src/components/gene/ProteinStructure3D.vue
@@ -47,6 +47,16 @@
         Variants outside this region cannot be visualized in 3D.
       </v-alert>
 
+      <!-- Unified variant filter + colour-by controls (all-variants view).
+           Defaults to missense-only; shares the design + state shape with the
+           protein and gene plots. -->
+      <VariantPlotControls
+        v-if="showAllVariants && !loading && !error"
+        v-model="filterState"
+        :variants="variantsInStructure"
+        class="mb-3"
+      />
+
       <!-- Main Content: 3D Viewport + Optional Variant Panel -->
       <v-row no-gutters>
         <!-- 3D Viewport Column — full width on mobile, 8/12 alongside the
@@ -63,6 +73,7 @@
             :show-distance-line="showDistanceLine"
             :variants="variants"
             :show-all-variants="showAllVariants"
+            :coloring-mode="filterState.coloringMode"
             @loading="loading = $event"
             @loaded="structureLoaded = true"
             @error="error = $event"
@@ -80,14 +91,13 @@
             :selected-variant-id="selectedVariantId"
             :hovered-variant-id="hoveredVariantId"
             :sort-by="sortBy"
-            :filter-pathogenicity="filterPathogenicity"
             :filter-distance="filterDistance"
+            :coloring-mode="filterState.coloringMode"
             @select="selectVariant"
             @hover="hoverVariant"
             @unhover="unhoverVariant"
             @clear-filters="clearFilters"
             @update:sort-by="sortBy = $event"
-            @update:filter-pathogenicity="filterPathogenicity = $event"
             @update:filter-distance="filterDistance = $event"
           />
         </v-col>
@@ -165,13 +175,20 @@
 
 <script>
 import { STRUCTURE_START, STRUCTURE_END } from '@/utils/dnaDistanceCalculator';
-import { getPathogenicityColor, getPathogenicityScore } from '@/utils/colors';
+import { getPathogenicityScore } from '@/utils/colors';
+import {
+  createDefaultFilterState,
+  getVariantColorByMode,
+  isVariantVisibleByFilters,
+  withOnlyConsequence,
+} from '@/utils/variantFilters';
 import { extractPNotation } from '@/utils/hgvs';
 import { extractAAPosition as extractAAPositionUtil } from '@/utils/proteinDomains';
 import StructureViewer from '@/components/gene/protein-structure/StructureViewer.vue';
 import StructureControls from '@/components/gene/protein-structure/StructureControls.vue';
 import VariantPanel from '@/components/gene/protein-structure/VariantPanel.vue';
 import DistanceStatsCard from '@/components/gene/protein-structure/DistanceStatsCard.vue';
+import VariantPlotControls from '@/components/gene/VariantPlotControls.vue';
 
 // HNF1B protein domains (from UniProt P35680)
 // Note: PDB 2H8R only covers residues 90-308 (with gap 187-230)
@@ -213,6 +230,7 @@ export default {
     StructureControls,
     VariantPanel,
     DistanceStatsCard,
+    VariantPlotControls,
   },
   props: {
     variants: {
@@ -243,9 +261,12 @@ export default {
       // For showAllVariants mode
       selectedVariantId: null,
       hoveredVariantId: null,
-      // Sorting and filtering
+      // Sorting and filtering. The 3D structure is most informative for
+      // missense variants (point substitutions that map to a single residue
+      // in the DNA-binding domain), so the unified variant controls default to
+      // showing missense only; users can widen via the chips / "All".
       sortBy: 'position',
-      filterPathogenicity: null,
+      filterState: withOnlyConsequence(createDefaultFilterState(), 'missense'),
       filterDistance: null,
       // Cache for variant distances (built by the viewer, keyed by variant_id)
       variantDistanceCache: {},
@@ -314,16 +335,8 @@ export default {
         _distanceInfo: this.variantDistanceCache[v.variant_id] || null,
       }));
 
-      // Apply pathogenicity filter
-      if (this.filterPathogenicity) {
-        variants = variants.filter((v) => {
-          const classification = (v.classificationVerdict || '').toUpperCase();
-          if (this.filterPathogenicity === 'VUS') {
-            return classification.includes('UNCERTAIN') || classification.includes('VUS');
-          }
-          return classification.includes(this.filterPathogenicity);
-        });
-      }
+      // Apply the unified pathogenicity + consequence filters (AND-logic).
+      variants = variants.filter((v) => isVariantVisibleByFilters(v, this.filterState));
 
       // Apply distance filter
       if (this.filterDistance) {
@@ -362,7 +375,8 @@ export default {
     },
 
     getVariantChipColor(variant) {
-      return getPathogenicityColor(variant.classificationVerdict);
+      // Mode-aware (classification ⇄ consequence) to match the colour-by toggle.
+      return getVariantColorByMode(variant, this.filterState);
     },
 
     getVariantLabel(variant) {
@@ -392,7 +406,9 @@ export default {
     },
 
     clearFilters() {
-      this.filterPathogenicity = null;
+      // Reset to all-visible (widening past the missense-only default) and
+      // clear the distance filter.
+      this.filterState = createDefaultFilterState();
       this.filterDistance = null;
     },
 

--- a/frontend/src/components/gene/protein-structure/StructureViewer.vue
+++ b/frontend/src/components/gene/protein-structure/StructureViewer.vue
@@ -27,7 +27,7 @@ import {
   STRUCTURE_START,
   STRUCTURE_END,
 } from '@/utils/dnaDistanceCalculator';
-import { getPathogenicityHexColor } from '@/utils/colors';
+import { getVariantColorByMode } from '@/utils/variantFilters';
 import { extractPNotation } from '@/utils/hgvs';
 import { extractAAPosition as extractAAPositionUtil } from '@/utils/proteinDomains';
 
@@ -83,6 +83,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    coloringMode: {
+      type: String,
+      default: 'classification',
+    },
   },
   emits: [
     'loading',
@@ -108,6 +112,10 @@ export default {
     },
     colorByDomain() {
       this.updateRepresentation();
+    },
+    coloringMode() {
+      // Recolour the highlighted variant when the colour-by mode changes.
+      this.highlightActiveVariant();
     },
     activeVariant() {
       this.highlightActiveVariant();
@@ -516,8 +524,9 @@ export default {
     },
 
     getVariantColor(variant) {
-      // Convert hex color string to NGL-compatible hex number
-      const hexString = getPathogenicityHexColor(variant.classificationVerdict);
+      // Mode-aware hex (classification ⇄ consequence), converted to an
+      // NGL-compatible hex number.
+      const hexString = getVariantColorByMode(variant, { coloringMode: this.coloringMode });
       return parseInt(hexString.replace('#', ''), 16);
     },
 

--- a/frontend/src/components/gene/protein-structure/VariantPanel.vue
+++ b/frontend/src/components/gene/protein-structure/VariantPanel.vue
@@ -25,19 +25,6 @@
         @update:model-value="$emit('update:sortBy', $event)"
       />
 
-      <!-- Pathogenicity Filter -->
-      <v-select
-        :model-value="filterPathogenicity"
-        :items="pathogenicityOptions"
-        label="Pathogenicity"
-        density="compact"
-        hide-details
-        variant="outlined"
-        clearable
-        class="filter-select"
-        @update:model-value="$emit('update:filterPathogenicity', $event)"
-      />
-
       <!-- Distance Filter -->
       <v-select
         :model-value="filterDistance"
@@ -93,7 +80,7 @@
         }}
       </div>
       <v-btn
-        v-if="totalInStructure > 0 && (filterPathogenicity || filterDistance)"
+        v-if="totalInStructure > 0"
         size="x-small"
         variant="text"
         color="primary"
@@ -108,7 +95,7 @@
 
 <script>
 import { extractPNotation } from '@/utils/hgvs';
-import { getPathogenicityColor } from '@/utils/colors';
+import { getVariantColorByMode } from '@/utils/variantFilters';
 import { extractAAPosition as extractAAPositionUtil } from '@/utils/proteinDomains';
 
 export default {
@@ -136,37 +123,23 @@ export default {
       type: String,
       default: 'position',
     },
-    filterPathogenicity: {
-      type: String,
-      default: null,
-    },
     filterDistance: {
       type: String,
       default: null,
     },
+    // Colour-by mode shared with the unified controls (classification | consequence).
+    coloringMode: {
+      type: String,
+      default: 'classification',
+    },
   },
-  emits: [
-    'select',
-    'hover',
-    'unhover',
-    'clear-filters',
-    'update:sortBy',
-    'update:filterPathogenicity',
-    'update:filterDistance',
-  ],
+  emits: ['select', 'hover', 'unhover', 'clear-filters', 'update:sortBy', 'update:filterDistance'],
   data() {
     return {
       sortOptions: [
         { title: 'Position', value: 'position' },
         { title: 'Distance to DNA', value: 'distance' },
         { title: 'Pathogenicity', value: 'pathogenicity' },
-      ],
-      pathogenicityOptions: [
-        { title: 'Pathogenic', value: 'PATHOGENIC' },
-        { title: 'Likely Pathogenic', value: 'LIKELY_PATHOGENIC' },
-        { title: 'VUS', value: 'VUS' },
-        { title: 'Likely Benign', value: 'LIKELY_BENIGN' },
-        { title: 'Benign', value: 'BENIGN' },
       ],
       distanceOptions: [
         { title: 'Close (<5 Å)', value: 'close' },
@@ -181,7 +154,8 @@ export default {
     },
 
     getVariantChipColor(variant) {
-      return getPathogenicityColor(variant.classificationVerdict);
+      // Mode-aware (classification ⇄ consequence) to match the colour-by toggle.
+      return getVariantColorByMode(variant, { coloringMode: this.coloringMode });
     },
 
     getVariantLabel(variant) {

--- a/frontend/tests/unit/components/gene/protein-structure/VariantPanel.spec.js
+++ b/frontend/tests/unit/components/gene/protein-structure/VariantPanel.spec.js
@@ -37,7 +37,6 @@ function mountPanel(props = {}) {
       selectedVariantId: null,
       hoveredVariantId: null,
       sortBy: 'position',
-      filterPathogenicity: null,
       filterDistance: null,
       ...props,
     },
@@ -79,7 +78,6 @@ describe('VariantPanel', () => {
     const wrapper = mountPanel({
       variants: [],
       totalInStructure: 2,
-      filterPathogenicity: 'PATHOGENIC',
     });
     expect(wrapper.text()).toContain('No variants match filters');
     const clearBtn = wrapper.findAll('button').find((b) => b.text().includes('Clear Filters'));


### PR DESCRIPTION
## Summary

Follow-up to #362/#363. Brings the **3D structure** view in line with the protein and gene plots by adding the shared `VariantPlotControls` and replacing its ad-hoc filters with the unified filter state — and, importantly, **defaults it to missense only**.

### Changes
- **Unified controls** — colour-by toggle (Classification ⇄ Type) + pathogenicity + consequence filter rows above the 3D viewport (all-variants mode), reusing the same component and `filterState` shape as the other two plots.
- **Missense-only default** — PDB 2H8R covers residues 90-308 (DNA-binding domain), where the structure is most informative for point substitutions. The consequence filter starts at **missense only** (`withOnlyConsequence(createDefaultFilterState(), 'missense')`); users widen via the chips / "All". Verified live: panel shows **67 / 107** in-structure variants by default.
- **De-duplicated existing input** — removed the redundant single-select "Pathogenicity" dropdown from `VariantPanel` (now covered by the unified chips). Kept the 3D-specific **Sort by** + **DNA Distance** controls and the **Domain Colors** backbone switch (a structure-rendering option, distinct from variant colouring).
- **Mode-aware colouring everywhere** in 3D: the NGL active-variant highlight, the panel list avatars, and the header/selected chips all follow the colour-by toggle. Added a `StructureViewer` watcher so changing the mode recolours the highlighted residue.
- **Clear filters** resets to all-visible.

## Testing
- Full frontend gate green: **504 vitest tests**, eslint (0 errors), prettier (src+tests), build.
- **Playwright-verified** on the live dev app: missense-only default (67/107), colour-by Type recolours panel avatars (VUS-yellow → missense-blue), pathogenicity select removed from the panel, structure still loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)