### PR TITLE
chore(frontend): bump version to 0.0.4

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hnf1b-db-frontend",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hnf1b-db-frontend",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "@tiptap/core": "^3.24.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hnf1b-db-frontend",
   "private": true,
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Patch bump **0.0.3 → 0.0.4** for the frontend, covering the variant-visualization control work merged this cycle:

- **#362** — shared variant-type filtering + colour-by (Classification/Type) toggle on the protein & gene plots
- **#363** — SysNDD-style control redesign (tonal chips, segmented toggle, aligned rows)
- **#364** — 3D-structure view unified with the shared controls, defaulting to missense-only
- **#365** — Colour-by toggle height + card-title spacing fixes
- **#366** — alert double-icon cleanup across the viz cards

`package.json` + `package-lock.json` bumped together (root entries only; `npm version patch`), satisfying the lock-step pre-commit guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)