### PR TITLE
fix(viz): compact, evenly-padded Colour-by toggle

### DIFF
--- a/frontend/src/components/gene/HNF1BGeneVisualization.vue
+++ b/frontend/src/components/gene/HNF1BGeneVisualization.vue
@@ -86,7 +86,7 @@
       </v-row>
 
       <!-- Variant filter + colour-by controls (all-variants view only) -->
-      <v-row v-if="!currentVariantId" class="mb-1">
+      <v-row v-if="!currentVariantId" class="mb-1 pt-4">
         <v-col cols="12">
           <VariantPlotControls v-model="filterState" :variants="variantsWithPositions" />
           <div

--- a/frontend/src/components/gene/HNF1BProteinVisualization.vue
+++ b/frontend/src/components/gene/HNF1BProteinVisualization.vue
@@ -30,7 +30,7 @@
 
     <v-card-text>
       <!-- Variant filter + colour-by controls (all-variants view only) -->
-      <v-row v-if="!currentVariantId" class="mb-1">
+      <v-row v-if="!currentVariantId" class="mb-1 pt-4">
         <v-col cols="12">
           <VariantPlotControls v-model="filterState" :variants="snvVariants" class="mb-2" />
 

--- a/frontend/src/components/gene/VariantPlotControls.vue
+++ b/frontend/src/components/gene/VariantPlotControls.vue
@@ -23,7 +23,7 @@
       <v-btn-toggle
         :model-value="modelValue.coloringMode"
         mandatory
-        divided
+        density="compact"
         rounded="lg"
         variant="outlined"
         color="primary"
@@ -201,13 +201,23 @@ export default {
   padding-top: 5px;
 }
 
-/* Give the segmented toggle a defined outline + comfortable height/padding. */
+/* Compact, evenly-padded segmented toggle. v-btn-toggle's default density
+   renders 48px buttons that ignore size="small", so pin a tight height and
+   centre the content with comfortable horizontal padding. */
 .vpc-toggle {
-  height: 34px;
+  height: 30px;
 }
 
 .vpc-toggle :deep(.v-btn) {
-  height: 34px;
+  height: 30px;
+  min-height: 30px;
+  padding-inline: 16px;
+}
+
+.vpc-toggle :deep(.v-btn__content) {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
 }
 
 .vpc-chips {


### PR DESCRIPTION
## Summary

Follow-up to the design feedback: the "Colour by" segmented toggle looked **weirdly high with no padding**.

**Root cause:** a `v-btn-toggle` ignores child `size="small"` and its default density renders **48px** buttons; the prior fix forced a 34px height (still too tall) and `divided` added a stray divider, so the 12px labels floated in an over-tall box.

**Fix:** pin a tight **30px** height, centre the button content, and give the labels comfortable **16px** horizontal padding — so the toggle reads as a compact, well-proportioned segmented control in rhythm with the filter chips below.

CSS-only (plus removing the `divided` prop); behaviour unchanged. Gate green: vitest, eslint, prettier, build. Playwright-verified on the live dev app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)