### PR TITLE
fix(viz): clean up double-icon alerts in the variant visualizations

### DIFF
--- a/frontend/src/components/gene/HNF1BGeneVisualization.vue
+++ b/frontend/src/components/gene/HNF1BGeneVisualization.vue
@@ -59,10 +59,13 @@
       <!-- View Mode Toggle -->
       <v-row v-if="hasExtendedCNV" class="mb-3">
         <v-col cols="12">
-          <v-alert type="warning" density="compact" variant="tonal">
-            <v-icon left> mdi-alert </v-icon>
-            CNV extends beyond HNF1B gene ({{ formatCNVSize() }})
-          </v-alert>
+          <v-alert
+            type="warning"
+            variant="tonal"
+            density="compact"
+            rounded="lg"
+            :text="`CNV extends beyond the HNF1B gene (${formatCNVSize()}).`"
+          />
           <!-- Toggle button: only show when not in forced mode (i.e., when used standalone) -->
           <v-btn-group v-if="showViewModeToggle" mandatory class="mt-2">
             <v-btn

--- a/frontend/src/components/gene/HNF1BProteinVisualization.vue
+++ b/frontend/src/components/gene/HNF1BProteinVisualization.vue
@@ -77,22 +77,27 @@
       </v-row>
 
       <!-- Info Alert for CNVs -->
-      <v-alert v-if="cnvVariants.length > 0" type="warning" density="compact" class="mb-3">
-        <v-icon size="small" class="mr-1"> mdi-alert </v-icon>
-        {{ cnvVariants.length }} CNV(s) not shown in protein view. Switch to Gene View to see
-        structural variants.
-      </v-alert>
+      <v-alert
+        v-if="cnvVariants.length > 0"
+        type="warning"
+        variant="tonal"
+        density="compact"
+        rounded="lg"
+        class="mb-3"
+        :text="`${cnvVariants.length} CNV(s) are not shown in the protein view — switch to Gene View to see structural variants.`"
+      />
 
       <!-- Info Alert for Splice Variants -->
       <v-alert
         v-if="isCurrentVariantSpliceVariant"
         type="info"
-        density="compact"
         variant="tonal"
+        density="compact"
+        rounded="lg"
         class="mb-3"
+        title="Splice site variant detected"
       >
-        <v-icon size="small" class="mr-1"> mdi-information </v-icon>
-        <strong>Splice site variant detected:</strong> {{ currentVariantTranscript }}
+        <div class="font-weight-medium">{{ currentVariantTranscript }}</div>
         <div class="text-caption mt-1">
           This variant affects RNA splicing and cannot be displayed in protein view. The exact
           protein effect depends on how splicing is disrupted (exon skipping, intron retention, or

--- a/frontend/src/components/gene/ProteinStructure3D.vue
+++ b/frontend/src/components/gene/ProteinStructure3D.vue
@@ -41,11 +41,15 @@
 
     <v-card-text>
       <!-- Info Alert about structure coverage -->
-      <v-alert type="info" density="compact" variant="tonal" class="mb-3">
-        <v-icon size="small" class="mr-1"> mdi-information </v-icon>
-        <strong>Structure coverage:</strong> Residues 90-308 (DNA-binding domain, gap at 187-230).
-        Variants outside this region cannot be visualized in 3D.
-      </v-alert>
+      <v-alert
+        type="info"
+        variant="tonal"
+        density="compact"
+        rounded="lg"
+        class="mb-3"
+        title="Structure coverage"
+        text="Residues 90–308 (DNA-binding domain, gap at 187–230). Variants outside this region cannot be visualized in 3D."
+      />
 
       <!-- Unified variant filter + colour-by controls (all-variants view).
            Defaults to missense-only; shares the design + state shape with the
@@ -132,42 +136,43 @@
       <v-alert
         v-if="!showAllVariants && currentVariant && !currentVariantInStructure"
         type="warning"
-        density="compact"
         variant="tonal"
+        density="compact"
+        rounded="lg"
+        icon="mdi-map-marker-off"
         class="mt-3"
+        title="Variant not in structure"
       >
-        <v-icon size="small" class="mr-1"> mdi-map-marker-off </v-icon>
-        <strong>Current variant not in structure:</strong>
         {{ currentVariant.protein || currentVariant.transcript }} is outside the PDB structure range
-        (residues 90-308, gap at 187-230).
+        (residues 90–308, gap at 187–230).
       </v-alert>
 
       <!-- Selected variant info (all variants mode) -->
       <v-alert
         v-if="showAllVariants && selectedVariant"
         :type="selectedVariantInStructure ? 'info' : 'warning'"
-        density="compact"
+        :icon="selectedVariantInStructure ? 'mdi-cursor-default-click' : 'mdi-map-marker-off'"
         variant="tonal"
+        density="compact"
+        rounded="lg"
         class="mt-3"
       >
-        <v-icon size="small" class="mr-1">
-          {{ selectedVariantInStructure ? 'mdi-cursor-default-click' : 'mdi-map-marker-off' }}
-        </v-icon>
-        <strong>Selected:</strong> {{ getVariantLabel(selectedVariant) }}
-        <v-chip size="x-small" :color="getVariantChipColor(selectedVariant)" class="ml-2">
-          {{ selectedVariant.classificationVerdict || 'Unknown' }}
-        </v-chip>
-        <v-btn
-          v-if="selectedVariant"
-          size="x-small"
-          variant="outlined"
-          color="primary"
-          class="ml-3"
-          @click="emitVariantClicked(selectedVariant)"
-        >
-          <v-icon size="x-small" left>mdi-open-in-new</v-icon>
-          View Details
-        </v-btn>
+        <div class="d-flex align-center flex-wrap ga-2">
+          <span> <strong>Selected:</strong> {{ getVariantLabel(selectedVariant) }} </span>
+          <v-chip size="x-small" :color="getVariantChipColor(selectedVariant)">
+            {{ selectedVariant.classificationVerdict || 'Unknown' }}
+          </v-chip>
+          <v-spacer />
+          <v-btn
+            size="x-small"
+            variant="outlined"
+            color="primary"
+            @click="emitVariantClicked(selectedVariant)"
+          >
+            <v-icon size="x-small" start>mdi-open-in-new</v-icon>
+            View Details
+          </v-btn>
+        </div>
       </v-alert>
     </v-card-text>
   </v-card>


### PR DESCRIPTION
## Summary

The info/warning callouts in the variant viz cards looked weird and showed **two icons** — the `v-alert`'s built-in `type` icon **plus** a redundant inline `<v-icon>` — and were styled inconsistently (the protein CNV warning wasn't even tonal).

Redesigned them to one clean, consistent system:
- **Single icon** — the alert `type` icon, or a meaningful custom one via the `icon` prop (e.g. `mdi-map-marker-off` for out-of-range variants).
- Consistent **`variant="tonal"` + `density="compact"` + `rounded="lg"`**.
- Proper hierarchy via the **`title`/`text` props** (bold lead + description) instead of inline `<strong>` + loose text.
- The **"Selected variant"** callout is now a tidy flex row — chip inline, "View Details" pushed to the end.
- **En-dashes** for residue ranges (90–308, 187–230).

Covers the two you flagged ("Structure coverage…", "CNV extends beyond HNF1B gene…") plus the matching alerts in the protein and 3D cards.

## Testing
- Template-only. Full frontend gate green: **504 vitest tests**, eslint, prettier, build.
- **Playwright-verified**: each alert now renders exactly **one** icon (structure-coverage and CNV alerts confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)