### PR TITLE
chore: bump frontend/backend/mcp patch versions (post deps #378)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hnf1b-api"
-version = "0.2.0"
+version = "0.2.1"
 description = "FastAPI-based REST API for managing clinical and genetic data for individuals with HNF1B disease"
 requires-python = ">=3.10"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1641,7 +1641,7 @@ wheels = [
 
 [[package]]
 name = "hnf1b-api"
-version = "0.2.0"
+version = "0.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hnf1b-db-frontend",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hnf1b-db-frontend",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "@tiptap/core": "^3.24.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hnf1b-db-frontend",
   "private": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mcp/contract/openapi.snapshot.json
+++ b/mcp/contract/openapi.snapshot.json
@@ -3703,7 +3703,7 @@
   "info": {
     "description": "GA4GH Phenopackets v2 compliant API for HNF1B disease data",
     "title": "HNF1B Phenopackets API",
-    "version": "0.2.0"
+    "version": "0.2.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hnf1b-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "Read-only MCP server exposing HNF1B-db public data to LLMs"
 requires-python = ">=3.11"
 dependencies = [

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -573,7 +573,7 @@ wheels = [
 
 [[package]]
 name = "hnf1b-mcp"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Patch ("fix") version bumps for the three components whose dependencies were updated in #378.

| Component | From | To | Ripple handled |
|---|---|---|---|
| frontend | 0.0.4 | 0.0.5 | `package.json` + `package-lock.json` in lock-step (`npm version patch`) |
| backend | 0.2.0 | 0.2.1 | `pyproject.toml` (single source via `app/core/version.py`) + `uv.lock` self-entry |
| mcp | 0.1.0 | 0.1.1 | `pyproject.toml` + `uv.lock` self-entry |

CI/Actions changes from #378 carry no package version, so nothing to bump there.

### Verification
- Backend `test_version.py` resolves the version dynamically from `pyproject.toml` (no hardcoded snapshot); guards only require beta `0.X.Y` — 0.2.1 satisfies them. DB-backed run in CI.
- MCP: 436/436 tests pass, contract-drift guard clean (capabilities/tool-guide versions are content hashes, independent of the package version).
- Frontend: version string is not referenced by any test/bundle; `npm version patch` kept the lockfile in lock-step (version-only diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)