### PR TITLE
feat: add independent phenopacket review foundations

### DIFF
--- a/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
+++ b/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
@@ -281,7 +281,7 @@ git commit -m "feat(backend): enforce independent review policy"
 - Approval calls Task 3 policy under the existing row lock and copies the `in_review` snapshot unchanged.
 - Publication validates expected approved ID/digest and copies approved content unchanged; `_canonicalize_for_persistence(..., publish=True)` must not run in `_publish`.
 
-- [ ] **Step 1: Write failing exact-snapshot service tests**
+- [x] **Step 1: Write failing exact-snapshot service tests**
 
 ```python
 async def test_submit_freezes_publish_canonical_content(db_session, draft_record, curator_user):
@@ -298,27 +298,27 @@ async def test_publish_copies_approved_extension_content_unchanged(...):
 
 Cover stale candidate ID, stale digest, missing/false attestation, publish-time canonicalizer mutation (must never be called), stale approved ID/digest, actor role and decision metadata in the v2 hash, and exact public-head pointer swap.
 
-- [ ] **Step 2: Run focused tests and observe current publish-time mutation behavior**
+- [x] **Step 2: Run focused tests and observe current publish-time mutation behavior**
 
 Run: `cd backend && uv run pytest tests/test_exact_review_snapshot.py tests/test_state_flows.py tests/test_revision_immutability.py -q`
 
 Expected: FAIL because current approval has no conditional digest/attestation and `_publish` canonicalizes.
 
-- [ ] **Step 3: Implement conditional schemas and service behavior**
+- [x] **Step 3: Implement conditional schemas and service behavior**
 
 Use Pydantic model validation so approval requires only candidate fields/attestation and publication requires only approved fields. Translate `ReviewPolicyError` to stable structured router errors. Preserve optimistic record `revision` checks in addition to candidate/approved identity checks.
 
-- [ ] **Step 4: Update creation writes to v2 audit without rewriting history**
+- [x] **Step 4: Update creation writes to v2 audit without rewriting history**
 
 Newly created records and all new revision events record actor role, full digest, and ledger v2. Existing rows with null v2 fields remain readable and immutable. Add response fields so review clients can echo exact IDs/digests.
 
-- [ ] **Step 5: Run lifecycle/API/visibility regression tests**
+- [x] **Step 5: Run lifecycle/API/visibility regression tests**
 
 Run: `cd backend && uv run pytest tests/test_exact_review_snapshot.py tests/test_state_flows.py tests/test_revision_immutability.py tests/test_api_transitions.py tests/test_visibility_endpoints.py tests/test_state_service_canonicalization_hook.py tests/test_state_invariants.py tests/test_state_service_clone_cycle_full.py tests/test_state_service_invariant_i8.py tests/test_openapi_contract.py -q`
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit exact review semantics**
+- [x] **Step 6: Commit exact review semantics**
 
 ```bash
 git add backend/app/phenopackets/models.py backend/app/phenopackets/services/state_service.py \

--- a/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
+++ b/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
@@ -363,7 +363,7 @@ git commit -m "feat(backend): bind approval to exact candidate snapshot"
 - Expansion activation revision is `e0f422b00006`, down revision `d0f422b00005`.
 - Database functions/triggers lock the phenopacket row for blocking issue insert/resolve/reopen/delete/identity changes and active revision/state changes, then validate ownership/state/revision linkage; a deferred constraint trigger checks approved-plus-unresolved final state. Resolution events reject database UPDATE/DELETE.
 
-- [ ] **Step 1: Write failing blocking-issue API/service tests**
+- [x] **Step 1: Write failing blocking-issue API/service tests**
 
 ```python
 async def test_owner_cannot_resolve_or_delete_blocking_issue(...):
@@ -380,17 +380,17 @@ async def test_ordinary_comment_routes_remain_backward_compatible(...):
 
 Cover unrelated revision nomination, non-review state creation, missing rationale/disposition, retraction as resolution, append-only resolution/reopen events, all legacy resolve/unresolve/delete routes, admin-owner bypass attempts, and router rollback on failures.
 
-- [ ] **Step 2: Run focused comment tests and confirm bypasses**
+- [x] **Step 2: Run focused comment tests and confirm bypasses**
 
 Run: `cd backend && uv run pytest tests/test_blocking_review_issues.py tests/test_comments_service_mutations.py tests/test_comments_router.py -q`
 
 Expected: FAIL because current routes allow any curator resolve/unresolve and author/admin delete.
 
-- [ ] **Step 3: Implement phenopacket-first comment mutations**
+- [x] **Step 3: Implement phenopacket-first comment mutations**
 
 Load comment identity, acquire the phenopacket row lock by `record_id`, reload/lock the comment, then discriminate `review_revision_id`. Use Task 3 policy for blocking operations. Write a `CommentResolutionEvent` before updating the current projection. Reject DELETE on a blocking issue; do not soft-delete it.
 
-- [ ] **Step 4: Write failing raw-SQL race and activation-migration tests**
+- [x] **Step 4: Write failing raw-SQL race and activation-migration tests**
 
 Use two independent async connections/transactions and explicit barriers, not sleeps. Test all four orderings:
 
@@ -404,17 +404,17 @@ Tx B: insert/reopen issue -> blocks -> rejects review_closed after A commit
 
 Also assert active `editing_revision_id` requires `draft_owner_id` in both ORM metadata and the database, review revision belongs to the comment record, blocking issues cannot be soft/hard deleted or detached by direct SQL, resolution events are append-only, ambiguous owner preflight aborts, and downgrade refuses after a resolution event or v2 revision exists.
 
-- [ ] **Step 5: Implement activation migration and guarded downgrade**
+- [x] **Step 5: Implement activation migration and guarded downgrade**
 
 Create lock-taking trigger functions with one global order: `phenopackets FOR UPDATE` before revision/comment checks. Augment the existing pointer-state trigger rather than replacing it. Backfill missing active owners from recursive deterministic active-cycle ancestry; run a preflight that raises with record IDs when ancestry is ambiguous. Add the same audit-data downgrade preflight to the d0 expansion migration because the rollout intentionally runs v2 application writers before e0 activation. Both downgrade paths succeed only when no blocking issue, resolution event, v2 ledger revision, decision metadata, actor role, or content digest exists. Do not modify existing revision rows to reconstruct roles/hashes.
 
-- [ ] **Step 6: Run migration, race, comment, and state tests**
+- [x] **Step 6: Run migration, race, comment, and state tests**
 
 Run: `cd backend && uv run pytest tests/migration/test_independent_review_activation_migration.py tests/migration/test_independent_review_sql_races.py tests/test_blocking_review_issues.py tests/test_comments_service_mutations.py tests/test_comments_router.py tests/test_comments_permissions.py tests/test_comments_soft_delete.py tests/test_state_invariants.py tests/test_review_models.py tests/test_review_policy.py tests/test_alembic_env_autogenerate.py -q`
 
 Expected: PASS with both raw-SQL commit orders proven.
 
-- [ ] **Step 7: Commit review issues and invariant activation**
+- [x] **Step 7: Commit review issues and invariant activation**
 
 ```bash
 git add backend/app/comments/schemas.py backend/app/comments/service.py backend/app/comments/routers.py \

--- a/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
+++ b/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
@@ -79,7 +79,7 @@
 - Migration revision is `d0f422b00005`, down revision `c0f422b00004`.
 - Does not add lock-taking triggers or the active-owner constraint; Task 5 activates those after application support exists.
 
-- [ ] **Step 1: Write failing ORM and migration-contract tests**
+- [x] **Step 1: Write failing ORM and migration-contract tests**
 
 ```python
 def test_revision_exposes_v2_audit_columns():
@@ -94,13 +94,13 @@ def test_review_issue_and_resolution_event_models_are_linked():
 
 The migration test must import the revision module, assert its revision chain, upgrade a temporary/test schema, inspect nullability/FKs/check constraints/indexes, and verify downgrade succeeds while all new tables/columns are empty.
 
-- [ ] **Step 2: Run the focused tests and confirm the schema is absent**
+- [x] **Step 2: Run the focused tests and confirm the schema is absent**
 
 Run: `cd backend && uv run pytest tests/migration/test_independent_review_expand_migration.py tests/test_review_models.py tests/test_alembic_env_autogenerate.py -q`
 
 Expected: FAIL because the migration, columns, and model do not exist.
 
-- [ ] **Step 3: Implement the nullable expansion**
+- [x] **Step 3: Implement the nullable expansion**
 
 Add the four nullable revision columns; add nullable `comments.review_revision_id` with `ON DELETE RESTRICT`; create `comment_resolution_events` with:
 
@@ -115,7 +115,7 @@ CheckConstraint(
 
 Add database checks for `content_sha256 ~ '^sha256:[0-9a-f]{64}$'`, `ledger_version IS NULL OR ledger_version = 2`, `decision_metadata IS NULL OR ledger_version = 2`, allowlisted actor-role snapshots where present, trimmed resolution rationale length `1..500`, and resolution-event actor role `curator|admin`. Create a partial index for live unresolved phenopacket blocking issues on `(record_id, review_revision_id)` where `record_type = 'phenopacket' AND review_revision_id IS NOT NULL AND resolved_at IS NULL AND deleted_at IS NULL`. Leave existing rows null and do not disable the revision immutability trigger. Import both new ORM models in `alembic/env.py` so autogenerate sees the complete metadata graph.
 
-- [ ] **Step 4: Register cleanup order and verify upgrade/downgrade**
+- [x] **Step 4: Register cleanup order and verify upgrade/downgrade**
 
 Add `comment_resolution_events` before `comments` in `_MUTABLE_TABLES`. Run:
 
@@ -123,7 +123,7 @@ Add `comment_resolution_events` before `comments` in `_MUTABLE_TABLES`. Run:
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the expansion**
+- [x] **Step 5: Commit the expansion**
 
 ```bash
 git add backend/alembic/versions/d0f422b00005_expand_independent_review_audit.py \

--- a/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
+++ b/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
@@ -195,8 +195,10 @@ git commit -m "feat(backend): add full-content revision digests"
 - Create: `backend/app/phenopackets/review/policy.py`
 - Create: `backend/app/phenopackets/review/schemas.py`
 - Modify: `backend/app/phenopackets/services/transitions.py`
+- Modify: `backend/app/phenopackets/services/state_service.py`
 - Create: `backend/tests/test_review_policy.py`
 - Modify: `backend/tests/test_state_transitions.py`
+- Modify: `backend/tests/test_state_flows.py`
 
 **Interfaces:**
 
@@ -224,21 +226,21 @@ async def test_review_eligibility_matrix(...):
     ...
 ```
 
-Also test NULL owner fails closed, viewer has no actions, unresolved issues block only approval, request-changes is available to an eligible curator, approved may reopen to changes requested, and only admins may publish.
+Also test NULL owner fails closed, viewer has no actions, unresolved issues block only approval, request-changes is available to an eligible curator, approved may reopen to changes requested, only admins may publish, and direct state-service calls cannot bypass actor-specific policy.
 
 - [ ] **Step 2: Run policy and transition tests to prove current admin-only behavior fails**
 
-Run: `cd backend && uv run pytest tests/test_review_policy.py tests/test_state_transitions.py -q`
+Run: `cd backend && uv run pytest tests/test_review_policy.py tests/test_state_transitions.py tests/test_state_flows.py -q`
 
 Expected: FAIL because curator review and independent-review errors are absent.
 
 - [ ] **Step 3: Implement the review policy and adjust the pure matrix**
 
-Keep structural state/role rules in `services/transitions.py`; move actor-specific owner/submitter/contributor/issue decisions into `ReviewPolicy`. Add `approved -> changes_requested`. Do not allow `admin` to bypass independence in either layer.
+Keep structural state/role rules in `services/transitions.py`; move actor-specific owner/submitter/contributor/issue decisions into `ReviewPolicy`. Integrate the policy in `state_service.py` after the phenopacket row lock and candidate lookup but before any revision mutation. Add `approved -> changes_requested`. Do not allow `admin` to bypass independence in either layer.
 
 - [ ] **Step 4: Verify policy tests and mypy**
 
-Run: `cd backend && uv run pytest tests/test_review_policy.py tests/test_state_transitions.py -q && uv run mypy app/phenopackets/review app/phenopackets/services/transitions.py`
+Run: `cd backend && uv run pytest tests/test_review_policy.py tests/test_state_transitions.py tests/test_state_flows.py -q && uv run mypy app/phenopackets/review app/phenopackets/services/transitions.py app/phenopackets/services/state_service.py`
 
 Expected: PASS.
 
@@ -246,7 +248,8 @@ Expected: PASS.
 
 ```bash
 git add backend/app/phenopackets/review backend/app/phenopackets/services/transitions.py \
-  backend/tests/test_review_policy.py backend/tests/test_state_transitions.py
+  backend/app/phenopackets/services/state_service.py backend/tests/test_review_policy.py \
+  backend/tests/test_state_transitions.py backend/tests/test_state_flows.py
 git commit -m "feat(backend): enforce independent review policy"
 ```
 

--- a/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
+++ b/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
@@ -265,6 +265,10 @@ git commit -m "feat(backend): enforce independent review policy"
 - Modify: `backend/tests/test_state_flows.py`
 - Modify: `backend/tests/test_revision_immutability.py`
 - Modify: `backend/tests/test_api_transitions.py`
+- Modify: `backend/tests/test_state_invariants.py`
+- Modify: `backend/tests/test_state_service_clone_cycle_full.py`
+- Modify: `backend/tests/test_state_service_invariant_i8.py`
+- Refresh: `mcp/contract/openapi.snapshot.json` for the conditional transition schema; Task 12 refreshes it again after the review endpoints are added
 
 **Interfaces:**
 
@@ -310,7 +314,7 @@ Newly created records and all new revision events record actor role, full digest
 
 - [ ] **Step 5: Run lifecycle/API/visibility regression tests**
 
-Run: `cd backend && uv run pytest tests/test_exact_review_snapshot.py tests/test_state_flows.py tests/test_revision_immutability.py tests/test_api_transitions.py tests/test_visibility_endpoints.py tests/test_state_service_canonicalization_hook.py -q`
+Run: `cd backend && uv run pytest tests/test_exact_review_snapshot.py tests/test_state_flows.py tests/test_revision_immutability.py tests/test_api_transitions.py tests/test_visibility_endpoints.py tests/test_state_service_canonicalization_hook.py tests/test_state_invariants.py tests/test_state_service_clone_cycle_full.py tests/test_state_service_invariant_i8.py tests/test_openapi_contract.py -q`
 
 Expected: PASS.
 
@@ -320,7 +324,9 @@ Expected: PASS.
 git add backend/app/phenopackets/models.py backend/app/phenopackets/services/state_service.py \
   backend/app/phenopackets/services/phenopacket_service.py backend/app/phenopackets/routers/transitions.py \
   backend/tests/test_exact_review_snapshot.py backend/tests/test_state_flows.py \
-  backend/tests/test_revision_immutability.py backend/tests/test_api_transitions.py
+  backend/tests/test_revision_immutability.py backend/tests/test_api_transitions.py \
+  backend/tests/test_state_invariants.py backend/tests/test_state_service_clone_cycle_full.py \
+  backend/tests/test_state_service_invariant_i8.py mcp/contract/openapi.snapshot.json
 git commit -m "feat(backend): bind approval to exact candidate snapshot"
 ```
 

--- a/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
+++ b/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
@@ -439,18 +439,26 @@ git commit -m "feat(backend): gate approval on blocking review issues"
 - Create: `backend/app/phenopackets/review/repository.py`
 - Create: `backend/app/phenopackets/review/service.py`
 - Extend: `backend/app/phenopackets/review/schemas.py`
+- Modify: `backend/app/phenopackets/review/policy.py`
 - Create: `backend/app/phenopackets/routers/review.py`
 - Modify: `backend/app/phenopackets/routers/__init__.py`
 - Fix: `backend/app/phenopackets/routers/crud.py` effective-state projection
+- Modify: `backend/app/comments/schemas.py`
+- Modify: `backend/app/comments/service.py`
+- Modify: `backend/app/comments/routers.py`
 - Create: `backend/tests/test_review_queue.py`
 - Create: `backend/tests/test_review_context.py`
 - Modify: `backend/tests/test_crud_state_branching.py`
+- Modify: `backend/tests/test_comments_router.py`
+- Modify: `backend/tests/test_blocking_review_issues.py`
 - Modify: `backend/tests/test_openapi_contract.py`
+- Refresh: `mcp/contract/openapi.snapshot.json`; Task 12 refreshes it again after final seeding/E2E contract changes
 
 **Interfaces:**
 
 - `ReviewRepository.list_queue(actor, query) -> tuple[list[ReviewQueueRow], int, StateCounts]` uses one centralized SQL effective-state expression for data/count filters.
 - `ReviewRepository.get_context(record_id, actor) -> ReviewContext | None` reads candidate, public baseline, issues, audit, contributors, and capability inputs coherently.
+- Repository queries precompute page-level policy facts so queue capability calculation has a bounded query count independent of page size; no per-row `ReviewPolicy` database calls are allowed.
 - `ReviewService.semantic_changes(baseline, candidate) -> list[SemanticChange]` returns `section`, `operation`, JSON pointer `path`, `before`, and `after`.
 - `GET /api/v2/phenopackets/review-queue` and `GET /api/v2/phenopackets/{id}/review-context` implement the approved DTO/query contract.
 - Queue rows return both `physical_state` and `effective_state`; context and each blocking issue return actor-specific `ActionCapability` objects shaped as `{action, allowed, blocked_by}`.
@@ -474,7 +482,7 @@ async def test_viewer_review_queue_is_not_discoverable(...):
     assert response.status_code == 404
 ```
 
-Cover pagination/count parity, allowlisted sorting, oldest-submission default, state/owner/eligibility/issues filters, search, state counts, own-row visibility with disabled capabilities, and old public-head retention.
+Cover anonymous/viewer non-disclosure, pagination/count parity, allowlisted sorting, oldest-submission default, state/owner/eligibility/issues filters, search, state counts, own-row visibility with disabled capabilities, old public-head retention, and application SELECT-count independence between one-row and full-page responses.
 
 - [ ] **Step 2: Write failing coherent-context and semantic-change tests**
 
@@ -494,15 +502,18 @@ Register the review router before the CRUD catch-all. Keep SQL expressions share
 
 Run: `cd backend && uv run pytest tests/test_review_queue.py tests/test_review_context.py tests/test_crud_state_branching.py tests/test_visibility_endpoints.py tests/test_openapi_contract.py -q`
 
-Expected before snapshot refresh: only the snapshot equality test may fail due intentional API additions; vocabulary contract must pass. Snapshot refresh belongs to Task 12.
+Refresh the deterministic snapshot only after the live review schemas are correct, inspect the generated diff, then rerun. Expected: PASS; Task 12 performs the final refresh after its remaining contract changes.
 
 - [ ] **Step 6: Commit the review API**
 
 ```bash
 git add backend/app/phenopackets/review backend/app/phenopackets/routers/review.py \
   backend/app/phenopackets/routers/__init__.py backend/app/phenopackets/routers/crud.py \
+  backend/app/comments/schemas.py backend/app/comments/service.py backend/app/comments/routers.py \
   backend/tests/test_review_queue.py backend/tests/test_review_context.py \
-  backend/tests/test_crud_state_branching.py
+  backend/tests/test_crud_state_branching.py backend/tests/test_comments_router.py \
+  backend/tests/test_blocking_review_issues.py backend/tests/test_openapi_contract.py \
+  mcp/contract/openapi.snapshot.json
 git commit -m "feat(backend): expose review queue and context"
 ```
 

--- a/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
+++ b/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
@@ -209,7 +209,7 @@ git commit -m "feat(backend): add full-content revision digests"
 - Contributor scope is content events `created|draft_created|draft_saved` after the current published-head revision number, or all such events for a never-published record.
 - Pure transition rules allow curator/admin review transitions, but the state service must call policy checks before mutation; publish remains admin-only.
 
-- [ ] **Step 1: Write the failing role/owner/submitter/contributor matrix**
+- [x] **Step 1: Write the failing role/owner/submitter/contributor matrix**
 
 ```python
 @pytest.mark.parametrize(
@@ -228,23 +228,23 @@ async def test_review_eligibility_matrix(...):
 
 Also test NULL owner fails closed, viewer has no actions, unresolved issues block only approval, request-changes is available to an eligible curator, approved may reopen to changes requested, only admins may publish, and direct state-service calls cannot bypass actor-specific policy.
 
-- [ ] **Step 2: Run policy and transition tests to prove current admin-only behavior fails**
+- [x] **Step 2: Run policy and transition tests to prove current admin-only behavior fails**
 
 Run: `cd backend && uv run pytest tests/test_review_policy.py tests/test_state_transitions.py tests/test_state_flows.py -q`
 
 Expected: FAIL because curator review and independent-review errors are absent.
 
-- [ ] **Step 3: Implement the review policy and adjust the pure matrix**
+- [x] **Step 3: Implement the review policy and adjust the pure matrix**
 
 Keep structural state/role rules in `services/transitions.py`; move actor-specific owner/submitter/contributor/issue decisions into `ReviewPolicy`. Integrate the policy in `state_service.py` after the phenopacket row lock and candidate lookup but before any revision mutation. Add `approved -> changes_requested`. Do not allow `admin` to bypass independence in either layer.
 
-- [ ] **Step 4: Verify policy tests and mypy**
+- [x] **Step 4: Verify policy tests and mypy**
 
 Run: `cd backend && uv run pytest tests/test_review_policy.py tests/test_state_transitions.py tests/test_state_flows.py -q && uv run mypy app/phenopackets/review app/phenopackets/services/transitions.py app/phenopackets/services/state_service.py`
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the policy layer**
+- [x] **Step 5: Commit the policy layer**
 
 ```bash
 git add backend/app/phenopackets/review backend/app/phenopackets/services/transitions.py \

--- a/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
+++ b/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
@@ -147,7 +147,7 @@ git commit -m "feat(backend): expand independent review schema"
 - The v2 payload includes parent revision, revision number, state/event/from/to, reason, patch, full-content digest, projection hash, actor ID, actor role, and canonical decision metadata.
 - Task 4 integrates these pure functions into all new revision writes; this task does not modify `state_service.py`.
 
-- [ ] **Step 1: Write failing digest and tamper-evidence tests**
+- [x] **Step 1: Write failing digest and tamper-evidence tests**
 
 ```python
 def test_content_digest_covers_extension_fields_and_ignores_key_order():
@@ -164,23 +164,23 @@ def test_v2_ledger_hash_changes_with_role_or_decision_metadata():
     assert ledger_sha256(base) != ledger_sha256({**base, "decision_metadata": {"independentReview": True}})
 ```
 
-- [ ] **Step 2: Run the tests and confirm imports fail**
+- [x] **Step 2: Run the tests and confirm imports fail**
 
 Run: `cd backend && uv run pytest tests/test_revision_ledger_v2.py -q`
 
 Expected: FAIL with `ModuleNotFoundError`.
 
-- [ ] **Step 3: Implement deterministic hashing**
+- [x] **Step 3: Implement deterministic hashing**
 
 Reuse `app.phenopackets.curation.hashing.canonical_json`/`sha256_digest`; do not introduce a second serializer. Normalize only the explicit ledger payload, never remove `hnf1bCuration` or unknown extension keys from content.
 
-- [ ] **Step 4: Run focused hashing and projection tests**
+- [x] **Step 4: Run focused hashing and projection tests**
 
 Run: `cd backend && uv run pytest tests/test_revision_ledger_v2.py tests/curation/test_projection_properties.py -q`
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the ledger utility**
+- [x] **Step 5: Commit the ledger utility**
 
 ```bash
 git add backend/app/phenopackets/services/revision_ledger.py backend/tests/test_revision_ledger_v2.py

--- a/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
+++ b/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
@@ -337,6 +337,10 @@ git commit -m "feat(backend): bind approval to exact candidate snapshot"
 - Modify: `backend/app/comments/schemas.py`
 - Modify: `backend/app/comments/service.py`
 - Modify: `backend/app/comments/routers.py`
+- Modify: `backend/app/auth/dependencies.py`
+- Modify: `backend/app/phenopackets/models.py`
+- Modify: `backend/app/phenopackets/review/policy.py`
+- Modify: `backend/alembic/versions/d0f422b00005_expand_independent_review_audit.py`
 - Create: `backend/alembic/versions/e0f422b00006_activate_independent_review_invariants.py`
 - Create: `backend/tests/test_blocking_review_issues.py`
 - Create: `backend/tests/migration/test_independent_review_sql_races.py`
@@ -345,6 +349,9 @@ git commit -m "feat(backend): bind approval to exact candidate snapshot"
 - Modify: `backend/tests/test_comments_router.py`
 - Modify: `backend/tests/test_comments_permissions.py`
 - Modify: `backend/tests/test_comments_soft_delete.py`
+- Modify: `backend/tests/test_review_models.py`
+- Modify: `backend/tests/test_review_policy.py`
+- Modify: `backend/tests/test_alembic_env_autogenerate.py`
 
 **Interfaces:**
 
@@ -352,8 +359,9 @@ git commit -m "feat(backend): bind approval to exact candidate snapshot"
 - `ReviewIssueResolveRequest(record_revision, disposition, rationale)` and `ReviewIssueReopenRequest(record_revision, rationale)` implement the conditional bodies in the spec.
 - `CommentsService` mutation methods flush but never commit; routers own commit/rollback.
 - Blocking issue operations acquire the owning phenopacket `FOR UPDATE` before locking/loading the comment.
+- `ReviewPolicy` exposes a public issue-action eligibility entry point: create only in `in_review`; resolve/reopen in `in_review|changes_requested`; all retain owner/submitter/contributor exclusions.
 - Expansion activation revision is `e0f422b00006`, down revision `d0f422b00005`.
-- Database functions/triggers lock the phenopacket row for blocking issue insert/resolve/reopen and active revision/state changes, then validate ownership/state/revision linkage; a deferred constraint trigger checks approved-plus-unresolved final state.
+- Database functions/triggers lock the phenopacket row for blocking issue insert/resolve/reopen/delete/identity changes and active revision/state changes, then validate ownership/state/revision linkage; a deferred constraint trigger checks approved-plus-unresolved final state. Resolution events reject database UPDATE/DELETE.
 
 - [ ] **Step 1: Write failing blocking-issue API/service tests**
 
@@ -394,15 +402,15 @@ Tx A: approve/lock -> hold -> commit
 Tx B: insert/reopen issue -> blocks -> rejects review_closed after A commit
 ```
 
-Also assert active `editing_revision_id` requires `draft_owner_id`, review revision belongs to the comment record, ambiguous owner preflight aborts, and downgrade refuses after a resolution event or v2 revision exists.
+Also assert active `editing_revision_id` requires `draft_owner_id` in both ORM metadata and the database, review revision belongs to the comment record, blocking issues cannot be soft/hard deleted or detached by direct SQL, resolution events are append-only, ambiguous owner preflight aborts, and downgrade refuses after a resolution event or v2 revision exists.
 
 - [ ] **Step 5: Implement activation migration and guarded downgrade**
 
-Create lock-taking trigger functions with one global order: `phenopackets FOR UPDATE` before revision/comment checks. Augment the existing pointer-state trigger rather than replacing it. Backfill missing active owners from recursive deterministic active-cycle ancestry; run a preflight that raises with record IDs when ancestry is ambiguous. Guard downgrade before dropping any audit/invariant object: it succeeds only when no blocking issue, resolution event, v2 ledger revision, or decision metadata exists. Do not modify existing revision rows to reconstruct roles/hashes.
+Create lock-taking trigger functions with one global order: `phenopackets FOR UPDATE` before revision/comment checks. Augment the existing pointer-state trigger rather than replacing it. Backfill missing active owners from recursive deterministic active-cycle ancestry; run a preflight that raises with record IDs when ancestry is ambiguous. Add the same audit-data downgrade preflight to the d0 expansion migration because the rollout intentionally runs v2 application writers before e0 activation. Both downgrade paths succeed only when no blocking issue, resolution event, v2 ledger revision, decision metadata, actor role, or content digest exists. Do not modify existing revision rows to reconstruct roles/hashes.
 
 - [ ] **Step 6: Run migration, race, comment, and state tests**
 
-Run: `cd backend && uv run pytest tests/migration/test_independent_review_activation_migration.py tests/migration/test_independent_review_sql_races.py tests/test_blocking_review_issues.py tests/test_comments_service_mutations.py tests/test_comments_router.py tests/test_comments_permissions.py tests/test_comments_soft_delete.py tests/test_state_invariants.py -q`
+Run: `cd backend && uv run pytest tests/migration/test_independent_review_activation_migration.py tests/migration/test_independent_review_sql_races.py tests/test_blocking_review_issues.py tests/test_comments_service_mutations.py tests/test_comments_router.py tests/test_comments_permissions.py tests/test_comments_soft_delete.py tests/test_state_invariants.py tests/test_review_models.py tests/test_review_policy.py tests/test_alembic_env_autogenerate.py -q`
 
 Expected: PASS with both raw-SQL commit orders proven.
 
@@ -410,12 +418,17 @@ Expected: PASS with both raw-SQL commit orders proven.
 
 ```bash
 git add backend/app/comments/schemas.py backend/app/comments/service.py backend/app/comments/routers.py \
+  backend/app/auth/dependencies.py backend/app/phenopackets/models.py \
+  backend/app/phenopackets/review/policy.py \
+  backend/alembic/versions/d0f422b00005_expand_independent_review_audit.py \
   backend/alembic/versions/e0f422b00006_activate_independent_review_invariants.py \
   backend/tests/test_blocking_review_issues.py \
   backend/tests/migration/test_independent_review_sql_races.py \
   backend/tests/migration/test_independent_review_activation_migration.py \
   backend/tests/test_comments_service_mutations.py backend/tests/test_comments_router.py \
-  backend/tests/test_comments_permissions.py backend/tests/test_comments_soft_delete.py
+  backend/tests/test_comments_permissions.py backend/tests/test_comments_soft_delete.py \
+  backend/tests/test_review_models.py backend/tests/test_review_policy.py \
+  backend/tests/test_alembic_env_autogenerate.py
 git commit -m "feat(backend): gate approval on blocking review issues"
 ```
 

--- a/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
+++ b/.planning/plans/2026-08-14-independent-phenopacket-review-plan.md
@@ -1,0 +1,918 @@
+# Independent Phenopacket Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver an end-to-end four-eyes Phenopacket workflow with an open curator review queue, revision-bound blocking issues, exact immutable sign-off, admin publication, and private pre-publication content.
+
+**Architecture:** Preserve the existing dual-head revision state machine and add a focused review domain (`policy`, `queries`, `schemas`, `router`) rather than a second workflow model. Canonicalize before review, hash the complete candidate, serialize application and direct-SQL writers on the phenopacket row, and make backend capabilities authoritative. Add a server-driven Vue review queue/workspace that consumes the new DTOs and reuses existing Phenopacket, history, comment, and table primitives.
+
+**Tech Stack:** FastAPI, Python 3.10+ (CI Python 3.12), async SQLAlchemy/asyncpg, PostgreSQL JSONB/triggers, Alembic, Pydantic, pytest; Vue 3 Composition API with `<script setup>`, Vuetify 4, Pinia/Axios, Vitest, Playwright, npm.
+
+## Global Constraints
+
+- The approved design is `.planning/specs/2026-08-14-independent-phenopacket-review-design.md`; its one-pass review is `.planning/reviews/2026-08-14-independent-phenopacket-review-spec-review.md`.
+- Preserve `draft -> in_review -> changes_requested -> in_review -> approved -> published`; do not collapse `changes_requested` into `draft`.
+- The open queue is visible only to active curators/admins; there is no assignment, claiming, bulk approval, new editor role, or panel quorum.
+- Owner, active candidate submitter, and active-cycle content contributors cannot approve or request changes; admins never bypass independence.
+- Only revision-bound blocking issues gate approval; ordinary and historical comments remain non-blocking.
+- Canonicalize and validate before `in_review`; approval and publication copy canonical content unchanged and verify the complete `content_jsonb` digest.
+- Public reads stay pinned to `head_published_revision_id`; an old public head remains public during re-review.
+- All backend code remains async-first and routers/services/repositories stay separated.
+- All queue pagination, filtering, and sorting is server-driven; `AppDataTable` remains in server mode.
+- Frontend local imports use `@/`; no `console.log`; use `window.logService`.
+- New production-sensitive paths fail closed with stable structured errors.
+- Existing append-only revision rows are never rewritten to reconstruct historical roles or v2 hashes.
+- Schema rollback preserves audit data and refuses destructive downgrade after activation data exists.
+- Use TDD for every implementation task, small intentional commits, and relevant verification before integration.
+
+## File and ownership map
+
+| Area | Files | Responsibility |
+| --- | --- | --- |
+| Schema | `backend/app/phenopackets/models.py`, `backend/app/comments/models.py`, two new Alembic revisions | Nullable expansion, resolution-event ledger, lock/constraint activation |
+| Revision integrity | `backend/app/phenopackets/services/revision_ledger.py`, `state_service.py`, `phenopacket_service.py` | Full-content digest, v2 ledger hash, canonical freeze, exact approval/publication |
+| Review policy | `backend/app/phenopackets/review/policy.py`, `schemas.py` | Independence, capabilities, typed errors and DTOs |
+| Review queries/API | `backend/app/phenopackets/review/repository.py`, `service.py`, `backend/app/phenopackets/routers/review.py` | Queue, coherent review context, semantic changes |
+| Review issues | `backend/app/comments/service.py`, `schemas.py`, `routers.py` | Blocking issue create/resolve/reopen/retract semantics and transaction boundaries |
+| Frontend transport | `frontend/src/api/domain/reviews.js`, `phenopackets.js`, `comments.js`, review composables | DTO calls, mutation payloads, state refresh/error handling |
+| Frontend queue | `frontend/src/views/ReviewQueue.vue` | URL-backed server table, filters, loading/error/empty/mobile states |
+| Frontend workspace | `frontend/src/views/PhenopacketReview.vue`, `frontend/src/components/review/*` | Semantic diff, issues, audit, actions, responsive/a11y behavior |
+| Navigation/policy consumers | router, app bar, drawer, state menu, Phenopacket detail | Curator guards/links and server-authoritative capabilities |
+| End-to-end contract | backend OpenAPI snapshot/tests, frontend Playwright | Two-user lifecycle, visibility, concurrency/conflict, public-head invariants |
+
+## Acceptance coverage map
+
+| Design criterion | Planned proof |
+| --- | --- |
+| 1. Owner/submitter/contributor cannot decide | Tasks 3-5 policy/service/API tests; Tasks 10-12 UI and distinct-actor E2E |
+| 2. Eligible curator/admin can review without assignment | Tasks 3 and 6 policy/queue tests; Task 12 E2E |
+| 3. Unresolved issue blocks approval under races | Task 5 service, migration, and four-order raw-SQL tests |
+| 4. Exact approval audit | Tasks 1-4 schema, digest, snapshot, and ledger tests |
+| 5. Exact mutation-free publication | Task 4 canonicalizer-spy/content-equality tests; Task 12 E2E |
+| 6. Candidate privacy and old public head | Tasks 4 and 6 visibility tests; Task 12 two-cycle E2E |
+| 7. Server-driven effective-state queue | Tasks 6 and 8 query/count/URL/table tests |
+| 8. Complete responsive workspace | Tasks 9-10 component, accessibility, build, and mobile tests |
+| 9. Historical comments remain non-blocking | Tasks 1 and 5 migration/backward-compatibility tests |
+| 10. All verification layers pass | Tasks 12-13 focused/full/migration/E2E/Actions checks |
+| 11. Independent reviews adjudicated | Existing spec-review artifact and Task 13 one-pass PR review artifact |
+
+---
+
+### Task 1: Expand the persistence model without activating workflow constraints
+
+**Files:**
+
+- Create: `backend/alembic/versions/d0f422b00005_expand_independent_review_audit.py`
+- Modify: `backend/alembic/env.py`
+- Modify: `backend/app/phenopackets/models.py`
+- Modify: `backend/app/comments/models.py`
+- Modify: `backend/tests/conftest.py`
+- Create: `backend/tests/migration/test_independent_review_expand_migration.py`
+- Create: `backend/tests/test_review_models.py`
+- Modify: `backend/tests/test_alembic_env_autogenerate.py`
+
+**Interfaces:**
+
+- Produces `PhenopacketRevision.actor_role: str | None`, `decision_metadata: dict[str, Any] | None`, `content_sha256: str | None`, and `ledger_version: int | None`.
+- Produces `Comment.review_revision_id: int | None` and relationship `review_revision`.
+- Produces `CommentResolutionEvent` with `action`, `disposition`, `rationale`, `actor_id`, `actor_role`, and `created_at`.
+- Migration revision is `d0f422b00005`, down revision `c0f422b00004`.
+- Does not add lock-taking triggers or the active-owner constraint; Task 5 activates those after application support exists.
+
+- [ ] **Step 1: Write failing ORM and migration-contract tests**
+
+```python
+def test_revision_exposes_v2_audit_columns():
+    columns = PhenopacketRevision.__table__.c
+    assert {"actor_role", "decision_metadata", "content_sha256", "ledger_version"} <= set(columns)
+
+
+def test_review_issue_and_resolution_event_models_are_linked():
+    assert Comment.__table__.c.review_revision_id.foreign_keys
+    assert CommentResolutionEvent.__table__.c.comment_id.foreign_keys
+```
+
+The migration test must import the revision module, assert its revision chain, upgrade a temporary/test schema, inspect nullability/FKs/check constraints/indexes, and verify downgrade succeeds while all new tables/columns are empty.
+
+- [ ] **Step 2: Run the focused tests and confirm the schema is absent**
+
+Run: `cd backend && uv run pytest tests/migration/test_independent_review_expand_migration.py tests/test_review_models.py tests/test_alembic_env_autogenerate.py -q`
+
+Expected: FAIL because the migration, columns, and model do not exist.
+
+- [ ] **Step 3: Implement the nullable expansion**
+
+Add the four nullable revision columns; add nullable `comments.review_revision_id` with `ON DELETE RESTRICT`; create `comment_resolution_events` with:
+
+```python
+CheckConstraint(
+    "(action = 'reopened' AND disposition IS NULL) OR "
+    "(action = 'resolved' AND disposition IN "
+    "('addressed','accepted_with_rationale','retracted','superseded'))",
+    name="ck_comment_resolution_event_action_disposition",
+)
+```
+
+Add database checks for `content_sha256 ~ '^sha256:[0-9a-f]{64}$'`, `ledger_version IS NULL OR ledger_version = 2`, `decision_metadata IS NULL OR ledger_version = 2`, allowlisted actor-role snapshots where present, trimmed resolution rationale length `1..500`, and resolution-event actor role `curator|admin`. Create a partial index for live unresolved phenopacket blocking issues on `(record_id, review_revision_id)` where `record_type = 'phenopacket' AND review_revision_id IS NOT NULL AND resolved_at IS NULL AND deleted_at IS NULL`. Leave existing rows null and do not disable the revision immutability trigger. Import both new ORM models in `alembic/env.py` so autogenerate sees the complete metadata graph.
+
+- [ ] **Step 4: Register cleanup order and verify upgrade/downgrade**
+
+Add `comment_resolution_events` before `comments` in `_MUTABLE_TABLES`. Run:
+
+`cd backend && uv run pytest tests/migration/test_independent_review_expand_migration.py tests/test_review_models.py tests/test_alembic_env_autogenerate.py tests/test_comments_ast_immutable.py tests/test_revision_immutability.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the expansion**
+
+```bash
+git add backend/alembic/versions/d0f422b00005_expand_independent_review_audit.py \
+  backend/alembic/env.py backend/app/phenopackets/models.py backend/app/comments/models.py \
+  backend/tests/conftest.py backend/tests/migration/test_independent_review_expand_migration.py \
+  backend/tests/test_review_models.py backend/tests/test_alembic_env_autogenerate.py
+git commit -m "feat(backend): expand independent review schema"
+```
+
+### Task 2: Centralize full-content and v2 ledger hashing
+
+**Files:**
+
+- Create: `backend/app/phenopackets/services/revision_ledger.py`
+- Create: `backend/tests/test_revision_ledger_v2.py`
+
+**Interfaces:**
+
+- Produces `content_sha256(content: Mapping[str, Any]) -> str` using the existing canonical JSON contract and returning `sha256:<64 lowercase hex>`.
+- Produces `build_ledger_v2_payload(...) -> dict[str, Any]` and `ledger_sha256(payload: Mapping[str, Any]) -> str`.
+- The v2 payload includes parent revision, revision number, state/event/from/to, reason, patch, full-content digest, projection hash, actor ID, actor role, and canonical decision metadata.
+- Task 4 integrates these pure functions into all new revision writes; this task does not modify `state_service.py`.
+
+- [ ] **Step 1: Write failing digest and tamper-evidence tests**
+
+```python
+def test_content_digest_covers_extension_fields_and_ignores_key_order():
+    left = {"subject": {"id": "1"}, "hnf1bCuration": {"flag": True}}
+    reordered = {"hnf1bCuration": {"flag": True}, "subject": {"id": "1"}}
+    changed = {"subject": {"id": "1"}, "hnf1bCuration": {"flag": False}}
+    assert content_sha256(left) == content_sha256(reordered)
+    assert content_sha256(left) != content_sha256(changed)
+
+
+def test_v2_ledger_hash_changes_with_role_or_decision_metadata():
+    base = build_fixture_payload()
+    assert ledger_sha256(base) != ledger_sha256({**base, "actor_role": "admin"})
+    assert ledger_sha256(base) != ledger_sha256({**base, "decision_metadata": {"independentReview": True}})
+```
+
+- [ ] **Step 2: Run the tests and confirm imports fail**
+
+Run: `cd backend && uv run pytest tests/test_revision_ledger_v2.py -q`
+
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement deterministic hashing**
+
+Reuse `app.phenopackets.curation.hashing.canonical_json`/`sha256_digest`; do not introduce a second serializer. Normalize only the explicit ledger payload, never remove `hnf1bCuration` or unknown extension keys from content.
+
+- [ ] **Step 4: Run focused hashing and projection tests**
+
+Run: `cd backend && uv run pytest tests/test_revision_ledger_v2.py tests/curation/test_projection_properties.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the ledger utility**
+
+```bash
+git add backend/app/phenopackets/services/revision_ledger.py backend/tests/test_revision_ledger_v2.py
+git commit -m "feat(backend): add full-content revision digests"
+```
+
+### Task 3: Implement independent-review policy and server capabilities
+
+**Files:**
+
+- Create: `backend/app/phenopackets/review/__init__.py`
+- Create: `backend/app/phenopackets/review/policy.py`
+- Create: `backend/app/phenopackets/review/schemas.py`
+- Modify: `backend/app/phenopackets/services/transitions.py`
+- Create: `backend/tests/test_review_policy.py`
+- Modify: `backend/tests/test_state_transitions.py`
+
+**Interfaces:**
+
+- Produces `ReviewBlockCode = Literal['self_review_forbidden','reviewer_submitted','reviewer_contributed','review_author_unknown','unresolved_review_issues','review_closed']`.
+- Produces immutable `ActionCapability(action: str, allowed: bool, blocked_by: list[str])`.
+- Produces `ReviewPolicy.evaluate(db, phenopacket, candidate_revision, actor, unresolved_count) -> ReviewCapabilities`.
+- Produces `ReviewPolicy.require_independent_reviewer(...) -> None`, raising typed `ReviewPolicyError(code, message, context)`.
+- Contributor scope is content events `created|draft_created|draft_saved` after the current published-head revision number, or all such events for a never-published record.
+- Pure transition rules allow curator/admin review transitions, but the state service must call policy checks before mutation; publish remains admin-only.
+
+- [ ] **Step 1: Write the failing role/owner/submitter/contributor matrix**
+
+```python
+@pytest.mark.parametrize(
+    ("role", "is_owner", "submitted", "contributed", "allowed", "code"),
+    [
+        ("curator", False, False, False, True, None),
+        ("admin", False, False, False, True, None),
+        ("curator", True, False, True, False, "self_review_forbidden"),
+        ("admin", False, True, False, False, "reviewer_submitted"),
+        ("admin", False, False, True, False, "reviewer_contributed"),
+    ],
+)
+async def test_review_eligibility_matrix(...):
+    ...
+```
+
+Also test NULL owner fails closed, viewer has no actions, unresolved issues block only approval, request-changes is available to an eligible curator, approved may reopen to changes requested, and only admins may publish.
+
+- [ ] **Step 2: Run policy and transition tests to prove current admin-only behavior fails**
+
+Run: `cd backend && uv run pytest tests/test_review_policy.py tests/test_state_transitions.py -q`
+
+Expected: FAIL because curator review and independent-review errors are absent.
+
+- [ ] **Step 3: Implement the review policy and adjust the pure matrix**
+
+Keep structural state/role rules in `services/transitions.py`; move actor-specific owner/submitter/contributor/issue decisions into `ReviewPolicy`. Add `approved -> changes_requested`. Do not allow `admin` to bypass independence in either layer.
+
+- [ ] **Step 4: Verify policy tests and mypy**
+
+Run: `cd backend && uv run pytest tests/test_review_policy.py tests/test_state_transitions.py -q && uv run mypy app/phenopackets/review app/phenopackets/services/transitions.py`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the policy layer**
+
+```bash
+git add backend/app/phenopackets/review backend/app/phenopackets/services/transitions.py \
+  backend/tests/test_review_policy.py backend/tests/test_state_transitions.py
+git commit -m "feat(backend): enforce independent review policy"
+```
+
+### Task 4: Freeze canonical candidates and publish the exact approved snapshot
+
+**Files:**
+
+- Modify: `backend/app/phenopackets/models.py` (`TransitionRequest`, `RevisionResponse`)
+- Modify: `backend/app/phenopackets/services/state_service.py`
+- Modify: `backend/app/phenopackets/services/phenopacket_service.py`
+- Modify: `backend/app/phenopackets/routers/transitions.py`
+- Create: `backend/tests/test_exact_review_snapshot.py`
+- Modify: `backend/tests/test_state_flows.py`
+- Modify: `backend/tests/test_revision_immutability.py`
+- Modify: `backend/tests/test_api_transitions.py`
+
+**Interfaces:**
+
+- `TransitionRequest` adds optional conditional fields:
+  `candidate_revision_id`, `candidate_content_sha256`, `approved_revision_id`, `approved_content_sha256`, and `attestation`.
+- `ApprovalAttestation` requires literal `True` for `independent_review` and `no_unmanaged_conflict`.
+- `_append_revision(...)` accepts `decision_metadata: dict[str, Any] | None`, records actor role/content digest/ledger version, and uses Task 2 hashing.
+- `RevisionResponse` exposes actor role, decision metadata, content digest, ledger version, and `actor_role_at_decision_recorded`; old rows remain explicitly labeled as lacking a recorded role snapshot rather than inferring one from the user's current role.
+- Submit/resubmit canonicalizes with `publish=True` before writing `in_review`.
+- Approval calls Task 3 policy under the existing row lock and copies the `in_review` snapshot unchanged.
+- Publication validates expected approved ID/digest and copies approved content unchanged; `_canonicalize_for_persistence(..., publish=True)` must not run in `_publish`.
+
+- [ ] **Step 1: Write failing exact-snapshot service tests**
+
+```python
+async def test_submit_freezes_publish_canonical_content(db_session, draft_record, curator_user):
+    record, submitted = await service.transition(..., to_state="in_review", actor=curator_user)
+    assert submitted.content_sha256 == content_sha256(submitted.content_jsonb)
+    assert record.phenopacket == submitted.content_jsonb
+
+
+async def test_publish_copies_approved_extension_content_unchanged(...):
+    assert content_sha256(published.content_jsonb) == approved.content_sha256
+    assert published.content_jsonb == approved.content_jsonb
+    assert published.content_jsonb["hnf1bCuration"] == approved.content_jsonb["hnf1bCuration"]
+```
+
+Cover stale candidate ID, stale digest, missing/false attestation, publish-time canonicalizer mutation (must never be called), stale approved ID/digest, actor role and decision metadata in the v2 hash, and exact public-head pointer swap.
+
+- [ ] **Step 2: Run focused tests and observe current publish-time mutation behavior**
+
+Run: `cd backend && uv run pytest tests/test_exact_review_snapshot.py tests/test_state_flows.py tests/test_revision_immutability.py -q`
+
+Expected: FAIL because current approval has no conditional digest/attestation and `_publish` canonicalizes.
+
+- [ ] **Step 3: Implement conditional schemas and service behavior**
+
+Use Pydantic model validation so approval requires only candidate fields/attestation and publication requires only approved fields. Translate `ReviewPolicyError` to stable structured router errors. Preserve optimistic record `revision` checks in addition to candidate/approved identity checks.
+
+- [ ] **Step 4: Update creation writes to v2 audit without rewriting history**
+
+Newly created records and all new revision events record actor role, full digest, and ledger v2. Existing rows with null v2 fields remain readable and immutable. Add response fields so review clients can echo exact IDs/digests.
+
+- [ ] **Step 5: Run lifecycle/API/visibility regression tests**
+
+Run: `cd backend && uv run pytest tests/test_exact_review_snapshot.py tests/test_state_flows.py tests/test_revision_immutability.py tests/test_api_transitions.py tests/test_visibility_endpoints.py tests/test_state_service_canonicalization_hook.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit exact review semantics**
+
+```bash
+git add backend/app/phenopackets/models.py backend/app/phenopackets/services/state_service.py \
+  backend/app/phenopackets/services/phenopacket_service.py backend/app/phenopackets/routers/transitions.py \
+  backend/tests/test_exact_review_snapshot.py backend/tests/test_state_flows.py \
+  backend/tests/test_revision_immutability.py backend/tests/test_api_transitions.py
+git commit -m "feat(backend): bind approval to exact candidate snapshot"
+```
+
+### Task 5: Add blocking review-issue semantics and activate database invariants
+
+**Files:**
+
+- Modify: `backend/app/comments/schemas.py`
+- Modify: `backend/app/comments/service.py`
+- Modify: `backend/app/comments/routers.py`
+- Create: `backend/alembic/versions/e0f422b00006_activate_independent_review_invariants.py`
+- Create: `backend/tests/test_blocking_review_issues.py`
+- Create: `backend/tests/migration/test_independent_review_sql_races.py`
+- Create: `backend/tests/migration/test_independent_review_activation_migration.py`
+- Modify: `backend/tests/test_comments_service_mutations.py`
+- Modify: `backend/tests/test_comments_router.py`
+- Modify: `backend/tests/test_comments_permissions.py`
+- Modify: `backend/tests/test_comments_soft_delete.py`
+
+**Interfaces:**
+
+- `CommentCreate` adds optional `record_revision` and `review_revision_id`.
+- `ReviewIssueResolveRequest(record_revision, disposition, rationale)` and `ReviewIssueReopenRequest(record_revision, rationale)` implement the conditional bodies in the spec.
+- `CommentsService` mutation methods flush but never commit; routers own commit/rollback.
+- Blocking issue operations acquire the owning phenopacket `FOR UPDATE` before locking/loading the comment.
+- Expansion activation revision is `e0f422b00006`, down revision `d0f422b00005`.
+- Database functions/triggers lock the phenopacket row for blocking issue insert/resolve/reopen and active revision/state changes, then validate ownership/state/revision linkage; a deferred constraint trigger checks approved-plus-unresolved final state.
+
+- [ ] **Step 1: Write failing blocking-issue API/service tests**
+
+```python
+async def test_owner_cannot_resolve_or_delete_blocking_issue(...):
+    resolved = await client.post(f"/api/v2/comments/{issue.id}/resolve", headers=owner_headers, json={...})
+    deleted = await client.delete(f"/api/v2/comments/{issue.id}", headers=owner_headers)
+    assert resolved.status_code == 403
+    assert deleted.status_code == 409
+    assert deleted.json()["detail"]["code"] == "review_issue_delete_forbidden"
+
+
+async def test_ordinary_comment_routes_remain_backward_compatible(...):
+    assert (await client.post(f"/api/v2/comments/{comment.id}/resolve", headers=curator_headers)).status_code == 200
+```
+
+Cover unrelated revision nomination, non-review state creation, missing rationale/disposition, retraction as resolution, append-only resolution/reopen events, all legacy resolve/unresolve/delete routes, admin-owner bypass attempts, and router rollback on failures.
+
+- [ ] **Step 2: Run focused comment tests and confirm bypasses**
+
+Run: `cd backend && uv run pytest tests/test_blocking_review_issues.py tests/test_comments_service_mutations.py tests/test_comments_router.py -q`
+
+Expected: FAIL because current routes allow any curator resolve/unresolve and author/admin delete.
+
+- [ ] **Step 3: Implement phenopacket-first comment mutations**
+
+Load comment identity, acquire the phenopacket row lock by `record_id`, reload/lock the comment, then discriminate `review_revision_id`. Use Task 3 policy for blocking operations. Write a `CommentResolutionEvent` before updating the current projection. Reject DELETE on a blocking issue; do not soft-delete it.
+
+- [ ] **Step 4: Write failing raw-SQL race and activation-migration tests**
+
+Use two independent async connections/transactions and explicit barriers, not sleeps. Test all four orderings:
+
+```text
+Tx A: insert/reopen unresolved blocking issue -> hold -> commit
+Tx B: advance active revision to approved -> blocks -> rejects after A commit
+
+Tx A: approve/lock -> hold -> commit
+Tx B: insert/reopen issue -> blocks -> rejects review_closed after A commit
+```
+
+Also assert active `editing_revision_id` requires `draft_owner_id`, review revision belongs to the comment record, ambiguous owner preflight aborts, and downgrade refuses after a resolution event or v2 revision exists.
+
+- [ ] **Step 5: Implement activation migration and guarded downgrade**
+
+Create lock-taking trigger functions with one global order: `phenopackets FOR UPDATE` before revision/comment checks. Augment the existing pointer-state trigger rather than replacing it. Backfill missing active owners from recursive deterministic active-cycle ancestry; run a preflight that raises with record IDs when ancestry is ambiguous. Guard downgrade before dropping any audit/invariant object: it succeeds only when no blocking issue, resolution event, v2 ledger revision, or decision metadata exists. Do not modify existing revision rows to reconstruct roles/hashes.
+
+- [ ] **Step 6: Run migration, race, comment, and state tests**
+
+Run: `cd backend && uv run pytest tests/migration/test_independent_review_activation_migration.py tests/migration/test_independent_review_sql_races.py tests/test_blocking_review_issues.py tests/test_comments_service_mutations.py tests/test_comments_router.py tests/test_comments_permissions.py tests/test_comments_soft_delete.py tests/test_state_invariants.py -q`
+
+Expected: PASS with both raw-SQL commit orders proven.
+
+- [ ] **Step 7: Commit review issues and invariant activation**
+
+```bash
+git add backend/app/comments/schemas.py backend/app/comments/service.py backend/app/comments/routers.py \
+  backend/alembic/versions/e0f422b00006_activate_independent_review_invariants.py \
+  backend/tests/test_blocking_review_issues.py \
+  backend/tests/migration/test_independent_review_sql_races.py \
+  backend/tests/migration/test_independent_review_activation_migration.py \
+  backend/tests/test_comments_service_mutations.py backend/tests/test_comments_router.py \
+  backend/tests/test_comments_permissions.py backend/tests/test_comments_soft_delete.py
+git commit -m "feat(backend): gate approval on blocking review issues"
+```
+
+### Task 6: Build the server-driven review queue and coherent review context
+
+**Files:**
+
+- Create: `backend/app/phenopackets/review/repository.py`
+- Create: `backend/app/phenopackets/review/service.py`
+- Extend: `backend/app/phenopackets/review/schemas.py`
+- Create: `backend/app/phenopackets/routers/review.py`
+- Modify: `backend/app/phenopackets/routers/__init__.py`
+- Fix: `backend/app/phenopackets/routers/crud.py` effective-state projection
+- Create: `backend/tests/test_review_queue.py`
+- Create: `backend/tests/test_review_context.py`
+- Modify: `backend/tests/test_crud_state_branching.py`
+- Modify: `backend/tests/test_openapi_contract.py`
+
+**Interfaces:**
+
+- `ReviewRepository.list_queue(actor, query) -> tuple[list[ReviewQueueRow], int, StateCounts]` uses one centralized SQL effective-state expression for data/count filters.
+- `ReviewRepository.get_context(record_id, actor) -> ReviewContext | None` reads candidate, public baseline, issues, audit, contributors, and capability inputs coherently.
+- `ReviewService.semantic_changes(baseline, candidate) -> list[SemanticChange]` returns `section`, `operation`, JSON pointer `path`, `before`, and `after`.
+- `GET /api/v2/phenopackets/review-queue` and `GET /api/v2/phenopackets/{id}/review-context` implement the approved DTO/query contract.
+- Queue rows return both `physical_state` and `effective_state`; context and each blocking issue return actor-specific `ActionCapability` objects shaped as `{action, allowed, blocked_by}`.
+- Comment responses expose `review_revision_id`, `is_blocking_issue`, and append-only resolution events without changing the ordinary-comment contract.
+- Public CRUD filtering remains physical-head based; curator CRUD rows now include correct `effective_state`.
+
+- [ ] **Step 1: Write failing queue projection and authorization tests**
+
+```python
+async def test_queue_filters_published_record_by_in_review_effective_state(...):
+    response = await client.get(
+        "/api/v2/phenopackets/review-queue?filter[state]=in_review&page[number]=1&page[size]=10",
+        headers=reviewer_headers,
+    )
+    row = response.json()["data"][0]
+    assert row["physical_state"] == "published"
+    assert row["effective_state"] == "in_review"
+
+
+async def test_viewer_review_queue_is_not_discoverable(...):
+    assert response.status_code == 404
+```
+
+Cover pagination/count parity, allowlisted sorting, oldest-submission default, state/owner/eligibility/issues filters, search, state counts, own-row visibility with disabled capabilities, and old public-head retention.
+
+- [ ] **Step 2: Write failing coherent-context and semantic-change tests**
+
+Test new records (no baseline/all added), revised records (public head baseline), nested add/remove/replace, arrays, unknown extension fields, unresolved-first issues, contributor/submission audit, and actor-specific capability blockers.
+
+- [ ] **Step 3: Run queue/context tests and confirm endpoints are absent**
+
+Run: `cd backend && uv run pytest tests/test_review_queue.py tests/test_review_context.py tests/test_crud_state_branching.py -q`
+
+Expected: FAIL with 404/import errors.
+
+- [ ] **Step 4: Implement repository/service/router boundaries**
+
+Register the review router before the CRUD catch-all. Keep SQL expressions shared between row and count queries. Avoid per-row queries by joining/aggregating owner, submitted revision, blocking issue count, and contributors. Return typed Pydantic response models rather than ad hoc dicts.
+
+- [ ] **Step 5: Verify API, visibility, query-count, and OpenAPI tests**
+
+Run: `cd backend && uv run pytest tests/test_review_queue.py tests/test_review_context.py tests/test_crud_state_branching.py tests/test_visibility_endpoints.py tests/test_openapi_contract.py -q`
+
+Expected before snapshot refresh: only the snapshot equality test may fail due intentional API additions; vocabulary contract must pass. Snapshot refresh belongs to Task 12.
+
+- [ ] **Step 6: Commit the review API**
+
+```bash
+git add backend/app/phenopackets/review backend/app/phenopackets/routers/review.py \
+  backend/app/phenopackets/routers/__init__.py backend/app/phenopackets/routers/crud.py \
+  backend/tests/test_review_queue.py backend/tests/test_review_context.py \
+  backend/tests/test_crud_state_branching.py
+git commit -m "feat(backend): expose review queue and context"
+```
+
+### Task 7: Add frontend review transport, route guard, and navigation
+
+**Files:**
+
+- Create: `frontend/src/api/domain/reviews.js`
+- Modify: `frontend/src/api/domain/comments.js`
+- Modify: `frontend/src/api/domain/phenopackets.js`
+- Modify: `frontend/src/api/index.js`
+- Create: `frontend/tests/unit/api/reviews.spec.js`
+- Create: `frontend/tests/unit/api/comments.spec.js`
+- Modify: `frontend/tests/unit/api/phenopackets.spec.js`
+- Modify: `frontend/src/router/index.js`
+- Modify: `frontend/src/components/AppBar.vue`
+- Modify: `frontend/src/components/MobileDrawer.vue`
+- Create: `frontend/src/views/ReviewQueue.vue`
+- Create: `frontend/src/views/PhenopacketReview.vue`
+- Create: `frontend/tests/unit/router/reviewRoutes.spec.js`
+- Create: `frontend/tests/unit/components/ReviewNavigation.spec.js`
+
+**Interfaces:**
+
+```javascript
+getReviewQueue(params)
+getReviewContext(phenopacketId)
+transitionPhenopacket(id, toState, reason, recordRevision, conditional = {})
+createComment({ recordType, recordId, bodyMarkdown, mentionUserIds, recordRevision, reviewRevisionId })
+resolveComment(commentId, request?)
+unresolveComment(commentId, request?)
+```
+
+Routes `ReviewQueue` and `PhenopacketReview` use `requiresAuth: true, requiresCurator: true`. Export a testable `resolveRouteAccess(to, from, authStore)` and return `NotFound` for authenticated viewers. API modules serialize snake_case HTTP contracts and never infer policy.
+
+- [ ] **Step 1: Write failing transport serialization tests**
+
+Assert every queue parameter alias, encoded context ID, candidate ID/digest/attestation approval payload, approved ID/digest publication payload, omission of irrelevant fields, revision-bound issue creation, typed resolve/reopen bodies, and ordinary bodyless resolution.
+
+- [ ] **Step 2: Write failing guard/navigation tests**
+
+```javascript
+it('returns NotFound for a viewer without disclosing the review record', async () => {
+  expect(await resolveRouteAccess(reviewRoute, from, viewerStore)).toEqual({ name: 'NotFound' });
+});
+```
+
+Cover anonymous return URL, curator/admin access, desktop/mobile menu visibility, and drawer close.
+
+- [ ] **Step 3: Run focused frontend tests and confirm missing modules/routes**
+
+Run: `cd frontend && npm test -- tests/unit/api/reviews.spec.js tests/unit/api/comments.spec.js tests/unit/api/phenopackets.spec.js tests/unit/router/reviewRoutes.spec.js tests/unit/components/ReviewNavigation.spec.js`
+
+Expected: FAIL.
+
+- [ ] **Step 4: Implement transport, guards, and lazy routes**
+
+Use lazy route imports and create accessible loading shells for both route components so this commit remains buildable. Tasks 8 and 10 replace the shells with the queue and workspace. Preserve existing login initialization and admin guards.
+
+- [ ] **Step 5: Verify focused tests and lint**
+
+Run: `cd frontend && npm test -- tests/unit/api/reviews.spec.js tests/unit/api/comments.spec.js tests/unit/api/phenopackets.spec.js tests/unit/router/reviewRoutes.spec.js tests/unit/components/ReviewNavigation.spec.js && npm run lint:check`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit transport/navigation**
+
+```bash
+git add frontend/src/api frontend/src/router/index.js frontend/src/components/AppBar.vue \
+  frontend/src/components/MobileDrawer.vue frontend/src/views/ReviewQueue.vue \
+  frontend/src/views/PhenopacketReview.vue frontend/tests/unit/api \
+  frontend/tests/unit/router/reviewRoutes.spec.js frontend/tests/unit/components/ReviewNavigation.spec.js
+git commit -m "feat(frontend): add curator review routes and transport"
+```
+
+### Task 8: Implement URL-backed server review queue
+
+**Files:**
+
+- Create: `frontend/src/composables/useReviewQueue.js`
+- Modify: `frontend/src/views/ReviewQueue.vue`
+- Create: `frontend/tests/unit/composables/useReviewQueue.spec.js`
+- Create: `frontend/tests/unit/views/ReviewQueue.spec.js`
+
+**Interfaces:**
+
+```javascript
+useReviewQueue() => {
+  items, meta, loading, error,
+  page, pageSize, sort, search, tab, eligibility, issues,
+  load, retry, clearFilters, setTab
+}
+```
+
+Tab mapping is exact: `needs-review -> in_review`, `changes-requested -> changes_requested`, `approved -> approved`, and `my-drafts -> draft + owner=mine`. Queue DTO rows use `physical_state` and `effective_state`; the view always displays effective state.
+
+- [ ] **Step 1: Write failing composable tests**
+
+Cover URL hydration, exact tab filters, page reset on filter/search/tab changes, backend totals, stale-response suppression, and preserved error for retry.
+
+- [ ] **Step 2: Run composable tests and observe missing implementation**
+
+Run: `cd frontend && npm test -- tests/unit/composables/useReviewQueue.spec.js`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement queue state against `getReviewQueue`**
+
+Reuse `useTableUrlState` semantics. Track a monotonically increasing request token or AbortController so an older response cannot overwrite a newer one. Do no client sorting/pagination.
+
+- [ ] **Step 4: Write failing queue-view tests**
+
+Assert server totals, effective state, explicit focusable Review link, retry, true-empty versus filtered-empty messages, mobile state/issue count, and absence of bulk approval or row-click-only navigation.
+
+- [ ] **Step 5: Implement `ReviewQueue.vue`**
+
+Use `AppDataTable`, standard toolbar/pagination components, `StateBadge`, skeletons, alert/retry, and mobile slots. Keep query state shareable.
+
+- [ ] **Step 6: Verify queue tests and accessibility lint**
+
+Run: `cd frontend && npm test -- tests/unit/composables/useReviewQueue.spec.js tests/unit/views/ReviewQueue.spec.js && npm run lint:check`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the queue**
+
+```bash
+git add frontend/src/composables/useReviewQueue.js frontend/src/views/ReviewQueue.vue \
+  frontend/tests/unit/composables/useReviewQueue.spec.js frontend/tests/unit/views/ReviewQueue.spec.js
+git commit -m "feat(frontend): add server-driven review queue"
+```
+
+### Task 9: Implement review context, semantic comparison, and blocking issues
+
+**Files:**
+
+- Create: `frontend/src/composables/useReviewContext.js`
+- Create: `frontend/src/composables/useReviewIssues.js`
+- Create: `frontend/src/components/review/SemanticDiff.vue`
+- Create: `frontend/src/components/review/CandidateSnapshot.vue`
+- Create: `frontend/src/components/review/ReviewIssuesPanel.vue`
+- Create: `frontend/src/components/review/ReviewIssueDialog.vue`
+- Create: `frontend/tests/unit/composables/useReviewContext.spec.js`
+- Create: `frontend/tests/unit/composables/useReviewIssues.spec.js`
+- Create: `frontend/tests/unit/components/review/SemanticDiff.spec.js`
+- Create: `frontend/tests/unit/components/review/CandidateSnapshot.spec.js`
+- Create: `frontend/tests/unit/components/review/ReviewIssuesPanel.spec.js`
+- Create: `frontend/tests/unit/components/review/ReviewIssueDialog.spec.js`
+
+**Interfaces:**
+
+```javascript
+useReviewContext(id) => {
+  context, loading, error, conflict, liveMessage,
+  load, reload, markConflict, clearConflict
+}
+
+useReviewIssues({ recordId, recordRevision, candidateRevisionId, reload }) => {
+  submitting, error, createIssue, resolveIssue, reopenIssue
+}
+```
+
+The backend semantic diff is authoritative. `CandidateSnapshot` reuses existing subject, phenotype, disease, interpretation, measurement, and metadata cards. Each blocking issue consumes its own backend-returned capabilities; it never inherits ordinary comment author/admin deletion rules.
+
+- [ ] **Step 1: Write failing context/diff tests**
+
+Cover one coherent load, unavailable issue status failing closed, add/remove/change text plus icons, before/after rendering without color dependence, null baseline “New phenopacket”, complete candidate cards, and raw extension content.
+
+- [ ] **Step 2: Implement the context composable and display components**
+
+Do not compute a client diff. Sanitize rendered values through existing utilities and provide accessible labels for JSON pointers/operations.
+
+- [ ] **Step 3: Write failing blocking-issue tests**
+
+Cover exact candidate binding, disposition allowlist, rationale, unresolved-first ordering, server capabilities, no Delete action, reload after mutation, and issue-count live announcement.
+
+- [ ] **Step 4: Implement issue composable/panel/dialog**
+
+Use Task 7 transport. Preserve ordinary `DiscussionTab` unchanged except for shared response-field compatibility.
+
+- [ ] **Step 5: Verify focused tests, format, and lint**
+
+Run: `cd frontend && npm test -- tests/unit/composables/useReviewContext.spec.js tests/unit/composables/useReviewIssues.spec.js tests/unit/components/review && npm run format:check && npm run lint:check`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit comparison/issues**
+
+```bash
+git add frontend/src/composables/useReviewContext.js frontend/src/composables/useReviewIssues.js \
+  frontend/src/components/review frontend/tests/unit/composables/useReviewContext.spec.js \
+  frontend/tests/unit/composables/useReviewIssues.spec.js frontend/tests/unit/components/review
+git commit -m "feat(frontend): add review comparison and issues"
+```
+
+### Task 10: Implement exact-revision decisions and assemble the responsive workspace
+
+**Files:**
+
+- Create: `frontend/src/composables/useReviewActions.js`
+- Create: `frontend/src/components/review/ReviewActionPanel.vue`
+- Create: `frontend/src/components/review/ReviewDecisionDialog.vue`
+- Create: `frontend/src/components/review/ReviewHeader.vue`
+- Modify: `frontend/src/views/PhenopacketReview.vue`
+- Create: `frontend/tests/unit/composables/useReviewActions.spec.js`
+- Create: `frontend/tests/unit/components/review/ReviewActionPanel.spec.js`
+- Create: `frontend/tests/unit/components/review/ReviewDecisionDialog.spec.js`
+- Create: `frontend/tests/unit/components/review/ReviewHeader.spec.js`
+- Create: `frontend/tests/unit/views/PhenopacketReview.spec.js`
+
+**Interfaces:**
+
+```javascript
+useReviewActions(id, contextRef, { reload, onCompleted }) => {
+  pendingAction, submitting, error, conflict,
+  approve, requestChanges, reopenApproved, publish, withdraw
+}
+```
+
+Approval payloads originate only from loaded candidate ID/digest; publication originates only from loaded approval ID/digest. Backend capabilities drive every action and denial reason.
+
+- [ ] **Step 1: Write failing action tests**
+
+Cover unknown/open issue disabling, both attestations and rationale, server self-review/contributor explanations, publish capability, structured conflict mapping, no retry after conflict, unresolved count copy, and focus restoration.
+
+- [ ] **Step 2: Implement action composable and dialogs**
+
+Map `revision_mismatch` and `review_revision_mismatch` to a reload-required state. Never synthesize an approval/publication identity from route or current record state.
+
+- [ ] **Step 3: Write failing workspace/header tests**
+
+Cover audit metadata, preserved back-to-queue query, skeleton/retry/private-404 states, refresh after mutation, conflict replacement, candidate/raw JSON/history views, right rail desktop layout, and single-column mobile order/sticky safe-area controls.
+
+- [ ] **Step 4: Assemble `PhenopacketReview.vue`**
+
+Desktop main column contains changes/candidate/JSON/history; the right rail contains review issues, discussion summary, and decisions. Mobile order is header, content tabs, issues, decisions. Use `aria-live="polite"`, one `h1`, 44px targets, focus trap/return, and text plus icons.
+
+- [ ] **Step 5: Verify workspace tests and build**
+
+Run: `cd frontend && npm test -- tests/unit/composables/useReviewActions.spec.js tests/unit/components/review tests/unit/views/PhenopacketReview.spec.js && npm run lint:check && npm run build`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the workspace**
+
+```bash
+git add frontend/src/composables/useReviewActions.js frontend/src/components/review \
+  frontend/src/views/PhenopacketReview.vue frontend/tests/unit/composables/useReviewActions.spec.js \
+  frontend/tests/unit/components/review frontend/tests/unit/views/PhenopacketReview.spec.js
+git commit -m "feat(frontend): add exact-revision review workspace"
+```
+
+### Task 11: Remove local transition policy and close legacy UI/API bypasses
+
+**Files:**
+
+- Modify: `frontend/src/components/state/TransitionMenu.vue`
+- Modify: `frontend/src/components/state/TransitionModal.vue`
+- Modify: `frontend/src/composables/usePhenopacketState.js`
+- Modify: `frontend/src/views/PagePhenopacket.vue`
+- Modify: `frontend/src/components/curation/reports/ReportObservationWorkspace.vue`
+- Modify their existing Vitest files
+
+**Interfaces:**
+
+- `TransitionMenu` accepts only backend `capabilities` and emits a selected simple transition.
+- Approval, approved reopening, and publication route to the focused workspace because the generic dialog cannot safely construct exact revision/digest/attestation payloads.
+- `PagePhenopacket` exposes “Open review workspace” in active review states.
+- Direct publication in `ReportObservationWorkspace` is removed and replaced with an open-review affordance.
+
+- [ ] **Step 1: Replace local-matrix tests with capability tests**
+
+Assert only server capabilities render, denial reasons display, conditional actions route to review workspace, and no `RULES`, `role`, or `isOwner` props remain.
+
+- [ ] **Step 2: Write failing detail/report-workspace bypass tests**
+
+Assert active review records link to the workspace and report curation can no longer call publication without approved ID/digest.
+
+- [ ] **Step 3: Implement server-authoritative consumers**
+
+Preserve legacy state labels/history. Do not recreate policy in computed properties.
+
+- [ ] **Step 4: Run focused and full affected unit tests**
+
+Run: `cd frontend && npm test -- tests/unit/components/state tests/unit/views/PagePhenopacket.spec.js tests/unit/components/curation/ReportObservationWorkspace.spec.js`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit bypass removal**
+
+```bash
+git add frontend/src/components/state frontend/src/composables/usePhenopacketState.js \
+  frontend/src/views/PagePhenopacket.vue frontend/src/components/curation/reports/ReportObservationWorkspace.vue \
+  frontend/tests/unit/components/state frontend/tests/unit/views/PagePhenopacket.spec.js \
+  frontend/tests/unit/components/curation/ReportObservationWorkspace.spec.js
+git commit -m "refactor(frontend): consume server review capabilities"
+```
+
+### Task 12: Update contracts, seed distinct actors, and prove the lifecycle end to end
+
+**Files:**
+
+- Modify: `backend/scripts/seed_dev_users.py`
+- Modify: `backend/tests/test_seed_dev_users.py`
+- Refresh: `mcp/contract/openapi.snapshot.json`
+- Modify: `backend/tests/test_openapi_contract.py`
+- Modify: `frontend/tests/e2e/helpers/auth.js`
+- Create: `frontend/tests/e2e/independent-review.spec.js`
+- Create: `frontend/tests/e2e/review-workspace-accessibility.spec.js`
+- Modify: `frontend/tests/e2e/state-lifecycle.spec.js`
+- Modify: `frontend/tests/e2e/comments.spec.js`
+- Modify: `frontend/tests/e2e/dual-read-invariant.spec.js`
+- Modify: `frontend/tests/e2e/README.md`
+
+**Interfaces:**
+
+- Seed two distinct active verified curator fixtures plus an admin without weakening production authentication.
+- Add `loginAsCuratorA` and `loginAsCuratorB`, using `E2E_CURATOR_A_*`/`E2E_CURATOR_B_*` with deterministic development-only fallbacks.
+- OpenAPI documents queue/context DTOs, conditional transition fields, ordinary/bodyless and blocking/typed comment mutations, structured errors, and actor capabilities.
+
+- [ ] **Step 1: Write/update seeder and OpenAPI contract tests**
+
+Assert both curators are distinct/active/verified and snapshot exposes the new request/response/error contracts. Run focused backend tests and confirm intentional snapshot drift.
+
+- [ ] **Step 2: Refresh the deterministic OpenAPI snapshot under CI Python 3.12**
+
+Run: `cd backend && uv run python scripts/dump_openapi.py > ../mcp/contract/openapi.snapshot.json` only after the live schema tests are correct. Inspect the diff and verify only intentional review-contract changes.
+
+- [ ] **Step 3: Replace same-admin lifecycle assumptions**
+
+Update existing backend/E2E fixtures so owner, reviewer, and publisher are distinct where policy requires. Do not weaken assertions to accept both old and new workflows.
+
+- [ ] **Step 4: Write the principal Playwright lifecycle**
+
+Prove: curator A creates/submits; anonymous/viewer cannot discover; A cannot decide; curator B finds through server filters, raises an issue, requests changes, resolves with disposition/rationale, approves exact revision/digest; content stays private until admin publication; a second cycle retains the old public head until replacement publication.
+
+- [ ] **Step 5: Add conflicts, reopening, keyboard, and mobile E2E coverage**
+
+Cover approved-to-changes-requested, stale revision/digest reload-required state, keyboard-only queue/issue/decision path, 375×812 layout/no overflow, named controls, focus behavior, and non-color diff cues.
+
+- [ ] **Step 6: Run focused backend and E2E contracts**
+
+Run:
+
+```bash
+cd backend && uv run pytest tests/test_openapi_contract.py tests/test_seed_dev_users.py tests/test_api_transitions.py -q
+cd frontend && npm run e2e -- tests/e2e/independent-review.spec.js tests/e2e/review-workspace-accessibility.spec.js tests/e2e/state-lifecycle.spec.js tests/e2e/dual-read-invariant.spec.js
+```
+
+Expected: PASS with genuinely distinct authenticated actors.
+
+- [ ] **Step 7: Commit contracts and E2E proof**
+
+```bash
+git add backend/scripts/seed_dev_users.py backend/tests/test_seed_dev_users.py \
+  backend/tests/test_openapi_contract.py mcp/contract/openapi.snapshot.json \
+  frontend/tests/e2e/helpers/auth.js frontend/tests/e2e/independent-review.spec.js \
+  frontend/tests/e2e/review-workspace-accessibility.spec.js \
+  frontend/tests/e2e/state-lifecycle.spec.js frontend/tests/e2e/comments.spec.js \
+  frontend/tests/e2e/dual-read-invariant.spec.js frontend/tests/e2e/README.md
+git commit -m "test(review): prove independent curation lifecycle"
+```
+
+### Task 13: Verify, document, adversarially review, and prepare the PR
+
+**Files:**
+
+- Update: `.planning/plans/2026-08-14-independent-phenopacket-review-plan.md` checkboxes
+- Create: `.planning/reviews/2026-08-14-independent-phenopacket-review-pr-review.md`
+- Create: `docs/curation-review-workflow.md`
+
+**Interfaces:**
+
+- Verification evidence maps every acceptance criterion in the design spec to a test, runtime check, migration check, or rendered behavior.
+- One independent `gpt-5.6-sol` xhigh reviewer performs the requested one-pass adversarial PR review; it reports only and does not edit.
+- The primary agent adjudicates every finding, fixes accepted findings with TDD, reruns relevant/full checks, and records dispositions once; there is no second independent review pass.
+
+- [ ] **Step 1: Run backend formatting, lint, typing, migrations, and full tests**
+
+```bash
+make lint
+make typecheck
+make test
+cd backend && uv run alembic heads
+```
+
+Exercise expand -> backend-compatible -> activation -> head and guarded downgrade behavior against a disposable/test database. Expected head is the activation revision.
+
+The rollout order is exact: apply `d0f422b00005`, deploy the v2-writing backend, then apply `e0f422b00006`. The migration proof must also demonstrate empty-data downgrade success and post-audit downgrade refusal.
+
+- [ ] **Step 2: Run frontend formatting, lint, tests, build, and focused E2E**
+
+```bash
+cd frontend
+npm run format:check
+npm run lint:check
+npm test
+npm run build
+npm run e2e -- tests/e2e/independent-review.spec.js tests/e2e/review-workspace-accessibility.spec.js
+```
+
+- [ ] **Step 3: Perform runtime smoke checks**
+
+Start the isolated backend/frontend against migrated dev services. Verify queue loading, distinct-user decisions, issue gate, public privacy before publication, old-head behavior during re-review, exact digest/approval/publication equality, desktop/mobile rendering, and structured conflicts. Capture only non-sensitive evidence.
+
+- [ ] **Step 4: Run the requirement-by-requirement completion audit**
+
+For every design acceptance criterion, record authoritative evidence and mark proven/missing/contradicted. Continue implementation for every missing or indirect item; do not infer completion from broad green suites.
+
+Write `docs/curation-review-workflow.md` with the operator-visible state lifecycle, independent-review exclusions, blocking-issue dispositions, exact-revision sign-off contract, publication boundary, rollout order, and guarded rollback behavior.
+
+- [ ] **Step 5: Dispatch the one-pass adversarial PR reviewer**
+
+Give the reviewer the design, spec-review artifact, implementation plan, complete diff, test evidence, and current code. Save its report and primary-agent dispositions in `.planning/reviews/2026-08-14-independent-phenopacket-review-pr-review.md`.
+
+- [ ] **Step 6: Address accepted review findings with focused failing tests and rerun all impacted checks**
+
+Commit fixes intentionally. Document any rejected finding with code/test evidence, not preference.
+
+- [ ] **Step 7: Publish the branch and open a draft PR**
+
+Use the repository's GitHub publication workflow: inspect status/diff, commit remaining intentional changes, push `feat/peer-review-workflow`, open a draft PR with design/verification/review links, and never include secrets or local environment symlinks.
+
+- [ ] **Step 8: Inspect GitHub Actions and drive the PR green**
+
+Inspect every required check. For any failure, use systematic debugging, fix with a regression test, push, and re-run until all required Actions are green or a deliberate external blocker is documented.
+
+- [ ] **Step 9: Final commit of planning/review evidence**
+
+```bash
+git add .planning/plans/2026-08-14-independent-phenopacket-review-plan.md \
+  .planning/reviews/2026-08-14-independent-phenopacket-review-pr-review.md \
+  docs/curation-review-workflow.md
+git commit -m "docs(planning): record independent review delivery"
+```

--- a/.planning/reviews/2026-08-14-independent-phenopacket-review-spec-review.md
+++ b/.planning/reviews/2026-08-14-independent-phenopacket-review-spec-review.md
@@ -1,0 +1,77 @@
+# Independent Phenopacket Review Spec — One-Pass Review
+
+**Date:** 2026-08-14
+
+**Reviewed commit:** `07d27c0`
+
+**Reviewed artifact:** `.planning/specs/2026-08-14-independent-phenopacket-review-design.md`
+
+**Reviewer:** independent `gpt-5.6-sol` reviewer at `xhigh` reasoning. Opus 5 was requested but is not available in this environment; this was the strongest available substitute disclosed to the user.
+
+**Review mode:** One pass, report-only. No reviewer edits and no second review pass.
+
+## Outcome
+
+The reviewer reported four high-severity and one medium-severity actionable findings. All five were accepted and addressed by the primary agent before implementation planning.
+
+## Findings and disposition
+
+### 1. Exact approved snapshot lacked a full-content digest contract — High
+
+The initial spec relied partly on the existing projection hash even though it excludes extension content, and current publication canonicalizes content after approval.
+
+**Disposition:** Accepted.
+
+The revised spec now:
+
+- defines a versioned canonical full-`content_jsonb` SHA-256 digest;
+- canonicalizes and validates before entering `in_review`;
+- requires expected revision IDs and full-content digests for approval/publication;
+- stores the reviewed digest in decision metadata;
+- versions the ledger hash and includes full-content digest, role snapshot, and decision metadata;
+- requires publication to copy approved content unchanged;
+- adds extension-only and publish-time mutation regression tests.
+
+### 2. Deferred constraint alone did not prevent direct-writer write skew — High
+
+Two raw transactions could each pass a deferred cross-table check under `READ COMMITTED` without seeing the other's uncommitted change.
+
+**Disposition:** Accepted.
+
+The revised spec requires lock-taking triggers on both blocking-issue mutations and active revision/state changes. All supported application and direct SQL writers acquire the same phenopacket row lock before validation. The deferred trigger is only a final invariant check. Two-connection raw-SQL race tests are mandatory in both commit orders.
+
+### 3. Existing comment endpoints remained policy bypasses — High
+
+The initial spec did not fully define how generic resolve/unresolve/delete routes behave after a comment becomes a blocking review issue.
+
+**Disposition:** Accepted.
+
+The revised spec defines conditional request schemas and behavior for create, resolve, reopen, retract, and delete. Blocking issues require optimistic record context, reviewer eligibility, rationale/disposition, and phenopacket-first locking. DELETE is forbidden for blocking issues, including for admins; retraction is an audited resolution disposition. Every legacy mutation route receives policy tests.
+
+### 4. Conventional downgrade could erase the sole sign-off audit — High
+
+A reversible migration that drops decision metadata or resolution events would leave published records without their authoritative review audit.
+
+**Disposition:** Accepted.
+
+The revised spec uses expand/activate migrations. Code can roll back while the expanded schema remains. Schema downgrade refuses after any blocking issue, resolution event, v2 ledger revision, or decision metadata exists. Guarded downgrade behavior is tested.
+
+### 5. Historical role backfill violated append-only history and implied false certainty — Medium
+
+Updating old revision rows conflicts with the append-only trigger, while copying a user's current role would not prove their historical role.
+
+**Disposition:** Accepted.
+
+The revised spec leaves historical actor-role/full-digest/version fields unset. UI fallback is explicitly labelled as not recorded at decision time. Existing v1 ledger rows are never rewritten.
+
+## Residual risks accepted by product design
+
+- One independent sign-off is proportionate local quality control, not ClinGen panel consensus.
+- Admins are curator-capable by HNF1B-DB policy; role snapshot and attestation make this explicit.
+- Lock-taking database triggers add operational complexity but are required by the direct-writer invariant.
+- Open queues do not solve workload balancing; assignment remains a future extension.
+
+## Gate result
+
+**Pass after primary-agent corrections.** The written spec is ready for user confirmation and implementation planning. This review intentionally concludes the requested single spec-review pass.
+

--- a/.planning/specs/2026-08-14-independent-phenopacket-review-design.md
+++ b/.planning/specs/2026-08-14-independent-phenopacket-review-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-14
 
-**Status:** User-approved design; independent spec review pending
+**Status:** User-approved design; independent review findings addressed; awaiting written-spec confirmation
 
 **Scope:** Phenopacket curation workflow, review audit, curator-facing review queue/workspace, and publication gate
 
@@ -70,11 +70,11 @@ The following are deliberate HNF1B-DB product policies rather than universal bio
 
 1. Make self-review impossible at every API and UI entry point.
 2. Let any eligible curator/admin review an open submission without assignment.
-3. Freeze candidate content during review and bind sign-off to an exact revision/hash.
+3. Canonicalize before review, freeze candidate content during review, and bind sign-off to an exact revision and full-content digest.
 4. Require all blocking review issues to have a recorded disposition before approval.
 5. Keep ordinary discussion separate from blocking review issues.
 6. Give curators a server-driven queue and focused before/after review workspace.
-7. Preserve old public content during re-review and publish only the approved snapshot.
+7. Preserve old public content during re-review and publish the approved content byte-for-byte under the canonical JSON contract.
 8. Keep the revision ledger as the sole sign-off audit source; avoid a parallel review-state model.
 9. Close comment/approval races for HTTP and direct database writers.
 10. Preserve pagination, filtering, sorting, accessibility, mobile behavior, and fail-closed error handling.
@@ -108,13 +108,13 @@ For a published record with an active edit, `phenopackets.state` remains `publis
 
 | From | To | Actor and conditions |
 | --- | --- | --- |
-| `draft` | `in_review` | owner, or admin acting on behalf; reason required |
-| `changes_requested` | `in_review` | owner, or admin acting on behalf; reason required |
+| `draft` | `in_review` | owner, or admin acting on behalf; publish canonicalization/validation succeeds; reason required |
+| `changes_requested` | `in_review` | owner, or admin acting on behalf; publish canonicalization/validation succeeds; reason required |
 | `in_review` | `draft` | owner withdraws; admin emergency withdrawal remains audited |
 | `in_review` | `changes_requested` | eligible independent curator/admin; reason required |
-| `in_review` | `approved` | eligible independent curator/admin; zero open blocking issues; attestation and reason required |
+| `in_review` | `approved` | eligible independent curator/admin; exact candidate revision/digest; zero open blocking issues; attestation and reason required |
 | `approved` | `changes_requested` | eligible independent curator/admin reopens before publication; reason required |
-| `approved` | `published` | admin only; exact approved revision/hash required |
+| `approved` | `published` | admin only; exact approved revision/full-content digest required; content copied unchanged |
 | any active state | `archived` | admin only; reason required |
 
 No transition bypass exists for admins when the rule concerns reviewer independence.
@@ -150,6 +150,7 @@ Resolution and reopening append an immutable event containing:
 
 - issue ID;
 - action (`resolved` or `reopened`);
+- resolution disposition (`addressed`, `accepted_with_rationale`, `retracted`, or `superseded`) when resolving;
 - disposition/rationale;
 - authenticated actor ID and role snapshot;
 - server timestamp.
@@ -160,17 +161,19 @@ The comment row retains `resolved_at` and `resolved_by_id` as the current-state 
 
 Review-issue creation, resolution, reopening, approval, reopen-approved, and publication acquire the same phenopacket row lock before reading or changing review state. Locks are always acquired phenopacket-first, then comment/revision, to prevent deadlocks.
 
+This lock protocol is enforced for every writer, not merely application services. Database triggers on blocking-issue insert/reopen/resolve and on active-revision/state changes first acquire `SELECT ... FOR UPDATE` on the owning phenopacket row, then validate the operation. Direct SQL writers therefore serialize on the same record-scoped lock. A direct writer that bypasses or disables those triggers is outside the supported write contract.
+
 Approval under the lock verifies:
 
 1. optimistic record revision;
 2. reviewer eligibility;
-3. active `in_review` revision identity;
+3. active `in_review` revision identity and full-content digest;
 4. zero live unresolved blocking issues;
 5. valid attestation.
 
 If issue creation wins the lock, approval observes it and returns `409 unresolved_review_issues`. If approval wins, the waiting issue creation observes `approved` and returns `409 review_closed`. No committed state may contain an approved active revision and a newly created unresolved blocking issue.
 
-A deferred database constraint/trigger enforces the approved-plus-unresolved invariant for non-HTTP writers. Application locking remains necessary to produce deterministic errors and avoid retry-only behavior.
+A deferred database constraint trigger performs a final approved-plus-unresolved check after the lock-taking triggers have serialized non-HTTP writers. The deferred check alone is not treated as concurrency protection. Application locking remains necessary to produce deterministic errors and avoid retry-only behavior.
 
 ## 6. Audit and storage changes
 
@@ -186,37 +189,51 @@ comment_resolution_events
     id BIGINT PK
     comment_id BIGINT NOT NULL REFERENCES comments(id) ON DELETE RESTRICT
     action TEXT NOT NULL CHECK action IN ('resolved', 'reopened')
+    disposition TEXT NULL
     rationale TEXT NOT NULL
     actor_id BIGINT NOT NULL REFERENCES users(id) ON DELETE RESTRICT
     actor_role TEXT NOT NULL
     created_at TIMESTAMPTZ NOT NULL
 ```
 
-A partial index covers live unresolved blocking issues by record. A trigger verifies that `review_revision_id` belongs to the comment's phenopacket record and represents a review snapshot. Historical comments remain `NULL` and non-blocking.
+A check constraint requires an allowlisted disposition for `resolved` events and `NULL` disposition for `reopened` events. A partial index covers live unresolved blocking issues by record. Lock-taking triggers verify that `review_revision_id` belongs to the comment's phenopacket record and represents a review snapshot. Historical comments remain `NULL` and non-blocking.
 
 ### 6.2 Revision decision metadata
 
-Extend revision audit with an actor-role snapshot and structured decision metadata:
+Extend revision audit with a deterministic full-content digest, versioned ledger payload, actor-role snapshot, and structured decision metadata:
 
 ```text
 phenopacket_revisions.actor_role TEXT NULL
 phenopacket_revisions.decision_metadata JSONB NULL
+phenopacket_revisions.content_sha256 TEXT NULL
+phenopacket_revisions.ledger_version INTEGER NULL
 ```
 
-New revisions always snapshot `actor_role`. An approval revision stores a versioned payload equivalent to:
+`content_sha256` is SHA-256 over the complete `content_jsonb` serialized by the project's versioned canonical JSON function, including `hnf1bCuration` and extension fields. It is not the existing projection-only `projection_hash`. Every new revision records `content_sha256`, `actor_role`, and `ledger_version=2`. The v2 ledger hash covers parent/revision/state/event fields, full-content digest, actor role, and a canonical digest of decision metadata. Existing v1 hashes remain valid and are never rewritten.
+
+An approval revision stores a versioned payload equivalent to:
 
 ```json
 {
   "schemaVersion": 1,
   "reviewedRevisionId": 123,
+  "reviewedContentSha256": "sha256:...",
   "independentReview": true,
   "noUnmanagedConflict": true
 }
 ```
 
-The existing revision actor, timestamp, reason, parent, state, content, projection hash, and ledger hash remain authoritative. No mutable `reviewed_by` column or separate sign-off table is introduced.
+The existing revision actor, timestamp, reason, parent, state, content, projection hash, and ledger hash remain authoritative. The full-content digest closes the extension-field gap left by `projection_hash`. No mutable `reviewed_by` column or separate sign-off table is introduced.
 
-Existing revisions may backfill `actor_role` from current user roles for display, but the migration and documentation must label those values as reconstructed rather than historically guaranteed.
+Historical `actor_role`, `content_sha256`, and `ledger_version` remain `NULL`/v1 unless they were captured originally. The migration does not disable append-only protection or reconstruct a historical role from a user's current role. Display falls back to the current user relationship with an explicit “role at decision not recorded” label; it never presents that fallback as an attested snapshot.
+
+### 6.3 Canonical freeze and exact publication
+
+Publish canonicalization and publishability validation run while transitioning `draft` or `changes_requested` to `in_review`, before the candidate becomes reviewable. The resulting `in_review` revision is the exact canonical snapshot shown to reviewers. If canonicalization changes content, that canonical content, revision ID, and digest are returned to the submitter and review workspace.
+
+Approval requires the client-observed candidate revision ID and full-content digest, rechecks them under the row lock, and copies the candidate content unchanged into the approval revision. Publication requires the approved revision ID and digest, rechecks them under the lock, and copies approved `content_jsonb` unchanged into the new public-head revision. Publication performs validation assertions only; it must not canonicalize, default, normalize, timestamp, or otherwise mutate clinical or extension content.
+
+Any server-derived publication metadata must therefore be deterministic and present before review, or stored outside `content_jsonb` as publication audit metadata. Tests compare canonical serialized full content—not only projection fields—across candidate, approval, and published revisions.
 
 ### 6.3 Ownership integrity
 
@@ -263,9 +280,46 @@ The endpoint acquires a read lock compatible with the write protocol or uses one
 
 ### 7.4 Mutations
 
-Continue using `POST /api/v2/phenopackets/{id}/transitions`, adding structured approval attestation when `to_state='approved'`. The server rejects irrelevant or missing attestation fields.
+Continue using `POST /api/v2/phenopackets/{id}/transitions`. Approval additionally requires `candidate_revision_id`, `candidate_content_sha256`, and structured attestation. Publication additionally requires `approved_revision_id` and `approved_content_sha256`. The server rejects irrelevant, missing, or stale conditional fields.
 
-Extend comment mutations with `record_revision` and `review_revision_id` for blocking issues. The server verifies both values and never trusts a client-nominated unrelated revision.
+The existing comment routes remain, with explicit discriminated behavior:
+
+- `POST /api/v2/comments`: ordinary discussion keeps its existing body. A blocking issue additionally supplies `record_revision` and `review_revision_id`; the server verifies both and the reviewer's eligibility.
+- `POST /api/v2/comments/{id}/resolve`: ordinary discussion keeps backward-compatible optional input. A blocking issue requires `record_revision`, an allowlisted `disposition`, and a non-empty `rationale`; it uses phenopacket-first locking and independent-reviewer checks.
+- `POST /api/v2/comments/{id}/unresolve`: ordinary discussion keeps backward-compatible optional input. For a blocking issue this means reopen and requires `record_revision` plus a non-empty `rationale`; it uses the same locking and eligibility checks.
+- `DELETE /api/v2/comments/{id}`: continues to soft-delete ordinary discussion. It rejects blocking issues with `409 review_issue_delete_forbidden`, including for admins and the issue author.
+
+Blocking-issue retraction is `resolve` with `disposition='retracted'`; it is never deletion. The server loads the comment, discriminates on `review_revision_id`, and never trusts a client-nominated unrelated revision. Every legacy mutation route is covered by blocking-issue policy tests.
+
+Conditional request fields use explicit schemas:
+
+```text
+ApprovalAttestation
+    independent_review: Literal[true]
+    no_unmanaged_conflict: Literal[true]
+
+TransitionRequest additions
+    candidate_revision_id: PositiveInt | null
+    candidate_content_sha256: constrained sha256 string | null
+    approved_revision_id: PositiveInt | null
+    approved_content_sha256: constrained sha256 string | null
+    attestation: ApprovalAttestation | null
+
+CommentCreate additions
+    record_revision: NonNegativeInt | null
+    review_revision_id: PositiveInt | null
+
+ReviewIssueResolveRequest
+    record_revision: NonNegativeInt
+    disposition: addressed | accepted_with_rationale | retracted | superseded
+    rationale: string[1..500]
+
+ReviewIssueReopenRequest
+    record_revision: NonNegativeInt
+    rationale: string[1..500]
+```
+
+For ordinary comments, resolve/unresolve accept no body or an ignored-compatible empty body. For blocking issues the matching typed body is mandatory after the server loads and discriminates the comment. OpenAPI documents both cases and the API contract snapshot is refreshed.
 
 All curator-facing transition controls consume server-returned capabilities; the duplicated matrix in `TransitionMenu.vue` is removed.
 
@@ -279,6 +333,7 @@ Stable error codes include:
 - `unresolved_review_issues` with a count;
 - `review_revision_mismatch`;
 - `review_closed`;
+- `review_issue_delete_forbidden`;
 - `attestation_required`;
 - existing `revision_mismatch` and `invalid_transition`.
 
@@ -335,22 +390,24 @@ After publication, public detail may show “Independently reviewed” and the a
 1. Public queries continue to dereference only `head_published_revision_id`.
 2. Queue/context endpoints require active curator/admin role and never expose candidate data to viewers.
 3. Public search, aggregates, exports, and MCP results remain pinned to published heads during re-review.
-4. Publication canonicalization must not alter approved clinical content silently; any derived metadata change is hashed and tested.
+4. Canonicalization occurs before `in_review`; approval and publication assert the stored full-content digest and never alter approved clinical or extension content.
 5. Reviewer identity comes from authentication, never request bodies.
 6. Logs record transition/error codes and record/revision IDs but never clinical content or comment bodies.
 7. Metrics cover queue depth/age by state, approval latency, request-changes rate, and gate failures without patient-identifying labels.
 
 ## 10. Migration and rollout
 
-1. Add schema columns, resolution-event table, indexes, triggers, and constraints in one reversible Alembic migration based on the current head.
+1. Use an expand migration for nullable columns/table/indexes and an activation migration for lock-taking triggers, constraints, and ownership enforcement, both based on the current head.
 2. Preflight active edit cycles and deterministically backfill missing owners; abort with record IDs on ambiguity.
-3. Leave historical comments non-blocking and report their count.
+3. Leave historical comments non-blocking and historical revision audit fields unset; report their counts.
 4. Deploy backend schema/API support before enabling frontend navigation.
 5. Keep legacy `changes_requested` and history rendering throughout rollout.
 6. Validate queue counts against direct effective-state SQL before enabling decisions.
 7. Exercise the complete two-curator lifecycle in staging/local production-like configuration.
 
-No destructive data cleanup is part of the migration.
+Rollback is expand/activate, not destructive schema reversal. Application code may roll back while the added schema and audit rows remain. Alembic downgrade must refuse once any blocking issue, resolution event, v2 ledger revision, or decision metadata exists. Before activation and before any such data exists, downgrade may remove the unused expansion. This matches the repository precedent for refusing unsafe audit/invariant downgrades.
+
+No destructive data cleanup or audit erasure is part of migration or rollback.
 
 ## 11. Testing strategy
 
@@ -359,17 +416,20 @@ No destructive data cleanup is part of the migration.
 - pure policy matrix for every role, state, owner, contributor, and NULL-owner combination;
 - non-author curator/admin approval and request-changes;
 - author and content-contributor self-review rejection;
-- admin-only publication and exact approved revision/hash;
+- pre-review canonicalization and full-content digest stability, including extension-only changes;
+- admin-only publication and byte-for-byte canonical equality with the approved full-content snapshot;
 - ordinary, blocking, resolved, reopened, retracted, and historical comments;
 - required resolution rationale and approval attestation;
 - request-changes/resubmission with outstanding issues;
 - approved-to-changes-requested reopening;
-- two-real-session issue-create versus approve and issue-reopen versus approve in both lock orders;
+- two-real-session service-level issue-create versus approve and issue-reopen versus approve in both lock orders;
+- two-connection raw-SQL issue/approval races in both commit orders, proving lock-taking triggers prevent write skew;
 - concurrent approvals/request-changes with exactly one winner;
 - queue projection, counts, search, allowlisted sorting, and pagination;
 - physical `published` plus effective `in_review` projection;
 - new-record privacy and old-public-head visibility throughout re-review;
-- migration upgrade/downgrade, deterministic owner backfill, ambiguity failure, triggers, and legacy comment handling;
+- migration expand/activate, guarded downgrade refusal after audit data exists, deterministic owner backfill, ambiguity failure, lock-taking/deferred triggers, and legacy comment handling;
+- every legacy resolve/unresolve/delete route against a blocking issue;
 - approval audit actor/role/attestation and immutable revision behavior.
 
 ### 11.2 Frontend
@@ -409,13 +469,13 @@ The feature is complete only when all of the following are proven:
 1. No owner, active candidate submitter, or active-cycle content contributor can approve/request changes through UI, API, or direct transition service use.
 2. An eligible non-author curator and admin can review without assignment.
 3. Approval cannot commit with a live unresolved blocking issue, including under concurrent writes.
-4. Every approval identifies the exact candidate revision/hash, reviewer, role snapshot, rationale, attestation, and time.
-5. Admin publication promotes only that approved snapshot.
+4. Every approval identifies the exact candidate revision/full-content digest, reviewer, role snapshot, rationale, attestation, and time.
+5. Admin publication copies only that approved full-content snapshot without publish-time mutation.
 6. New candidates are private and old published heads remain public throughout re-review.
 7. The review queue is server-paginated/sorted/filtered and displays effective state correctly.
 8. The review workspace provides a usable before/after comparison, issues, history, and actor-correct actions on desktop and mobile.
 9. Ordinary historical comments do not unexpectedly block approval.
-10. Backend tests, frontend tests, lint, formatting, typing, build, focused Playwright, migration checks, and relevant GitHub Actions pass.
+10. Backend tests, frontend tests, lint, formatting, typing, build, focused Playwright, migration checks—including raw-SQL concurrency and guarded downgrade—and relevant GitHub Actions pass.
 11. A one-pass independent high-reasoning spec review and a one-pass independent high-reasoning PR review are completed, with actionable findings resolved or explicitly documented.
 
 ## 13. Rejected alternatives

--- a/.planning/specs/2026-08-14-independent-phenopacket-review-design.md
+++ b/.planning/specs/2026-08-14-independent-phenopacket-review-design.md
@@ -1,0 +1,449 @@
+# Independent Phenopacket Review Design
+
+**Date:** 2026-08-14
+
+**Status:** User-approved design; independent spec review pending
+
+**Scope:** Phenopacket curation workflow, review audit, curator-facing review queue/workspace, and publication gate
+
+## 1. Decision
+
+HNF1B-DB will retain its existing revisioned lifecycle and make it a real four-eyes workflow:
+
+```text
+draft -> in_review -> approved -> published
+             |            |
+             v            v
+      changes_requested <-+
+             |
+             +---------> in_review
+```
+
+An authenticated curator or admin may review any open submission except a submission they own, submitted on another user's behalf, or whose candidate content they changed during the active edit cycle. One eligible reviewer signs off the exact immutable candidate revision. Only an admin may publish that approved revision. Unpublished records and candidate revisions remain curator-only; when an already-published record is revised, its old immutable public head remains visible until the replacement is approved and published.
+
+The review queue is open to all active curators/admins. It does not use assignment, claiming, bulk approval, or a new editor role.
+
+## 2. Why this design
+
+### 2.1 Current system findings
+
+The repository already has the hard parts worth preserving:
+
+- immutable `phenopacket_revisions` snapshots with actor, reason, transition, hashes, and timestamps;
+- `draft`, `in_review`, `changes_requested`, `approved`, `published`, and `archived` states;
+- optimistic revision checks and a phenopacket row lock around transitions;
+- separate working-copy and public-head pointers;
+- public visibility that dereferences only the immutable published head;
+- curator comments with resolution state and edit history.
+
+The gaps are policy and workflow projection:
+
+- approval and request-changes are admin-only, while an admin can submit and approve the same work;
+- the frontend and backend both encode transition permissions, so they can drift;
+- the main curator list exposes physical `phenopackets.state` instead of the working copy's effective state;
+- there is no server-driven review queue or comparison workspace;
+- comments are record-wide and approval does not distinguish or gate on review issues;
+- the current end-to-end lifecycle test explicitly uses the same admin to approve and publish.
+
+### 2.2 Community-standard alignment
+
+CIViC permits curators to submit and reject work but does not permit them to accept their own submissions or revisions. ClinGen workflows separate in-progress/provisional work, expert approval, and publication and require review discrepancies to be reconciled or explicitly dispositioned before a final decision. A single independent sign-off is proportionate for literature-derived case-record publication; it must not be described as equivalent to ClinGen expert-panel consensus.
+
+Relevant primary sources:
+
+- [CIViC evidence curation and moderation](https://docs.civicdb.org/en/latest/curating/evidence.html)
+- [CIViC Standard Operating Procedure](https://pmc.ncbi.nlm.nih.gov/articles/PMC6883603/)
+- [ClinGen Gene-Disease Validity SOP v12](https://www.clinicalgenome.org/site/assets/files/10876/gene_disease_validity_standard_operating_procedures-_version_12.pdf)
+- [ClinGen Gene Curation Expert Panel Protocol v3](https://clinicalgenome.org/docs/clingen-gene-curation-expert-panel-protocol/)
+- [GA4GH Phenopackets v2 metadata](https://phenopacket-schema.readthedocs.io/en/stable/metadata.html)
+
+The following are deliberate HNF1B-DB product policies rather than universal biomedical requirements:
+
+- admins may act as scientific reviewers because HNF1B-DB treats its admin role as curator-capable;
+- only admins perform public release;
+- pending revisions remain private rather than publicly labelled as unreviewed;
+- one independent approval is sufficient.
+
+## 3. Goals and non-goals
+
+### 3.1 Goals
+
+1. Make self-review impossible at every API and UI entry point.
+2. Let any eligible curator/admin review an open submission without assignment.
+3. Freeze candidate content during review and bind sign-off to an exact revision/hash.
+4. Require all blocking review issues to have a recorded disposition before approval.
+5. Keep ordinary discussion separate from blocking review issues.
+6. Give curators a server-driven queue and focused before/after review workspace.
+7. Preserve old public content during re-review and publish only the approved snapshot.
+8. Keep the revision ledger as the sole sign-off audit source; avoid a parallel review-state model.
+9. Close comment/approval races for HTTP and direct database writers.
+10. Preserve pagination, filtering, sorting, accessibility, mobile behavior, and fail-closed error handling.
+
+### 3.2 Non-goals
+
+- reviewer assignment, claiming, workload balancing, or notifications;
+- multi-reviewer voting, panel quorum, or a dedicated editor role;
+- field-anchored annotation threads inside the Phenopacket form;
+- public access to pending queue metadata or candidate content;
+- retroactively classifying ordinary historical comments as blocking issues;
+- changing the GA4GH Phenopacket v2 clinical content model;
+- conflating source-data `Reviewed By` provenance with application workflow approval.
+
+## 4. Lifecycle and transition policy
+
+### 4.1 State meanings
+
+| Effective state | Meaning | Content editable by |
+| --- | --- | --- |
+| `draft` | Private candidate not submitted | draft owner |
+| `in_review` | Frozen candidate awaiting independent review | nobody |
+| `changes_requested` | Reviewer returned candidate with rationale | draft owner |
+| `approved` | Frozen candidate independently signed off | nobody |
+| `published` | Immutable public head | nobody; editing creates a private clone |
+| `archived` | Terminal internal record | nobody |
+
+For a published record with an active edit, `phenopackets.state` remains `published` while `editing_revision.state` is the authoritative effective state. Public reads continue to use `phenopackets.state='published'` plus `head_published_revision_id`; curator workflow reads use effective state.
+
+### 4.2 Allowed transitions
+
+| From | To | Actor and conditions |
+| --- | --- | --- |
+| `draft` | `in_review` | owner, or admin acting on behalf; reason required |
+| `changes_requested` | `in_review` | owner, or admin acting on behalf; reason required |
+| `in_review` | `draft` | owner withdraws; admin emergency withdrawal remains audited |
+| `in_review` | `changes_requested` | eligible independent curator/admin; reason required |
+| `in_review` | `approved` | eligible independent curator/admin; zero open blocking issues; attestation and reason required |
+| `approved` | `changes_requested` | eligible independent curator/admin reopens before publication; reason required |
+| `approved` | `published` | admin only; exact approved revision/hash required |
+| any active state | `archived` | admin only; reason required |
+
+No transition bypass exists for admins when the rule concerns reviewer independence.
+
+### 4.3 Reviewer eligibility
+
+An actor is eligible to review a candidate only when all of the following hold:
+
+1. The actor is active and has role `curator` or `admin`.
+2. `draft_owner_id` is non-null.
+3. The actor is not `draft_owner_id`.
+4. The actor did not submit the active candidate revision on another user's behalf.
+5. The actor did not author a content-changing `created`, `draft_created`, or `draft_saved` revision in the active edit cycle.
+6. The candidate is in a reviewable effective state.
+
+The active edit cycle begins after the current published head, or at record creation when there is no published head. State-transition events and discussion activity do not make an actor a content contributor. Contributor checks use immutable revision history, not client claims.
+
+Missing ownership or ambiguous revision ancestry fails closed with a machine-readable error. It is never interpreted as proof that the actor is independent.
+
+## 5. Blocking review issues
+
+### 5.1 Discussion versus review issue
+
+Existing comments remain ordinary discussion and never block approval. A blocking review issue is a comment whose `review_revision_id` references the exact `in_review` revision inspected by the reviewer.
+
+Only an eligible independent reviewer can create a blocking issue while the candidate is `in_review`. The issue remains associated with that immutable snapshot through request-changes, editing, and resubmission. Approval is blocked while any live blocking issue for the record is unresolved, including an issue raised against an earlier submission in the same cycle.
+
+The draft owner may reply in discussion but may not resolve, reopen, or delete a blocking issue. An eligible independent reviewer may resolve or reopen it while the active cycle is `in_review` or `changes_requested`, with a required rationale. Blocking issues cannot be soft-deleted to bypass the gate; retraction is a recorded resolution disposition.
+
+### 5.2 Resolution audit
+
+Resolution and reopening append an immutable event containing:
+
+- issue ID;
+- action (`resolved` or `reopened`);
+- disposition/rationale;
+- authenticated actor ID and role snapshot;
+- server timestamp.
+
+The comment row retains `resolved_at` and `resolved_by_id` as the current-state projection. The append-only event log is the audit source.
+
+### 5.3 Race-free invariant
+
+Review-issue creation, resolution, reopening, approval, reopen-approved, and publication acquire the same phenopacket row lock before reading or changing review state. Locks are always acquired phenopacket-first, then comment/revision, to prevent deadlocks.
+
+Approval under the lock verifies:
+
+1. optimistic record revision;
+2. reviewer eligibility;
+3. active `in_review` revision identity;
+4. zero live unresolved blocking issues;
+5. valid attestation.
+
+If issue creation wins the lock, approval observes it and returns `409 unresolved_review_issues`. If approval wins, the waiting issue creation observes `approved` and returns `409 review_closed`. No committed state may contain an approved active revision and a newly created unresolved blocking issue.
+
+A deferred database constraint/trigger enforces the approved-plus-unresolved invariant for non-HTTP writers. Application locking remains necessary to produce deterministic errors and avoid retry-only behavior.
+
+## 6. Audit and storage changes
+
+### 6.1 Comments
+
+Add:
+
+```text
+comments.review_revision_id BIGINT NULL
+    REFERENCES phenopacket_revisions(id) ON DELETE RESTRICT
+
+comment_resolution_events
+    id BIGINT PK
+    comment_id BIGINT NOT NULL REFERENCES comments(id) ON DELETE RESTRICT
+    action TEXT NOT NULL CHECK action IN ('resolved', 'reopened')
+    rationale TEXT NOT NULL
+    actor_id BIGINT NOT NULL REFERENCES users(id) ON DELETE RESTRICT
+    actor_role TEXT NOT NULL
+    created_at TIMESTAMPTZ NOT NULL
+```
+
+A partial index covers live unresolved blocking issues by record. A trigger verifies that `review_revision_id` belongs to the comment's phenopacket record and represents a review snapshot. Historical comments remain `NULL` and non-blocking.
+
+### 6.2 Revision decision metadata
+
+Extend revision audit with an actor-role snapshot and structured decision metadata:
+
+```text
+phenopacket_revisions.actor_role TEXT NULL
+phenopacket_revisions.decision_metadata JSONB NULL
+```
+
+New revisions always snapshot `actor_role`. An approval revision stores a versioned payload equivalent to:
+
+```json
+{
+  "schemaVersion": 1,
+  "reviewedRevisionId": 123,
+  "independentReview": true,
+  "noUnmanagedConflict": true
+}
+```
+
+The existing revision actor, timestamp, reason, parent, state, content, projection hash, and ledger hash remain authoritative. No mutable `reviewed_by` column or separate sign-off table is introduced.
+
+Existing revisions may backfill `actor_role` from current user roles for display, but the migration and documentation must label those values as reconstructed rather than historically guaranteed.
+
+### 6.3 Ownership integrity
+
+Add a local constraint that an active editing pointer requires a non-null draft owner. The migration derives missing active owners only when immutable revision ancestry identifies one actor deterministically. It reports and aborts on ambiguous rows instead of guessing. Historical published records without an active edit retain `draft_owner_id=NULL`.
+
+## 7. Backend architecture and API
+
+### 7.1 Boundaries
+
+- A review-policy service owns reviewer eligibility, contributor checks, blocking-issue counts, and actor-specific capabilities.
+- A review-query repository owns effective-state SQL, queue pagination, filters, counts, and consistent review-context reads.
+- The state service remains the sole writer of lifecycle revisions and public-head swaps.
+- The comments service owns discussion and review-issue mutations but participates in router-owned transactions; it no longer commits inside service methods.
+- Routers map typed domain failures to stable HTTP error contracts.
+
+### 7.2 Review queue
+
+`GET /api/v2/phenopackets/review-queue` is curator/admin-only and server-driven.
+
+Supported query state:
+
+- `page[number]`, `page[size]`;
+- `filter[state]` (`draft`, `in_review`, `changes_requested`, `approved`);
+- `filter[owner]` (`mine` or a user ID);
+- `filter[eligibility]` (`reviewable_by_me` or `all`);
+- `filter[issues]` (`open`, `none`, or `all`);
+- `q` for case/subject search;
+- allowlisted sorting, defaulting to oldest submission first for `in_review`.
+
+Each lean row includes record/public identifiers, subject label, physical and effective state, owner, submission actor/time, record revision, candidate revision, change count, open blocking-issue count, published-head presence, and actor-specific capabilities. `meta` includes pagination and state counts computed under the same visibility rules.
+
+### 7.3 Review context
+
+`GET /api/v2/phenopackets/{id}/review-context` is curator/admin-only and returns one coherent review snapshot:
+
+- candidate revision metadata and exact candidate content;
+- baseline published revision metadata, or `null` for a new record;
+- semantic changes grouped into Subject, Phenotypes, Diseases, Variants/Interpretations, Measurements, and Metadata, with operation, path, before, and after values;
+- owner, submission, contributor, approval, and publication audit metadata;
+- blocking issues plus ordinary discussion summary;
+- current record revision and actor-specific capabilities.
+
+The endpoint acquires a read lock compatible with the write protocol or uses one equivalent transactionally consistent query. A new record renders all candidate content as added. A revised record always compares the candidate with the current immutable public head, not merely the preceding save.
+
+### 7.4 Mutations
+
+Continue using `POST /api/v2/phenopackets/{id}/transitions`, adding structured approval attestation when `to_state='approved'`. The server rejects irrelevant or missing attestation fields.
+
+Extend comment mutations with `record_revision` and `review_revision_id` for blocking issues. The server verifies both values and never trusts a client-nominated unrelated revision.
+
+All curator-facing transition controls consume server-returned capabilities; the duplicated matrix in `TransitionMenu.vue` is removed.
+
+### 7.5 Errors
+
+Stable error codes include:
+
+- `self_review_forbidden`;
+- `reviewer_contributed`;
+- `review_author_unknown`;
+- `unresolved_review_issues` with a count;
+- `review_revision_mismatch`;
+- `review_closed`;
+- `attestation_required`;
+- existing `revision_mismatch` and `invalid_transition`.
+
+Authorization failures use `403`; stale/conflicting workflow state uses `409`; malformed input uses `422`. Viewer/anonymous access to private review endpoints returns `404` where required to avoid existence disclosure.
+
+## 8. Frontend design
+
+### 8.1 Routes and navigation
+
+Add curator-only routes:
+
+- `/curation/reviews` -> `ReviewQueue.vue`;
+- `/curation/reviews/:phenopacket_id` -> `PhenopacketReview.vue`.
+
+Add a `requiresCurator` route guard and “Review queue” entries beside “Create Phenopacket” in desktop and mobile Curate navigation.
+
+### 8.2 Queue
+
+The queue uses `AppDataTable` in its default server-driven mode and persists pagination, search, filters, and sorting in the URL. Tabs are:
+
+- Needs review (`in_review`, default);
+- Changes requested;
+- Approved / awaiting publication;
+- My drafts.
+
+Core columns/cards show case/subject, state, owner, submitted time, proposed-change count, open-issue count, eligibility, and an explicit Review/Open action. There is no row-click-only interaction and no bulk approval.
+
+Loading uses stable skeletons. API errors render an alert and Retry rather than an empty table. Empty results distinguish an empty queue from filters with no matches. Mobile cards retain state and issue count as primary signals.
+
+### 8.3 Review workspace
+
+The header shows case ID, state, owner, submission time, candidate revision, public-head status, eligibility, and a back-to-queue link.
+
+The main comparison groups added, removed, and changed values semantically and uses text/icons in addition to color. Secondary views expose the complete candidate, raw JSON, and revision history. A desktop right rail contains unresolved-first review issues, discussion, and the decision panel; mobile stacks these sections and uses a safe-area-aware decision bar.
+
+Actions are driven only by backend capabilities:
+
+- Approve opens an exact-revision confirmation, requires rationale and independent/no-unmanaged-conflict attestation, and remains disabled if issue status is unknown.
+- Request changes requires a rationale and preserves blocking issues.
+- Reopen approved requires a rationale.
+- Publish is admin-only and explicitly states that the approved revision will become public.
+- An author/contributor sees why review actions are unavailable.
+
+On `revision_mismatch` or `review_revision_mismatch`, controls are replaced with a reload-required conflict state; the UI never retries a decision blindly. Successful mutations refresh queue counts, context, history, and live announcements.
+
+### 8.4 Existing detail page
+
+The general phenopacket detail page remains a browsing/detail surface. Curators receive an “Open review workspace” affordance for active review states. Any retained transition menu consumes server capabilities so it cannot expose a bypass.
+
+After publication, public detail may show “Independently reviewed” and the approval date. Reviewer identity and internal rationale remain curator/admin-visible, avoiding accidental conflation with source-review provenance.
+
+## 9. Privacy, integrity, and observability
+
+1. Public queries continue to dereference only `head_published_revision_id`.
+2. Queue/context endpoints require active curator/admin role and never expose candidate data to viewers.
+3. Public search, aggregates, exports, and MCP results remain pinned to published heads during re-review.
+4. Publication canonicalization must not alter approved clinical content silently; any derived metadata change is hashed and tested.
+5. Reviewer identity comes from authentication, never request bodies.
+6. Logs record transition/error codes and record/revision IDs but never clinical content or comment bodies.
+7. Metrics cover queue depth/age by state, approval latency, request-changes rate, and gate failures without patient-identifying labels.
+
+## 10. Migration and rollout
+
+1. Add schema columns, resolution-event table, indexes, triggers, and constraints in one reversible Alembic migration based on the current head.
+2. Preflight active edit cycles and deterministically backfill missing owners; abort with record IDs on ambiguity.
+3. Leave historical comments non-blocking and report their count.
+4. Deploy backend schema/API support before enabling frontend navigation.
+5. Keep legacy `changes_requested` and history rendering throughout rollout.
+6. Validate queue counts against direct effective-state SQL before enabling decisions.
+7. Exercise the complete two-curator lifecycle in staging/local production-like configuration.
+
+No destructive data cleanup is part of the migration.
+
+## 11. Testing strategy
+
+### 11.1 Backend
+
+- pure policy matrix for every role, state, owner, contributor, and NULL-owner combination;
+- non-author curator/admin approval and request-changes;
+- author and content-contributor self-review rejection;
+- admin-only publication and exact approved revision/hash;
+- ordinary, blocking, resolved, reopened, retracted, and historical comments;
+- required resolution rationale and approval attestation;
+- request-changes/resubmission with outstanding issues;
+- approved-to-changes-requested reopening;
+- two-real-session issue-create versus approve and issue-reopen versus approve in both lock orders;
+- concurrent approvals/request-changes with exactly one winner;
+- queue projection, counts, search, allowlisted sorting, and pagination;
+- physical `published` plus effective `in_review` projection;
+- new-record privacy and old-public-head visibility throughout re-review;
+- migration upgrade/downgrade, deterministic owner backfill, ambiguity failure, triggers, and legacy comment handling;
+- approval audit actor/role/attestation and immutable revision behavior.
+
+### 11.2 Frontend
+
+- curator route guard and desktop/mobile navigation;
+- URL-backed server queue state;
+- loading, retry, true-empty, filtered-empty, and permission states;
+- effective-state and capability rendering;
+- semantic diff additions/removals/changes and no-baseline behavior;
+- author/contributor explanations;
+- unresolved/unknown issue approval gate;
+- transition payloads, attestation, and structured 403/409 handling;
+- discussion/review issue counts after create, resolve, reopen, and response;
+- keyboard focus, accessible names, `aria-live`, non-color cues, and mobile layout.
+
+### 11.3 End to end
+
+The principal Playwright scenario uses distinct accounts:
+
+1. Curator A creates and submits a new private case.
+2. Anonymous/viewer access cannot discover the candidate.
+3. Curator A cannot approve it.
+4. Curator B finds it through the server-driven open queue.
+5. Curator B creates a blocking issue and requests changes.
+6. Curator A edits, responds, and resubmits.
+7. Curator B records resolution and approves the exact revision.
+8. The case remains non-public until an admin publishes it.
+9. Public list/detail/search expose the approved content only after publication.
+10. A second cycle proves the old public head stays visible until the replacement is published.
+
+Additional E2E coverage verifies approved reopening, stale-revision conflicts, keyboard-only decisions, and the mobile queue/workspace.
+
+## 12. Acceptance criteria
+
+The feature is complete only when all of the following are proven:
+
+1. No owner, active candidate submitter, or active-cycle content contributor can approve/request changes through UI, API, or direct transition service use.
+2. An eligible non-author curator and admin can review without assignment.
+3. Approval cannot commit with a live unresolved blocking issue, including under concurrent writes.
+4. Every approval identifies the exact candidate revision/hash, reviewer, role snapshot, rationale, attestation, and time.
+5. Admin publication promotes only that approved snapshot.
+6. New candidates are private and old published heads remain public throughout re-review.
+7. The review queue is server-paginated/sorted/filtered and displays effective state correctly.
+8. The review workspace provides a usable before/after comparison, issues, history, and actor-correct actions on desktop and mobile.
+9. Ordinary historical comments do not unexpectedly block approval.
+10. Backend tests, frontend tests, lint, formatting, typing, build, focused Playwright, migration checks, and relevant GitHub Actions pass.
+11. A one-pass independent high-reasoning spec review and a one-pass independent high-reasoning PR review are completed, with actionable findings resolved or explicitly documented.
+
+## 13. Rejected alternatives
+
+### Separate sign-off/review-round tables
+
+They would support quorum and multiple decisions but duplicate the existing immutable revision ledger. Add them only if panel voting becomes a real requirement.
+
+### Dedicated editor role
+
+This mirrors CIViC more literally but conflicts with the selected curator/admin open queue and adds role-administration work without improving the requested one-reviewer invariant.
+
+### Reusing the general registry and detail page unchanged
+
+This keeps public browsing and workflow review tangled, forces client-side joins, and leaves race-prone permission logic in the frontend.
+
+### Treating every unresolved comment as blocking
+
+Historical and conversational comments would unexpectedly veto publication. Only explicitly revision-bound review issues participate in the gate.
+
+### Collapsing `changes_requested` into `draft`
+
+The explicit state distinguishes a reviewer return from voluntary drafting and preserves workflow metrics, queue clarity, and audit meaning.
+
+## 14. Known trade-offs
+
+- One independent sign-off is a local quality-control threshold, not expert-panel consensus.
+- Admins count as scientific reviewers by explicit HNF1B-DB policy; actor role and attestation make that decision auditable.
+- Open queues improve throughput but do not balance workload; assignment can be added later without changing the sign-off invariant.
+- Revision-bound blocking issues are intentionally record-level gates across a review cycle rather than field-anchored annotations.
+- Database constraint triggers add complexity, justified by the clinical-publication invariant and the existence of non-HTTP maintenance/import paths.

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -47,6 +47,9 @@ try:
     from app.comments.models import (
         CommentMention as CommentMention,
     )
+    from app.comments.models import (
+        CommentResolutionEvent as CommentResolutionEvent,
+    )
     from app.database import Base
 
     # Core models (2).

--- a/backend/alembic/versions/d0f422b00005_expand_independent_review_audit.py
+++ b/backend/alembic/versions/d0f422b00005_expand_independent_review_audit.py
@@ -1,0 +1,139 @@
+"""Expand storage for independent review and versioned revision audit.
+
+Revision ID: d0f422b00005
+Revises: c0f422b00004
+Create Date: 2026-08-14
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "d0f422b00005"
+down_revision = "c0f422b00004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add nullable audit storage without activating workflow constraints."""
+    op.add_column(
+        "phenopacket_revisions", sa.Column("actor_role", sa.Text(), nullable=True)
+    )
+    op.add_column(
+        "phenopacket_revisions",
+        sa.Column("decision_metadata", postgresql.JSONB(), nullable=True),
+    )
+    op.add_column(
+        "phenopacket_revisions",
+        sa.Column("content_sha256", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "phenopacket_revisions",
+        sa.Column("ledger_version", sa.Integer(), nullable=True),
+    )
+    op.create_check_constraint(
+        op.f("ck_phenopacket_revisions_actor_role"),
+        "phenopacket_revisions",
+        "actor_role IS NULL OR actor_role IN ('viewer', 'curator', 'admin')",
+    )
+    op.create_check_constraint(
+        op.f("ck_phenopacket_revisions_content_sha256"),
+        "phenopacket_revisions",
+        "content_sha256 IS NULL OR content_sha256 ~ '^sha256:[0-9a-f]{64}$'",
+    )
+    op.create_check_constraint(
+        op.f("ck_phenopacket_revisions_ledger_version"),
+        "phenopacket_revisions",
+        "ledger_version IS NULL OR ledger_version = 2",
+    )
+    op.create_check_constraint(
+        op.f("ck_phenopacket_revisions_decision_metadata_ledger"),
+        "phenopacket_revisions",
+        "decision_metadata IS NULL OR ledger_version = 2",
+    )
+
+    op.add_column(
+        "comments", sa.Column("review_revision_id", sa.BigInteger(), nullable=True)
+    )
+    op.create_foreign_key(
+        "fk_comments_review_revision",
+        "comments",
+        "phenopacket_revisions",
+        ["review_revision_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_table(
+        "comment_resolution_events",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("comment_id", sa.BigInteger(), nullable=False),
+        sa.Column("action", sa.Text(), nullable=False),
+        sa.Column("disposition", sa.Text(), nullable=True),
+        sa.Column("rationale", sa.Text(), nullable=False),
+        sa.Column("actor_id", sa.BigInteger(), nullable=False),
+        sa.Column("actor_role", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "(action = 'reopened' AND disposition IS NULL) OR "
+            "(action = 'resolved' AND disposition IN "
+            "('addressed','accepted_with_rationale','retracted','superseded'))",
+            name=op.f("ck_comment_resolution_event_action_disposition"),
+        ),
+        sa.CheckConstraint(
+            "char_length(btrim(rationale)) BETWEEN 1 AND 500",
+            name=op.f("ck_comment_resolution_event_rationale"),
+        ),
+        sa.CheckConstraint(
+            "actor_role IN ('curator', 'admin')",
+            name=op.f("ck_comment_resolution_event_actor_role"),
+        ),
+        sa.ForeignKeyConstraint(["comment_id"], ["comments.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["actor_id"], ["users.id"], ondelete="RESTRICT"),
+    )
+    op.create_index(
+        "ix_comments_live_unresolved_phenopacket_review_issues",
+        "comments",
+        ["record_id", "review_revision_id"],
+        unique=False,
+        postgresql_where=sa.text(
+            "record_type = 'phenopacket' AND review_revision_id IS NOT NULL "
+            "AND resolved_at IS NULL AND deleted_at IS NULL"
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove the unused nullable expansion without touching revision history."""
+    op.drop_index(
+        "ix_comments_live_unresolved_phenopacket_review_issues",
+        table_name="comments",
+    )
+    op.drop_table("comment_resolution_events")
+    op.drop_constraint("fk_comments_review_revision", "comments", type_="foreignkey")
+    op.drop_column("comments", "review_revision_id")
+
+    for constraint_name in (
+        "ck_phenopacket_revisions_decision_metadata_ledger",
+        "ck_phenopacket_revisions_ledger_version",
+        "ck_phenopacket_revisions_content_sha256",
+        "ck_phenopacket_revisions_actor_role",
+    ):
+        op.drop_constraint(
+            op.f(constraint_name), "phenopacket_revisions", type_="check"
+        )
+    for column_name in (
+        "ledger_version",
+        "content_sha256",
+        "decision_metadata",
+        "actor_role",
+    ):
+        op.drop_column("phenopacket_revisions", column_name)

--- a/backend/alembic/versions/d0f422b00005_expand_independent_review_audit.py
+++ b/backend/alembic/versions/d0f422b00005_expand_independent_review_audit.py
@@ -53,7 +53,8 @@ def upgrade() -> None:
     op.create_check_constraint(
         op.f("ck_phenopacket_revisions_decision_metadata_ledger"),
         "phenopacket_revisions",
-        "decision_metadata IS NULL OR ledger_version = 2",
+        "decision_metadata IS NULL OR "
+        "(ledger_version IS NOT NULL AND ledger_version = 2)",
     )
 
     op.add_column(
@@ -84,7 +85,7 @@ def upgrade() -> None:
         ),
         sa.CheckConstraint(
             "(action = 'reopened' AND disposition IS NULL) OR "
-            "(action = 'resolved' AND disposition IN "
+            "(action = 'resolved' AND disposition IS NOT NULL AND disposition IN "
             "('addressed','accepted_with_rationale','retracted','superseded'))",
             name=op.f("ck_comment_resolution_event_action_disposition"),
         ),

--- a/backend/alembic/versions/d0f422b00005_expand_independent_review_audit.py
+++ b/backend/alembic/versions/d0f422b00005_expand_independent_review_audit.py
@@ -18,6 +18,39 @@ branch_labels = None
 depends_on = None
 
 
+def assert_independent_review_downgrade_safe(bind) -> None:
+    """Refuse to erase any independent-review or v2 ledger evidence."""
+    evidence = (
+        bind.execute(
+            sa.text(
+                """
+                SELECT
+                    (SELECT count(*) FROM comments
+                     WHERE review_revision_id IS NOT NULL) AS blocking_issues,
+                    (SELECT count(*) FROM comment_resolution_events)
+                        AS resolution_events,
+                    (SELECT count(*) FROM phenopacket_revisions
+                     WHERE ledger_version = 2) AS v2_revisions,
+                    (SELECT count(*) FROM phenopacket_revisions
+                     WHERE decision_metadata IS NOT NULL) AS decision_metadata,
+                    (SELECT count(*) FROM phenopacket_revisions
+                     WHERE actor_role IS NOT NULL) AS actor_roles,
+                    (SELECT count(*) FROM phenopacket_revisions
+                     WHERE content_sha256 IS NOT NULL) AS content_digests
+                """
+            )
+        )
+        .mappings()
+        .one()
+    )
+    present = [name for name, count in evidence.items() if int(count) > 0]
+    if present:
+        raise RuntimeError(
+            "refusing independent-review downgrade; evidence present: "
+            + ", ".join(present)
+        )
+
+
 def upgrade() -> None:
     """Add nullable audit storage without activating workflow constraints."""
     op.add_column(
@@ -114,6 +147,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Remove the unused nullable expansion without touching revision history."""
+    assert_independent_review_downgrade_safe(op.get_bind())
     op.drop_index(
         "ix_comments_live_unresolved_phenopacket_review_issues",
         table_name="comments",

--- a/backend/alembic/versions/e0f422b00006_activate_independent_review_invariants.py
+++ b/backend/alembic/versions/e0f422b00006_activate_independent_review_invariants.py
@@ -1,0 +1,685 @@
+"""Activate independent-review locking, audit, and final-state invariants.
+
+Revision ID: e0f422b00006
+Revises: d0f422b00005
+Create Date: 2026-08-14
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "e0f422b00006"
+down_revision = "d0f422b00005"
+branch_labels = None
+depends_on = None
+
+
+def assert_independent_review_downgrade_safe(bind) -> None:
+    """Refuse to remove protections while any protected evidence exists."""
+    evidence = (
+        bind.execute(
+            sa.text(
+                """
+                SELECT
+                    (SELECT count(*) FROM comments
+                     WHERE review_revision_id IS NOT NULL) AS blocking_issues,
+                    (SELECT count(*) FROM comment_resolution_events)
+                        AS resolution_events,
+                    (SELECT count(*) FROM phenopacket_revisions
+                     WHERE ledger_version = 2) AS v2_revisions,
+                    (SELECT count(*) FROM phenopacket_revisions
+                     WHERE decision_metadata IS NOT NULL) AS decision_metadata,
+                    (SELECT count(*) FROM phenopacket_revisions
+                     WHERE actor_role IS NOT NULL) AS actor_roles,
+                    (SELECT count(*) FROM phenopacket_revisions
+                     WHERE content_sha256 IS NOT NULL) AS content_digests
+                """
+            )
+        )
+        .mappings()
+        .one()
+    )
+    present = [name for name, count in evidence.items() if int(count) > 0]
+    if present:
+        raise RuntimeError(
+            "refusing independent-review downgrade; evidence present: "
+            + ", ".join(present)
+        )
+
+
+def _preflight_and_backfill_active_owners() -> None:
+    """Resolve active owners from exact immutable ancestry or fail atomically."""
+    op.execute(
+        """
+        CREATE TEMP TABLE independent_review_owner_candidates
+        ON COMMIT DROP AS
+        WITH RECURSIVE ancestry AS (
+            SELECT
+                packet.id AS packet_id,
+                packet.head_published_revision_id AS head_id,
+                revision.id AS revision_id,
+                revision.record_id AS revision_record_id,
+                revision.parent_revision_id AS parent_id,
+                revision.revision_number,
+                revision.state AS revision_state,
+                revision.event_type,
+                revision.actor_id,
+                CASE
+                    WHEN revision.id IS NULL THEN ARRAY[]::BIGINT[]
+                    ELSE ARRAY[revision.id]
+                END AS path,
+                FALSE AS cycle,
+                (
+                    revision.id IS NULL
+                    OR revision.record_id IS DISTINCT FROM packet.id
+                    OR revision.state NOT IN
+                        ('draft', 'in_review', 'changes_requested', 'approved')
+                ) AS invalid
+            FROM phenopackets packet
+            LEFT JOIN phenopacket_revisions revision
+              ON revision.id = packet.editing_revision_id
+            WHERE packet.editing_revision_id IS NOT NULL
+              AND packet.draft_owner_id IS NULL
+
+            UNION ALL
+
+            SELECT
+                ancestry.packet_id,
+                ancestry.head_id,
+                parent.id,
+                parent.record_id,
+                parent.parent_revision_id,
+                parent.revision_number,
+                parent.state,
+                parent.event_type,
+                parent.actor_id,
+                ancestry.path || COALESCE(parent.id, -1),
+                parent.id = ANY(ancestry.path),
+                (
+                    ancestry.invalid
+                    OR parent.id IS NULL
+                    OR parent.record_id IS DISTINCT FROM ancestry.packet_id
+                    OR parent.revision_number >= ancestry.revision_number
+                    OR parent.id = ANY(ancestry.path)
+                )
+            FROM ancestry
+            LEFT JOIN phenopacket_revisions parent
+              ON parent.id = ancestry.parent_id
+            WHERE ancestry.revision_id IS NOT NULL
+              AND ancestry.parent_id IS NOT NULL
+              AND NOT ancestry.cycle
+              AND (
+                  ancestry.head_id IS NULL
+                  OR ancestry.revision_id <> ancestry.head_id
+              )
+        ), summarized AS (
+            SELECT
+                packet_id,
+                head_id,
+                bool_or(invalid) AS has_invalid_link,
+                bool_or(revision_id = head_id) FILTER (WHERE head_id IS NOT NULL)
+                    AS reached_head,
+                bool_or(revision_id IS NOT NULL AND parent_id IS NULL)
+                    FILTER (WHERE head_id IS NULL) AS reached_root,
+                count(*) FILTER (
+                    WHERE head_id IS NULL AND event_type = 'created'
+                ) AS created_events,
+                count(*) FILTER (
+                    WHERE head_id IS NULL AND event_type = 'created'
+                      AND parent_id IS NULL
+                ) AS created_roots,
+                count(*) FILTER (
+                    WHERE head_id IS NOT NULL AND event_type = 'draft_created'
+                ) AS draft_created_events,
+                count(*) FILTER (
+                    WHERE head_id IS NOT NULL AND event_type = 'draft_created'
+                      AND parent_id = head_id
+                ) AS draft_created_roots,
+                max(actor_id) FILTER (
+                    WHERE (
+                        head_id IS NULL
+                        AND event_type = 'created'
+                        AND parent_id IS NULL
+                    ) OR (
+                        head_id IS NOT NULL
+                        AND event_type = 'draft_created'
+                        AND parent_id = head_id
+                    )
+                ) AS owner_id
+            FROM ancestry
+            GROUP BY packet_id, head_id
+        )
+        SELECT
+            packet_id,
+            owner_id,
+            (
+                NOT has_invalid_link
+                AND owner_id IS NOT NULL
+                AND (
+                    (
+                        head_id IS NULL
+                        AND COALESCE(reached_root, FALSE)
+                        AND created_events = 1
+                        AND created_roots = 1
+                    ) OR (
+                        head_id IS NOT NULL
+                        AND COALESCE(reached_head, FALSE)
+                        AND draft_created_events = 1
+                        AND draft_created_roots = 1
+                    )
+                )
+            ) AS valid
+        FROM summarized;
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        DECLARE invalid_ids TEXT;
+        BEGIN
+            SELECT string_agg(packet_id::TEXT, ', ' ORDER BY packet_id)
+              INTO invalid_ids
+              FROM independent_review_owner_candidates
+             WHERE NOT valid;
+            IF invalid_ids IS NOT NULL THEN
+                RAISE EXCEPTION
+                    'independent review owner preflight failed: %', invalid_ids;
+            END IF;
+        END;
+        $$;
+        """
+    )
+    op.execute(
+        """
+        UPDATE phenopackets packet
+           SET draft_owner_id = candidate.owner_id
+          FROM independent_review_owner_candidates candidate
+         WHERE candidate.valid
+           AND packet.id = candidate.packet_id
+           AND packet.draft_owner_id IS NULL;
+        """
+    )
+    op.execute("DROP TABLE independent_review_owner_candidates")
+
+
+def _install_revision_lock_trigger() -> None:
+    op.execute(
+        """
+        CREATE FUNCTION lock_phenopacket_for_revision_insert()
+        RETURNS trigger AS $$
+        DECLARE
+            packet phenopackets%ROWTYPE;
+            head_number INTEGER;
+        BEGIN
+            SELECT * INTO packet
+              FROM phenopackets
+             WHERE id = NEW.record_id
+             FOR UPDATE;
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'review_revision_mismatch';
+            END IF;
+
+            IF packet.head_published_revision_id IS NOT NULL THEN
+                SELECT revision_number INTO head_number
+                  FROM phenopacket_revisions
+                 WHERE id = packet.head_published_revision_id
+                   AND record_id = packet.id
+                   AND state = 'published';
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION 'review_author_unknown';
+                END IF;
+            END IF;
+
+            IF NEW.state = 'approved' AND EXISTS (
+                SELECT 1
+                  FROM comments issue
+                  JOIN phenopacket_revisions reviewed
+                    ON reviewed.id = issue.review_revision_id
+                 WHERE issue.record_type = 'phenopacket'
+                   AND issue.record_id = packet.id
+                   AND issue.review_revision_id IS NOT NULL
+                   AND issue.resolved_at IS NULL
+                   AND issue.deleted_at IS NULL
+                   AND reviewed.record_id = packet.id
+                   AND (head_number IS NULL OR reviewed.revision_number > head_number)
+            ) THEN
+                RAISE EXCEPTION 'unresolved_review_issues';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER phenopacket_revisions_00_lock_record
+        BEFORE INSERT ON phenopacket_revisions
+        FOR EACH ROW EXECUTE FUNCTION lock_phenopacket_for_revision_insert();
+        """
+    )
+
+
+def _install_comment_and_event_triggers() -> None:
+    op.execute(
+        """
+        CREATE FUNCTION validate_review_issue_insert()
+        RETURNS trigger AS $$
+        DECLARE
+            packet phenopackets%ROWTYPE;
+            active_revision phenopacket_revisions%ROWTYPE;
+            reviewed_revision phenopacket_revisions%ROWTYPE;
+            head_number INTEGER;
+        BEGIN
+            IF NEW.review_revision_id IS NULL THEN
+                RETURN NEW;
+            END IF;
+            IF NEW.record_type <> 'phenopacket'
+               OR NEW.deleted_at IS NOT NULL
+               OR NEW.resolved_at IS NOT NULL THEN
+                RAISE EXCEPTION 'review_issue_mutation_forbidden';
+            END IF;
+
+            SELECT * INTO packet FROM phenopackets
+             WHERE id = NEW.record_id FOR UPDATE;
+            IF NOT FOUND OR packet.draft_owner_id IS NULL THEN
+                RAISE EXCEPTION 'review_author_unknown';
+            END IF;
+            SELECT * INTO active_revision FROM phenopacket_revisions
+             WHERE id = packet.editing_revision_id AND record_id = packet.id;
+            IF NOT FOUND OR active_revision.state <> 'in_review' THEN
+                RAISE EXCEPTION 'review_closed';
+            END IF;
+            IF active_revision.id <> NEW.review_revision_id THEN
+                RAISE EXCEPTION 'review_revision_mismatch';
+            END IF;
+            SELECT * INTO reviewed_revision FROM phenopacket_revisions
+             WHERE id = NEW.review_revision_id
+               AND record_id = packet.id AND state = 'in_review';
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'review_revision_mismatch';
+            END IF;
+            IF packet.head_published_revision_id IS NOT NULL THEN
+                SELECT revision_number INTO head_number
+                  FROM phenopacket_revisions
+                 WHERE id = packet.head_published_revision_id
+                   AND record_id = packet.id AND state = 'published';
+                IF NOT FOUND OR reviewed_revision.revision_number <= head_number THEN
+                    RAISE EXCEPTION 'review_revision_mismatch';
+                END IF;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER comments_review_issue_guard
+        BEFORE INSERT ON comments
+        FOR EACH ROW EXECUTE FUNCTION validate_review_issue_insert();
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION lock_phenopacket_for_resolution_event()
+        RETURNS trigger AS $$
+        DECLARE
+            issue comments%ROWTYPE;
+            packet phenopackets%ROWTYPE;
+            active_revision phenopacket_revisions%ROWTYPE;
+            expected_candidate_id BIGINT;
+            reviewed_revision phenopacket_revisions%ROWTYPE;
+            head_number INTEGER;
+        BEGIN
+            SELECT * INTO issue FROM comments WHERE id = NEW.comment_id;
+            IF NOT FOUND OR issue.review_revision_id IS NULL
+               OR issue.record_type <> 'phenopacket'
+               OR issue.deleted_at IS NOT NULL THEN
+                RAISE EXCEPTION 'review_issue_mutation_forbidden';
+            END IF;
+
+            SELECT * INTO packet FROM phenopackets
+             WHERE id = issue.record_id FOR UPDATE;
+            IF NOT FOUND OR packet.draft_owner_id IS NULL THEN
+                RAISE EXCEPTION 'review_author_unknown';
+            END IF;
+            SELECT * INTO active_revision FROM phenopacket_revisions
+             WHERE id = packet.editing_revision_id AND record_id = packet.id;
+            IF NOT FOUND OR active_revision.state NOT IN ('in_review','changes_requested') THEN
+                RAISE EXCEPTION 'review_closed';
+            END IF;
+            expected_candidate_id := active_revision.id;
+            IF active_revision.state = 'changes_requested' THEN
+                expected_candidate_id := active_revision.parent_revision_id;
+            END IF;
+            IF expected_candidate_id IS NULL
+               OR expected_candidate_id <> issue.review_revision_id THEN
+                RAISE EXCEPTION 'review_revision_mismatch';
+            END IF;
+            SELECT * INTO reviewed_revision FROM phenopacket_revisions
+             WHERE id = issue.review_revision_id
+               AND record_id = packet.id AND state = 'in_review';
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'review_revision_mismatch';
+            END IF;
+            IF packet.head_published_revision_id IS NOT NULL THEN
+                SELECT revision_number INTO head_number FROM phenopacket_revisions
+                 WHERE id = packet.head_published_revision_id
+                   AND record_id = packet.id AND state = 'published';
+                IF NOT FOUND OR reviewed_revision.revision_number <= head_number THEN
+                    RAISE EXCEPTION 'review_revision_mismatch';
+                END IF;
+            END IF;
+            IF NEW.action = 'resolved' AND issue.resolved_at IS NOT NULL THEN
+                RAISE EXCEPTION 'review_issue_already_resolved';
+            ELSIF NEW.action = 'reopened' AND issue.resolved_at IS NULL THEN
+                RAISE EXCEPTION 'review_issue_not_resolved';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER comment_resolution_events_lock_record
+        BEFORE INSERT ON comment_resolution_events
+        FOR EACH ROW EXECUTE FUNCTION lock_phenopacket_for_resolution_event();
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION reject_comment_resolution_event_mutation()
+        RETURNS trigger AS $$
+        BEGIN
+            RAISE EXCEPTION 'comment resolution events are append-only';
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER comment_resolution_events_immutable
+        BEFORE UPDATE OR DELETE ON comment_resolution_events
+        FOR EACH ROW EXECUTE FUNCTION reject_comment_resolution_event_mutation();
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION guard_review_issue_mutation()
+        RETURNS trigger AS $$
+        DECLARE matching_event BOOLEAN;
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                IF OLD.review_revision_id IS NOT NULL THEN
+                    RAISE EXCEPTION 'review_issue_mutation_forbidden';
+                END IF;
+                RETURN OLD;
+            END IF;
+
+            IF OLD.review_revision_id IS NULL AND NEW.review_revision_id IS NULL THEN
+                RETURN NEW;
+            END IF;
+            IF OLD.review_revision_id IS NULL
+               OR NEW.review_revision_id IS NULL
+               OR NEW.review_revision_id <> OLD.review_revision_id
+               OR NEW.record_id <> OLD.record_id
+               OR NEW.record_type <> OLD.record_type
+               OR NEW.deleted_at IS DISTINCT FROM OLD.deleted_at
+               OR NEW.deleted_by_id IS DISTINCT FROM OLD.deleted_by_id THEN
+                RAISE EXCEPTION 'review_issue_mutation_forbidden';
+            END IF;
+
+            IF NEW.resolved_at IS DISTINCT FROM OLD.resolved_at
+               OR NEW.resolved_by_id IS DISTINCT FROM OLD.resolved_by_id THEN
+                SELECT EXISTS (
+                    SELECT 1 FROM comment_resolution_events event
+                     WHERE event.comment_id = OLD.id
+                       -- MVCC exposes another transaction's uncommitted row to
+                       -- no one.  A visible event whose inserting xid is still
+                       -- absent from the current snapshot is therefore ours,
+                       -- including inserts made in a PostgreSQL subtransaction.
+                       AND NOT pg_visible_in_snapshot(
+                           (event.xmin::TEXT)::xid8,
+                           pg_current_snapshot()
+                       )
+                       AND (
+                           (
+                               OLD.resolved_at IS NULL
+                               AND NEW.resolved_at IS NOT NULL
+                               AND NEW.resolved_by_id IS NOT NULL
+                               AND event.action = 'resolved'
+                               AND event.actor_id = NEW.resolved_by_id
+                           ) OR (
+                               OLD.resolved_at IS NOT NULL
+                               AND NEW.resolved_at IS NULL
+                               AND NEW.resolved_by_id IS NULL
+                               AND event.action = 'reopened'
+                           )
+                       )
+                ) INTO matching_event;
+                IF NOT matching_event THEN
+                    RAISE EXCEPTION 'review_issue_resolution_event_required';
+                END IF;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER comments_review_issue_mutation_guard
+        BEFORE UPDATE OR DELETE ON comments
+        FOR EACH ROW EXECUTE FUNCTION guard_review_issue_mutation();
+        """
+    )
+
+
+def _install_final_state_triggers() -> None:
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION validate_phenopacket_revision_pointer()
+        RETURNS trigger AS $$
+        DECLARE
+            packet phenopackets%ROWTYPE;
+            active_state TEXT;
+            head_number INTEGER;
+        BEGIN
+            SELECT * INTO packet FROM phenopackets WHERE id = NEW.id;
+            IF packet.head_published_revision_id IS NOT NULL AND NOT EXISTS (
+                SELECT 1 FROM phenopacket_revisions revision
+                WHERE revision.id = packet.head_published_revision_id
+                  AND revision.record_id = packet.id
+                  AND revision.state = 'published'
+            ) THEN
+                RAISE EXCEPTION 'head_published_revision_id must be a published revision of its record';
+            END IF;
+            IF packet.state = 'published' AND packet.head_published_revision_id IS NULL THEN
+                RAISE EXCEPTION 'published phenopacket requires head_published_revision_id';
+            END IF;
+            IF packet.editing_revision_id IS NOT NULL AND NOT EXISTS (
+                SELECT 1 FROM phenopacket_revisions revision
+                WHERE revision.id = packet.editing_revision_id
+                  AND revision.record_id = packet.id
+                  AND revision.state IN ('draft', 'in_review', 'changes_requested', 'approved')
+            ) THEN
+                RAISE EXCEPTION 'editing_revision_id must be an editable revision of its record';
+            END IF;
+            IF packet.editing_revision_id IS NOT NULL AND packet.draft_owner_id IS NULL THEN
+                RAISE EXCEPTION 'active editing_revision_id requires draft_owner_id';
+            END IF;
+            IF packet.state = 'archived' AND packet.editing_revision_id IS NOT NULL THEN
+                RAISE EXCEPTION 'archived phenopacket cannot retain editing_revision_id';
+            END IF;
+
+            IF packet.editing_revision_id IS NOT NULL THEN
+                SELECT state INTO active_state FROM phenopacket_revisions
+                 WHERE id = packet.editing_revision_id AND record_id = packet.id;
+            END IF;
+            IF packet.head_published_revision_id IS NOT NULL THEN
+                SELECT revision_number INTO head_number FROM phenopacket_revisions
+                 WHERE id = packet.head_published_revision_id AND record_id = packet.id;
+            END IF;
+            IF active_state = 'approved' AND EXISTS (
+                SELECT 1 FROM comments issue
+                JOIN phenopacket_revisions reviewed
+                  ON reviewed.id = issue.review_revision_id
+                WHERE issue.record_type = 'phenopacket'
+                  AND issue.record_id = packet.id
+                  AND issue.review_revision_id IS NOT NULL
+                  AND issue.resolved_at IS NULL
+                  AND issue.deleted_at IS NULL
+                  AND reviewed.record_id = packet.id
+                  AND (head_number IS NULL OR reviewed.revision_number > head_number)
+            ) THEN
+                RAISE EXCEPTION 'unresolved_review_issues';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION validate_review_issue_final_state()
+        RETURNS trigger AS $$
+        DECLARE
+            packet phenopackets%ROWTYPE;
+            packet_id UUID;
+            active_state TEXT;
+            head_number INTEGER;
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                IF OLD.review_revision_id IS NULL THEN RETURN OLD; END IF;
+                packet_id := OLD.record_id;
+            ELSE
+                IF NEW.review_revision_id IS NULL THEN RETURN NEW; END IF;
+                packet_id := NEW.record_id;
+            END IF;
+            SELECT * INTO packet FROM phenopackets WHERE id = packet_id;
+            IF NOT FOUND THEN RETURN COALESCE(NEW, OLD); END IF;
+            SELECT state INTO active_state FROM phenopacket_revisions
+             WHERE id = packet.editing_revision_id AND record_id = packet.id;
+            IF packet.head_published_revision_id IS NOT NULL THEN
+                SELECT revision_number INTO head_number FROM phenopacket_revisions
+                 WHERE id = packet.head_published_revision_id AND record_id = packet.id;
+            END IF;
+            IF active_state = 'approved' AND EXISTS (
+                SELECT 1 FROM comments issue
+                JOIN phenopacket_revisions reviewed
+                  ON reviewed.id = issue.review_revision_id
+                WHERE issue.record_type = 'phenopacket'
+                  AND issue.record_id = packet.id
+                  AND issue.review_revision_id IS NOT NULL
+                  AND issue.resolved_at IS NULL
+                  AND issue.deleted_at IS NULL
+                  AND reviewed.record_id = packet.id
+                  AND (head_number IS NULL OR reviewed.revision_number > head_number)
+            ) THEN
+                RAISE EXCEPTION 'unresolved_review_issues';
+            END IF;
+            RETURN COALESCE(NEW, OLD);
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
+        CREATE CONSTRAINT TRIGGER comments_review_issue_final_state
+        AFTER INSERT OR UPDATE OR DELETE ON comments
+        DEFERRABLE INITIALLY DEFERRED
+        FOR EACH ROW EXECUTE FUNCTION validate_review_issue_final_state();
+        """
+    )
+
+
+def upgrade() -> None:
+    """Backfill owners and activate lock-serialized independent review."""
+    op.execute(
+        """
+        LOCK TABLE phenopackets, phenopacket_revisions, comments,
+                   comment_resolution_events
+        IN SHARE ROW EXCLUSIVE MODE;
+        """
+    )
+    _preflight_and_backfill_active_owners()
+    op.create_check_constraint(
+        op.f("ck_phenopackets_active_edit_owner"),
+        "phenopackets",
+        "editing_revision_id IS NULL OR draft_owner_id IS NOT NULL",
+    )
+    _install_revision_lock_trigger()
+    _install_comment_and_event_triggers()
+    _install_final_state_triggers()
+
+
+def _restore_b9_pointer_validator() -> None:
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION validate_phenopacket_revision_pointer()
+        RETURNS trigger AS $$
+        DECLARE
+            packet phenopackets%ROWTYPE;
+        BEGIN
+            SELECT * INTO packet FROM phenopackets WHERE id = NEW.id;
+            IF packet.head_published_revision_id IS NOT NULL AND NOT EXISTS (
+                SELECT 1 FROM phenopacket_revisions revision
+                WHERE revision.id = packet.head_published_revision_id
+                  AND revision.record_id = packet.id
+                  AND revision.state = 'published'
+            ) THEN
+                RAISE EXCEPTION 'head_published_revision_id must be a published revision of its record';
+            END IF;
+            IF packet.state = 'published' AND packet.head_published_revision_id IS NULL THEN
+                RAISE EXCEPTION 'published phenopacket requires head_published_revision_id';
+            END IF;
+            IF packet.editing_revision_id IS NOT NULL AND NOT EXISTS (
+                SELECT 1 FROM phenopacket_revisions revision
+                WHERE revision.id = packet.editing_revision_id
+                  AND revision.record_id = packet.id
+                  AND revision.state IN ('draft', 'in_review', 'changes_requested', 'approved')
+            ) THEN
+                RAISE EXCEPTION 'editing_revision_id must be an editable revision of its record';
+            END IF;
+            IF packet.state = 'archived' AND packet.editing_revision_id IS NOT NULL THEN
+                RAISE EXCEPTION 'archived phenopacket cannot retain editing_revision_id';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove activation only when no protected audit evidence exists."""
+    assert_independent_review_downgrade_safe(op.get_bind())
+    op.execute("DROP TRIGGER comments_review_issue_final_state ON comments")
+    op.execute("DROP FUNCTION validate_review_issue_final_state()")
+    op.execute("DROP TRIGGER comments_review_issue_mutation_guard ON comments")
+    op.execute("DROP FUNCTION guard_review_issue_mutation()")
+    op.execute(
+        "DROP TRIGGER comment_resolution_events_immutable ON comment_resolution_events"
+    )
+    op.execute("DROP FUNCTION reject_comment_resolution_event_mutation()")
+    op.execute(
+        "DROP TRIGGER comment_resolution_events_lock_record "
+        "ON comment_resolution_events"
+    )
+    op.execute("DROP FUNCTION lock_phenopacket_for_resolution_event()")
+    op.execute("DROP TRIGGER comments_review_issue_guard ON comments")
+    op.execute("DROP FUNCTION validate_review_issue_insert()")
+    op.execute(
+        "DROP TRIGGER phenopacket_revisions_00_lock_record ON phenopacket_revisions"
+    )
+    op.execute("DROP FUNCTION lock_phenopacket_for_revision_insert()")
+    op.drop_constraint(
+        op.f("ck_phenopackets_active_edit_owner"),
+        "phenopackets",
+        type_="check",
+    )
+    _restore_b9_pointer_validator()

--- a/backend/alembic/versions/e0f422b00006_activate_independent_review_invariants.py
+++ b/backend/alembic/versions/e0f422b00006_activate_independent_review_invariants.py
@@ -265,6 +265,63 @@ def _install_revision_lock_trigger() -> None:
 def _install_comment_and_event_triggers() -> None:
     op.execute(
         """
+        CREATE FUNCTION require_independent_review_actor(
+            packet_id UUID,
+            owner_id BIGINT,
+            candidate_id BIGINT,
+            head_number INTEGER,
+            review_actor_id BIGINT,
+            claimed_actor_role TEXT
+        ) RETURNS VOID AS $$
+        DECLARE
+            review_actor users%ROWTYPE;
+            candidate_submitter_id BIGINT;
+        BEGIN
+            IF owner_id IS NULL THEN
+                RAISE EXCEPTION 'review_author_unknown';
+            END IF;
+            SELECT * INTO review_actor FROM users WHERE id = review_actor_id;
+            IF NOT FOUND OR NOT review_actor.is_active
+               OR review_actor.role NOT IN ('curator','admin') THEN
+                RAISE EXCEPTION 'reviewer_not_eligible';
+            END IF;
+            IF claimed_actor_role IS NOT NULL
+               AND claimed_actor_role <> review_actor.role THEN
+                RAISE EXCEPTION 'reviewer_actor_role_mismatch';
+            END IF;
+            IF review_actor.id = owner_id THEN
+                RAISE EXCEPTION 'self_review_forbidden';
+            END IF;
+
+            SELECT actor_id INTO candidate_submitter_id
+              FROM phenopacket_revisions
+             WHERE id = candidate_id AND record_id = packet_id
+               AND state = 'in_review';
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'review_revision_mismatch';
+            END IF;
+            IF review_actor.id = candidate_submitter_id THEN
+                RAISE EXCEPTION 'reviewer_submitted';
+            END IF;
+            IF EXISTS (
+                SELECT 1 FROM phenopacket_revisions contribution
+                 WHERE contribution.record_id = packet_id
+                   AND contribution.actor_id = review_actor.id
+                   AND contribution.event_type IN
+                       ('created','draft_created','draft_saved')
+                   AND (
+                       head_number IS NULL
+                       OR contribution.revision_number > head_number
+                   )
+            ) THEN
+                RAISE EXCEPTION 'reviewer_contributed';
+            END IF;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
         CREATE FUNCTION validate_review_issue_insert()
         RETURNS trigger AS $$
         DECLARE
@@ -310,6 +367,14 @@ def _install_comment_and_event_triggers() -> None:
                     RAISE EXCEPTION 'review_revision_mismatch';
                 END IF;
             END IF;
+            PERFORM require_independent_review_actor(
+                packet.id,
+                packet.draft_owner_id,
+                reviewed_revision.id,
+                head_number,
+                NEW.author_id,
+                NULL
+            );
             RETURN NEW;
         END;
         $$ LANGUAGE plpgsql;
@@ -327,37 +392,60 @@ def _install_comment_and_event_triggers() -> None:
         CREATE FUNCTION lock_phenopacket_for_resolution_event()
         RETURNS trigger AS $$
         DECLARE
+            issue_probe comments%ROWTYPE;
             issue comments%ROWTYPE;
             packet phenopackets%ROWTYPE;
             active_revision phenopacket_revisions%ROWTYPE;
-            expected_candidate_id BIGINT;
             reviewed_revision phenopacket_revisions%ROWTYPE;
+            walk_revision phenopacket_revisions%ROWTYPE;
+            parent_revision phenopacket_revisions%ROWTYPE;
             head_number INTEGER;
+            candidate_in_cycle BOOLEAN := FALSE;
+            visited BIGINT[] := ARRAY[]::BIGINT[];
+            latest_event comment_resolution_events%ROWTYPE;
         BEGIN
-            SELECT * INTO issue FROM comments WHERE id = NEW.comment_id;
-            IF NOT FOUND OR issue.review_revision_id IS NULL
-               OR issue.record_type <> 'phenopacket'
-               OR issue.deleted_at IS NOT NULL THEN
+            SELECT * INTO issue_probe FROM comments WHERE id = NEW.comment_id;
+            IF NOT FOUND OR issue_probe.review_revision_id IS NULL
+               OR issue_probe.record_type <> 'phenopacket' THEN
                 RAISE EXCEPTION 'review_issue_mutation_forbidden';
             END IF;
 
             SELECT * INTO packet FROM phenopackets
-             WHERE id = issue.record_id FOR UPDATE;
+             WHERE id = issue_probe.record_id FOR UPDATE;
             IF NOT FOUND OR packet.draft_owner_id IS NULL THEN
                 RAISE EXCEPTION 'review_author_unknown';
+            END IF;
+            SELECT * INTO issue FROM comments
+             WHERE id = NEW.comment_id FOR UPDATE;
+            IF NOT FOUND OR issue.review_revision_id IS NULL
+               OR issue.record_type <> 'phenopacket'
+               OR issue.deleted_at IS NOT NULL
+               OR issue.record_id IS DISTINCT FROM issue_probe.record_id
+               OR issue.record_type IS DISTINCT FROM issue_probe.record_type
+               OR issue.review_revision_id IS DISTINCT FROM
+                  issue_probe.review_revision_id THEN
+                RAISE EXCEPTION 'review_issue_mutation_forbidden';
+            END IF;
+            SELECT * INTO latest_event FROM comment_resolution_events event
+             WHERE event.comment_id = issue.id
+             ORDER BY event.id DESC LIMIT 1;
+            IF FOUND AND NOT (
+                (
+                    latest_event.action = 'resolved'
+                    AND issue.resolved_at IS NOT NULL
+                    AND issue.resolved_by_id = latest_event.actor_id
+                ) OR (
+                    latest_event.action = 'reopened'
+                    AND issue.resolved_at IS NULL
+                    AND issue.resolved_by_id IS NULL
+                )
+            ) THEN
+                RAISE EXCEPTION 'review_issue_resolution_projection_mismatch';
             END IF;
             SELECT * INTO active_revision FROM phenopacket_revisions
              WHERE id = packet.editing_revision_id AND record_id = packet.id;
             IF NOT FOUND OR active_revision.state NOT IN ('in_review','changes_requested') THEN
                 RAISE EXCEPTION 'review_closed';
-            END IF;
-            expected_candidate_id := active_revision.id;
-            IF active_revision.state = 'changes_requested' THEN
-                expected_candidate_id := active_revision.parent_revision_id;
-            END IF;
-            IF expected_candidate_id IS NULL
-               OR expected_candidate_id <> issue.review_revision_id THEN
-                RAISE EXCEPTION 'review_revision_mismatch';
             END IF;
             SELECT * INTO reviewed_revision FROM phenopacket_revisions
              WHERE id = issue.review_revision_id
@@ -373,6 +461,52 @@ def _install_comment_and_event_triggers() -> None:
                     RAISE EXCEPTION 'review_revision_mismatch';
                 END IF;
             END IF;
+            walk_revision := active_revision;
+            LOOP
+                IF walk_revision.record_id <> packet.id
+                   OR walk_revision.id = ANY(visited) THEN
+                    RAISE EXCEPTION 'review_revision_mismatch';
+                END IF;
+                visited := array_append(visited, walk_revision.id);
+                IF walk_revision.id = issue.review_revision_id THEN
+                    candidate_in_cycle := TRUE;
+                END IF;
+
+                IF packet.head_published_revision_id IS NOT NULL
+                   AND walk_revision.id = packet.head_published_revision_id THEN
+                    IF walk_revision.state <> 'published'
+                       OR NOT candidate_in_cycle THEN
+                        RAISE EXCEPTION 'review_revision_mismatch';
+                    END IF;
+                    EXIT;
+                ELSIF packet.head_published_revision_id IS NULL
+                      AND walk_revision.parent_revision_id IS NULL THEN
+                    IF walk_revision.event_type <> 'created'
+                       OR NOT candidate_in_cycle THEN
+                        RAISE EXCEPTION 'review_revision_mismatch';
+                    END IF;
+                    EXIT;
+                ELSIF walk_revision.parent_revision_id IS NULL THEN
+                    RAISE EXCEPTION 'review_revision_mismatch';
+                END IF;
+
+                SELECT * INTO parent_revision FROM phenopacket_revisions
+                 WHERE id = walk_revision.parent_revision_id;
+                IF NOT FOUND OR parent_revision.record_id <> packet.id
+                   OR parent_revision.revision_number >=
+                      walk_revision.revision_number THEN
+                    RAISE EXCEPTION 'review_revision_mismatch';
+                END IF;
+                walk_revision := parent_revision;
+            END LOOP;
+            PERFORM require_independent_review_actor(
+                packet.id,
+                packet.draft_owner_id,
+                reviewed_revision.id,
+                head_number,
+                NEW.actor_id,
+                NEW.actor_role
+            );
             IF NEW.action = 'resolved' AND issue.resolved_at IS NOT NULL THEN
                 RAISE EXCEPTION 'review_issue_already_resolved';
             ELSIF NEW.action = 'reopened' AND issue.resolved_at IS NULL THEN
@@ -388,6 +522,44 @@ def _install_comment_and_event_triggers() -> None:
         CREATE TRIGGER comment_resolution_events_lock_record
         BEFORE INSERT ON comment_resolution_events
         FOR EACH ROW EXECUTE FUNCTION lock_phenopacket_for_resolution_event();
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION validate_resolution_event_projection()
+        RETURNS trigger AS $$
+        DECLARE
+            issue comments%ROWTYPE;
+            latest_event comment_resolution_events%ROWTYPE;
+        BEGIN
+            SELECT * INTO issue FROM comments WHERE id = NEW.comment_id;
+            SELECT * INTO latest_event FROM comment_resolution_events event
+             WHERE event.comment_id = NEW.comment_id
+             ORDER BY event.id DESC LIMIT 1;
+            IF issue.id IS NULL OR latest_event.id IS NULL OR NOT (
+                (
+                    latest_event.action = 'resolved'
+                    AND issue.resolved_at IS NOT NULL
+                    AND issue.resolved_by_id = latest_event.actor_id
+                ) OR (
+                    latest_event.action = 'reopened'
+                    AND issue.resolved_at IS NULL
+                    AND issue.resolved_by_id IS NULL
+                )
+            ) THEN
+                RAISE EXCEPTION 'review_issue_resolution_projection_mismatch';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
+        CREATE CONSTRAINT TRIGGER comment_resolution_events_projection_final_state
+        AFTER INSERT ON comment_resolution_events
+        DEFERRABLE INITIALLY DEFERRED
+        FOR EACH ROW EXECUTE FUNCTION validate_resolution_event_projection();
         """
     )
     op.execute(
@@ -667,12 +839,21 @@ def downgrade() -> None:
     )
     op.execute("DROP FUNCTION reject_comment_resolution_event_mutation()")
     op.execute(
+        "DROP TRIGGER comment_resolution_events_projection_final_state "
+        "ON comment_resolution_events"
+    )
+    op.execute("DROP FUNCTION validate_resolution_event_projection()")
+    op.execute(
         "DROP TRIGGER comment_resolution_events_lock_record "
         "ON comment_resolution_events"
     )
     op.execute("DROP FUNCTION lock_phenopacket_for_resolution_event()")
     op.execute("DROP TRIGGER comments_review_issue_guard ON comments")
     op.execute("DROP FUNCTION validate_review_issue_insert()")
+    op.execute(
+        "DROP FUNCTION require_independent_review_actor("
+        "UUID,BIGINT,BIGINT,INTEGER,BIGINT,TEXT)"
+    )
     op.execute(
         "DROP TRIGGER phenopacket_revisions_00_lock_record ON phenopacket_revisions"
     )

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -130,29 +130,6 @@ async def require_curator(current_user: User = Depends(get_current_user)) -> Use
 # D.2 comments ------------------------------------------------------------------
 
 
-async def require_comment_author_or_admin(
-    comment_id: int,
-    current_user: User = Depends(require_curator),
-    db: AsyncSession = Depends(get_db),
-) -> User:
-    """403 unless the caller authored the comment or is admin.
-
-    The router MUST use this for DELETE; PATCH has an additional
-    "author only (not admin)" check performed inline because the matrix
-    forbids admin body edits.
-    """
-    from app.comments.service import CommentsService  # local import avoids cycle
-
-    svc = CommentsService(db)
-    comment = await svc.get_by_id(comment_id, include_deleted=True)
-    if comment is None:
-        raise HTTPException(status_code=404, detail="Comment not found")
-    is_admin = current_user.role == "admin"
-    if comment.author_id != current_user.id and not is_admin:
-        raise HTTPException(status_code=403, detail="Author or admin only")
-    return current_user
-
-
 async def get_optional_user(
     request: Request,
     db: AsyncSession = Depends(get_db),

--- a/backend/app/comments/models.py
+++ b/backend/app/comments/models.py
@@ -8,21 +8,37 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import BigInteger, ForeignKey, Text
+from sqlalchemy import BigInteger, CheckConstraint, ForeignKey, Index, Text, text
 from sqlalchemy.dialects.postgresql import TIMESTAMP, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.schema import conv
 from sqlalchemy.sql import func
 
 from app.database import Base
 from app.models.user import User
+
+if TYPE_CHECKING:
+    from app.phenopackets.models import PhenopacketRevision
 
 
 class Comment(Base):
     """Curation-layer comment on a phenopacket (or future record types)."""
 
     __tablename__ = "comments"
+    __table_args__ = (
+        Index(
+            "ix_comments_live_unresolved_phenopacket_review_issues",
+            "record_id",
+            "review_revision_id",
+            postgresql_where=text(
+                "record_type = 'phenopacket' AND "
+                "review_revision_id IS NOT NULL AND "
+                "resolved_at IS NULL AND deleted_at IS NULL"
+            ),
+        ),
+    )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     record_type: Mapped[str] = mapped_column(Text, nullable=False)
@@ -49,6 +65,15 @@ class Comment(Base):
     deleted_by_id: Mapped[Optional[int]] = mapped_column(
         BigInteger, ForeignKey("users.id"), nullable=True
     )
+    review_revision_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger,
+        ForeignKey(
+            "phenopacket_revisions.id",
+            name=conv("fk_comments_review_revision"),
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+    )
 
     author: Mapped[User] = relationship("User", foreign_keys=[author_id], viewonly=True)
     resolved_by: Mapped[Optional[User]] = relationship(
@@ -57,6 +82,58 @@ class Comment(Base):
     deleted_by: Mapped[Optional[User]] = relationship(
         "User", foreign_keys=[deleted_by_id], viewonly=True
     )
+    review_revision: Mapped[Optional["PhenopacketRevision"]] = relationship(
+        "PhenopacketRevision", foreign_keys=[review_revision_id], viewonly=True
+    )
+    resolution_events: Mapped[list["CommentResolutionEvent"]] = relationship(
+        "CommentResolutionEvent", back_populates="comment", viewonly=True
+    )
+
+
+class CommentResolutionEvent(Base):
+    """Append-only audit event for resolving or reopening a review issue."""
+
+    __tablename__ = "comment_resolution_events"
+    __table_args__ = (
+        CheckConstraint(
+            "(action = 'reopened' AND disposition IS NULL) OR "
+            "(action = 'resolved' AND disposition IN "
+            "('addressed','accepted_with_rationale','retracted','superseded'))",
+            name=conv("ck_comment_resolution_event_action_disposition"),
+        ),
+        CheckConstraint(
+            "char_length(btrim(rationale)) BETWEEN 1 AND 500",
+            name=conv("ck_comment_resolution_event_rationale"),
+        ),
+        CheckConstraint(
+            "actor_role IN ('curator', 'admin')",
+            name=conv("ck_comment_resolution_event_actor_role"),
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    comment_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("comments.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    action: Mapped[str] = mapped_column(Text, nullable=False)
+    disposition: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    rationale: Mapped[str] = mapped_column(Text, nullable=False)
+    actor_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    actor_role: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    comment: Mapped[Comment] = relationship(
+        "Comment", back_populates="resolution_events", viewonly=True
+    )
+    actor: Mapped[User] = relationship("User", foreign_keys=[actor_id], viewonly=True)
 
 
 class CommentEdit(Base):

--- a/backend/app/comments/models.py
+++ b/backend/app/comments/models.py
@@ -97,7 +97,7 @@ class CommentResolutionEvent(Base):
     __table_args__ = (
         CheckConstraint(
             "(action = 'reopened' AND disposition IS NULL) OR "
-            "(action = 'resolved' AND disposition IN "
+            "(action = 'resolved' AND disposition IS NOT NULL AND disposition IN "
             "('addressed','accepted_with_rationale','retracted','superseded'))",
             name=conv("ck_comment_resolution_event_action_disposition"),
         ),

--- a/backend/app/comments/routers.py
+++ b/backend/app/comments/routers.py
@@ -15,13 +15,10 @@ import logging
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth.dependencies import (
-    require_comment_author_or_admin,
-    require_curator,
-)
+from app.auth.dependencies import require_curator
 from app.comments.models import Comment
 from app.comments.schemas import (
     CommentCreate,
@@ -33,6 +30,7 @@ from app.comments.schemas import (
 from app.comments.service import CommentsService
 from app.database import get_db
 from app.models.user import User
+from app.phenopackets.review.policy import ReviewPolicyError
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +135,38 @@ def _map_service_error(exc: Exception) -> HTTPException:
             status_code=404,
             detail={"code": "not_found", "message": str(exc)},
         )
+    if isinstance(exc, CommentsService.IssueInputInvalid):
+        return HTTPException(
+            status_code=422,
+            detail={"code": "review_issue_input_invalid", "message": str(exc)},
+        )
+    conflict_errors = (
+        (CommentsService.RevisionMismatch, "revision_mismatch"),
+        (CommentsService.ReviewRevisionMismatch, "review_revision_mismatch"),
+        (CommentsService.ReviewClosed, "review_closed"),
+        (
+            CommentsService.ReviewIssueDeleteForbidden,
+            "review_issue_delete_forbidden",
+        ),
+    )
+    for error_type, code in conflict_errors:
+        if isinstance(exc, error_type):
+            return HTTPException(
+                status_code=409,
+                detail={"code": code, "message": str(exc)},
+            )
+    if isinstance(exc, ReviewPolicyError):
+        status_code = (
+            409 if exc.code in {"review_closed", "unresolved_review_issues"} else 403
+        )
+        return HTTPException(
+            status_code=status_code,
+            detail={
+                "code": exc.code,
+                "message": exc.message,
+                **({"context": exc.context} if exc.context else {}),
+            },
+        )
     # Unmapped exception path: log the real cause server-side, return a
     # generic 500 so we don't leak SQL fragments / stack context to the
     # client (Copilot PR #254 routers.py:137).
@@ -167,10 +197,15 @@ async def create_comment(
             body_markdown=body.body_markdown,
             mention_user_ids=body.mention_user_ids,
             actor=current_user,
+            record_revision=body.record_revision,
+            review_revision_id=body.review_revision_id,
         )
+        response = await _build_comment_response(svc, comment)
+        await db.commit()
+        return response
     except Exception as exc:
+        await db.rollback()
         raise _map_service_error(exc) from exc
-    return await _build_comment_response(svc, comment)
 
 
 # ---------------------------------------------------------------------------
@@ -267,9 +302,12 @@ async def update_comment(
             mention_user_ids=body.mention_user_ids,
             actor=current_user,
         )
+        response = await _build_comment_response(svc, comment)
+        await db.commit()
+        return response
     except Exception as exc:
+        await db.rollback()
         raise _map_service_error(exc) from exc
-    return await _build_comment_response(svc, comment)
 
 
 # ---------------------------------------------------------------------------
@@ -280,31 +318,47 @@ async def update_comment(
 @router.post("/{comment_id}/resolve", response_model=CommentResponse)
 async def resolve_comment(
     comment_id: int,
+    body: Any = Body(default=None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_curator),
 ) -> CommentResponse:
     """Mark a comment as resolved."""
     svc = CommentsService(db)
     try:
-        comment = await svc.resolve(comment_id=comment_id, actor=current_user)
+        comment = await svc.resolve(
+            comment_id=comment_id,
+            actor=current_user,
+            issue_input=body,
+        )
+        response = await _build_comment_response(svc, comment)
+        await db.commit()
+        return response
     except Exception as exc:
+        await db.rollback()
         raise _map_service_error(exc) from exc
-    return await _build_comment_response(svc, comment)
 
 
 @router.post("/{comment_id}/unresolve", response_model=CommentResponse)
 async def unresolve_comment(
     comment_id: int,
+    body: Any = Body(default=None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_curator),
 ) -> CommentResponse:
     """Clear the resolved flag on a comment."""
     svc = CommentsService(db)
     try:
-        comment = await svc.unresolve(comment_id=comment_id, actor=current_user)
+        comment = await svc.unresolve(
+            comment_id=comment_id,
+            actor=current_user,
+            issue_input=body,
+        )
+        response = await _build_comment_response(svc, comment)
+        await db.commit()
+        return response
     except Exception as exc:
+        await db.rollback()
         raise _map_service_error(exc) from exc
-    return await _build_comment_response(svc, comment)
 
 
 # ---------------------------------------------------------------------------
@@ -316,15 +370,17 @@ async def unresolve_comment(
 async def delete_comment(
     comment_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_comment_author_or_admin),
+    current_user: User = Depends(require_curator),
 ) -> Response:
     """Soft-delete a comment (author or admin only)."""
     svc = CommentsService(db)
     try:
         await svc.soft_delete(comment_id=comment_id, actor=current_user)
+        await db.commit()
+        return Response(status_code=204)
     except Exception as exc:
+        await db.rollback()
         raise _map_service_error(exc) from exc
-    return Response(status_code=204)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/comments/schemas.py
+++ b/backend/app/comments/schemas.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import List, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt
 
 
 class CommentMentionOut(BaseModel):
@@ -49,6 +49,32 @@ class CommentCreate(BaseModel):
     record_id: UUID
     body_markdown: str = Field(min_length=1, max_length=10000)
     mention_user_ids: List[int] = Field(default_factory=list, max_length=50)
+    record_revision: Optional[NonNegativeInt] = None
+    review_revision_id: Optional[PositiveInt] = None
+
+
+class _ReviewIssueRequest(BaseModel):
+    """Strict optimistic-concurrency input shared by issue actions."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    record_revision: NonNegativeInt
+    rationale: str = Field(min_length=1, max_length=500)
+
+
+class ReviewIssueResolveRequest(_ReviewIssueRequest):
+    """Evidence required to resolve or retract one blocking review issue."""
+
+    disposition: Literal[
+        "addressed",
+        "accepted_with_rationale",
+        "retracted",
+        "superseded",
+    ]
+
+
+class ReviewIssueReopenRequest(_ReviewIssueRequest):
+    """Evidence required to reopen one blocking review issue."""
 
 
 class CommentUpdate(BaseModel):

--- a/backend/app/comments/service.py
+++ b/backend/app/comments/service.py
@@ -3,19 +3,27 @@
 from __future__ import annotations
 
 import uuid
-from typing import List, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Sequence, Tuple
 
+from pydantic import ValidationError
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.comments.models import Comment, CommentEdit, CommentMention
+from app.comments.models import (
+    Comment,
+    CommentEdit,
+    CommentMention,
+    CommentResolutionEvent,
+)
+from app.comments.schemas import ReviewIssueReopenRequest, ReviewIssueResolveRequest
 from app.models.user import User
-from app.phenopackets.models import Phenopacket
+from app.phenopackets.models import Phenopacket, PhenopacketRevision
+from app.phenopackets.review.policy import IssueAction, ReviewPolicy
 
 
 class CommentsService:
-    """All comment operations. Single-transaction, commit at the end of each method."""
+    """All comment operations, flushed into the router-owned transaction."""
 
     class RecordNotFound(Exception):
         """(record_type, record_id) does not resolve to a real record (C3)."""
@@ -38,6 +46,21 @@ class CommentsService:
     class SoftDeleted(Exception):
         """Write attempted on a soft-deleted comment (C6)."""
 
+    class RevisionMismatch(Exception):
+        """The optimistic phenopacket revision is stale."""
+
+    class ReviewRevisionMismatch(Exception):
+        """The issue does not identify the exact active review candidate."""
+
+    class ReviewClosed(Exception):
+        """The active cycle is not open for the requested issue action."""
+
+    class ReviewIssueDeleteForbidden(Exception):
+        """Blocking review issues are retained through audited retraction."""
+
+    class IssueInputInvalid(Exception):
+        """A blocking issue action omitted or malformed its conditional body."""
+
     def __init__(self, db: AsyncSession) -> None:
         """Initialise with an async database session."""
         self.db = db
@@ -46,34 +69,24 @@ class CommentsService:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    async def _check_record_exists(
-        self, record_type: str, record_id: uuid.UUID
-    ) -> None:
-        """C3 — verify target record is not hard-deleted (soft-deleted is OK).
+    async def _lock_record(self, record_type: str, record_id: uuid.UUID) -> Phenopacket:
+        """Lock a comment owner, including a soft-deleted phenopacket.
 
         The global soft-delete ORM filter (app.database._register_soft_delete_filter)
-        would exclude soft-deleted Phenopacket rows from the count query. We bypass
-        it via ``include_deleted=True`` so that soft-deleted records are still valid
-        comment targets (spec invariant C3).
+        is bypassed because comments remain addressable after owner soft deletion.
         """
         if record_type != "phenopacket":
             raise self.RecordNotFound(f"Unsupported record_type {record_type!r}")
-        stmt = (
-            select(func.count())
-            .select_from(Phenopacket)
-            .where(Phenopacket.id == record_id)
-        )
-        count = int(
-            (
-                await self.db.execute(
-                    stmt,
-                    execution_options={"include_deleted": True},
-                )
-            ).scalar()
-            or 0
-        )
-        if count == 0:
+        stmt = select(Phenopacket).where(Phenopacket.id == record_id).with_for_update()
+        record = (
+            await self.db.execute(
+                stmt,
+                execution_options={"include_deleted": True},
+            )
+        ).scalar_one_or_none()
+        if record is None:
             raise self.RecordNotFound(f"No phenopacket with id {record_id}")
+        return record
 
     async def _validate_mentions(self, mention_user_ids: Sequence[int]) -> List[int]:
         """Dedup + verify each id points to an active curator/admin."""
@@ -118,9 +131,25 @@ class CommentsService:
         body_markdown: str,
         mention_user_ids: Sequence[int],
         actor: User,
+        record_revision: int | None = None,
+        review_revision_id: int | None = None,
     ) -> Comment:
         """Insert a new comment and its mention rows atomically."""
-        await self._check_record_exists(record_type, record_id)
+        record = await self._lock_record(record_type, record_id)
+        is_issue = review_revision_id is not None or record_revision is not None
+        if is_issue:
+            if review_revision_id is None or record_revision is None:
+                raise self.IssueInputInvalid(
+                    "record_revision and review_revision_id are required together"
+                )
+            candidate = await self._validate_issue_action(
+                record,
+                review_revision_id=review_revision_id,
+                record_revision=record_revision,
+                actor=actor,
+                action="create",
+            )
+            review_revision_id = candidate.id
         validated_mentions = await self._validate_mentions(mention_user_ids)
 
         comment = Comment(
@@ -128,6 +157,7 @@ class CommentsService:
             record_id=record_id,
             author_id=actor.id,
             body_markdown=body_markdown,
+            review_revision_id=review_revision_id,
         )
         self.db.add(comment)
         await self.db.flush()  # obtain comment.id
@@ -135,7 +165,7 @@ class CommentsService:
         for uid in validated_mentions:
             self.db.add(CommentMention(comment_id=comment.id, user_id=uid))
 
-        await self.db.commit()
+        await self.db.flush()
         return await self._load_for_response(comment.id)
 
     # ------------------------------------------------------------------
@@ -248,15 +278,109 @@ class CommentsService:
     # Mutations
     # ------------------------------------------------------------------
 
-    async def _fetch_live_or_404(self, comment_id: int) -> Comment:
-        """Lock FOR UPDATE; raise SoftDeleted (→ 404) if already removed."""
+    async def _probe_comment_identity(
+        self, comment_id: int
+    ) -> tuple[int, str, uuid.UUID]:
+        """Read only immutable routing identity before acquiring either row lock."""
+        stmt = select(Comment.id, Comment.record_type, Comment.record_id).where(
+            Comment.id == comment_id
+        )
+        identity = (await self.db.execute(stmt)).one_or_none()
+        if identity is None:
+            raise self.SoftDeleted(f"comment {comment_id} not found")
+        return identity.id, identity.record_type, identity.record_id
+
+    async def _lock_phenopacket_then_comment(self, comment_id: int) -> Comment:
+        """Apply the global owner-before-comment lock protocol."""
+        identity = await self._probe_comment_identity(comment_id)
+        await self._lock_record(identity[1], identity[2])
         stmt = select(Comment).where(Comment.id == comment_id).with_for_update()
         comment = (await self.db.execute(stmt)).scalar_one_or_none()
         if comment is None:
             raise self.SoftDeleted(f"comment {comment_id} not found")
+        if (comment.id, comment.record_type, comment.record_id) != identity:
+            raise self.SoftDeleted(f"comment {comment_id} identity changed")
         if comment.deleted_at is not None:
             raise self.SoftDeleted(f"comment {comment_id} is soft-deleted")
         return comment
+
+    async def _validate_issue_action(
+        self,
+        record: Phenopacket,
+        *,
+        review_revision_id: int,
+        record_revision: int,
+        actor: User,
+        action: IssueAction,
+    ) -> PhenopacketRevision:
+        """Validate optimistic identity, active cycle, state, and independence."""
+        if record.revision != record_revision:
+            raise self.RevisionMismatch(
+                f"expected record revision {record_revision}, found {record.revision}"
+            )
+        if record.editing_revision_id is None:
+            raise self.ReviewClosed("record has no active review cycle")
+
+        active = await self.db.get(PhenopacketRevision, record.editing_revision_id)
+        if active is None or active.record_id != record.id:
+            raise self.ReviewRevisionMismatch("active review revision is invalid")
+
+        effective_state = active.state
+        expected_candidate_id = active.id
+        if action == "create":
+            if effective_state != "in_review":
+                raise self.ReviewClosed("review is not open for issue creation")
+        else:
+            if effective_state not in ("in_review", "changes_requested"):
+                raise self.ReviewClosed("review is not open for issue action")
+            if effective_state == "changes_requested":
+                if active.parent_revision_id is None:
+                    raise self.ReviewRevisionMismatch(
+                        "changes-requested revision has no candidate"
+                    )
+                expected_candidate_id = active.parent_revision_id
+
+        if review_revision_id != expected_candidate_id:
+            raise self.ReviewRevisionMismatch(
+                "review issue is not linked to the active candidate"
+            )
+        candidate = await self.db.get(PhenopacketRevision, review_revision_id)
+        if (
+            candidate is None
+            or candidate.record_id != record.id
+            or candidate.state != "in_review"
+        ):
+            raise self.ReviewRevisionMismatch(
+                "review issue candidate does not belong to this record"
+            )
+        await ReviewPolicy.require_issue_action(
+            self.db,
+            record,
+            candidate,
+            actor,
+            action=action,
+        )
+        return candidate
+
+    @classmethod
+    def _resolve_request(cls, issue_input: Any) -> ReviewIssueResolveRequest:
+        """Validate a resolve body only after locked issue discrimination."""
+        try:
+            return ReviewIssueResolveRequest.model_validate(issue_input)
+        except ValidationError as exc:
+            raise cls.IssueInputInvalid(
+                "blocking issue resolve input is invalid"
+            ) from exc
+
+    @classmethod
+    def _reopen_request(cls, issue_input: Any) -> ReviewIssueReopenRequest:
+        """Validate a reopen body only after locked issue discrimination."""
+        try:
+            return ReviewIssueReopenRequest.model_validate(issue_input)
+        except ValidationError as exc:
+            raise cls.IssueInputInvalid(
+                "blocking issue reopen input is invalid"
+            ) from exc
 
     async def update_body(
         self,
@@ -267,7 +391,7 @@ class CommentsService:
         actor: User,
     ) -> Comment:
         """PATCH body (author-only). Writes comment_edits + replaces mentions."""
-        comment = await self._fetch_live_or_404(comment_id)
+        comment = await self._lock_phenopacket_then_comment(comment_id)
         if comment.author_id != actor.id:
             raise self.NotAuthor(
                 f"actor {actor.id} is not comment author {comment.author_id}"
@@ -292,38 +416,101 @@ class CommentsService:
         for uid in validated:
             self.db.add(CommentMention(comment_id=comment.id, user_id=uid))
 
-        await self.db.commit()
+        await self.db.flush()
         return await self._load_for_response(comment.id)
 
-    async def resolve(self, *, comment_id: int, actor: User) -> Comment:
+    async def resolve(
+        self, *, comment_id: int, actor: User, issue_input: Any = None
+    ) -> Comment:
         """Mark a comment resolved; raises AlreadyResolved if already so."""
-        comment = await self._fetch_live_or_404(comment_id)
+        comment = await self._lock_phenopacket_then_comment(comment_id)
         if comment.resolved_at is not None:
             raise self.AlreadyResolved(f"comment {comment_id} already resolved")
+        if comment.review_revision_id is not None:
+            request = self._resolve_request(issue_input)
+            record = await self._locked_record_for_comment(comment)
+            await self._validate_issue_action(
+                record,
+                review_revision_id=comment.review_revision_id,
+                record_revision=request.record_revision,
+                actor=actor,
+                action="resolve",
+            )
+            self.db.add(
+                CommentResolutionEvent(
+                    comment_id=comment.id,
+                    action="resolved",
+                    disposition=request.disposition,
+                    rationale=request.rationale,
+                    actor_id=actor.id,
+                    actor_role=actor.role,
+                )
+            )
+            await self.db.flush()
         comment.resolved_at = func.now()
         comment.resolved_by_id = actor.id
         comment.updated_at = func.now()
-        await self.db.commit()
+        await self.db.flush()
         return await self._load_for_response(comment_id)
 
-    async def unresolve(self, *, comment_id: int, actor: User) -> Comment:
+    async def unresolve(
+        self, *, comment_id: int, actor: User, issue_input: Any = None
+    ) -> Comment:
         """Clear the resolved flag; raises NotResolved if not currently resolved."""
-        comment = await self._fetch_live_or_404(comment_id)
+        comment = await self._lock_phenopacket_then_comment(comment_id)
         if comment.resolved_at is None:
             raise self.NotResolved(f"comment {comment_id} is not resolved")
+        if comment.review_revision_id is not None:
+            request = self._reopen_request(issue_input)
+            record = await self._locked_record_for_comment(comment)
+            await self._validate_issue_action(
+                record,
+                review_revision_id=comment.review_revision_id,
+                record_revision=request.record_revision,
+                actor=actor,
+                action="reopen",
+            )
+            self.db.add(
+                CommentResolutionEvent(
+                    comment_id=comment.id,
+                    action="reopened",
+                    disposition=None,
+                    rationale=request.rationale,
+                    actor_id=actor.id,
+                    actor_role=actor.role,
+                )
+            )
+            await self.db.flush()
         comment.resolved_at = None
         comment.resolved_by_id = None
         comment.updated_at = func.now()
-        await self.db.commit()
+        await self.db.flush()
         return await self._load_for_response(comment_id)
+
+    async def _locked_record_for_comment(self, comment: Comment) -> Phenopacket:
+        """Return the already owner-locked record without changing lock order."""
+        stmt = select(Phenopacket).where(Phenopacket.id == comment.record_id)
+        record = (
+            await self.db.execute(
+                stmt,
+                execution_options={"include_deleted": True},
+            )
+        ).scalar_one_or_none()
+        if record is None:
+            raise self.RecordNotFound(f"No phenopacket with id {comment.record_id}")
+        return record
 
     async def soft_delete(self, *, comment_id: int, actor: User) -> None:
         """Soft-delete a comment (author or admin only). Terminal write (C6)."""
-        comment = await self._fetch_live_or_404(comment_id)
+        comment = await self._lock_phenopacket_then_comment(comment_id)
+        if comment.review_revision_id is not None:
+            raise self.ReviewIssueDeleteForbidden(
+                "blocking review issues must be retracted, not deleted"
+            )
         is_admin = actor.role == "admin"
         if comment.author_id != actor.id and not is_admin:
             raise self.NotAuthorOrAdmin(f"actor {actor.id} is not author and not admin")
         comment.deleted_at = func.now()
         comment.deleted_by_id = actor.id
         comment.updated_at = func.now()
-        await self.db.commit()
+        await self.db.flush()

--- a/backend/app/comments/service.py
+++ b/backend/app/comments/service.py
@@ -326,24 +326,16 @@ class CommentsService:
             raise self.ReviewRevisionMismatch("active review revision is invalid")
 
         effective_state = active.state
-        expected_candidate_id = active.id
         if action == "create":
             if effective_state != "in_review":
                 raise self.ReviewClosed("review is not open for issue creation")
+            if review_revision_id != active.id:
+                raise self.ReviewRevisionMismatch(
+                    "review issue is not linked to the active candidate"
+                )
         else:
             if effective_state not in ("in_review", "changes_requested"):
                 raise self.ReviewClosed("review is not open for issue action")
-            if effective_state == "changes_requested":
-                if active.parent_revision_id is None:
-                    raise self.ReviewRevisionMismatch(
-                        "changes-requested revision has no candidate"
-                    )
-                expected_candidate_id = active.parent_revision_id
-
-        if review_revision_id != expected_candidate_id:
-            raise self.ReviewRevisionMismatch(
-                "review issue is not linked to the active candidate"
-            )
         candidate = await self.db.get(PhenopacketRevision, review_revision_id)
         if (
             candidate is None

--- a/backend/app/phenopackets/models.py
+++ b/backend/app/phenopackets/models.py
@@ -314,7 +314,8 @@ class PhenopacketRevision(Base):
             name=conv("ck_phenopacket_revisions_ledger_version"),
         ),
         CheckConstraint(
-            "decision_metadata IS NULL OR ledger_version = 2",
+            "decision_metadata IS NULL OR "
+            "(ledger_version IS NOT NULL AND ledger_version = 2)",
             name=conv("ck_phenopacket_revisions_decision_metadata_ledger"),
         ),
     )

--- a/backend/app/phenopackets/models.py
+++ b/backend/app/phenopackets/models.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import (
     BigInteger,
+    CheckConstraint,
     Computed,
     DateTime,
     ForeignKey,
@@ -19,6 +20,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.schema import conv
 
 from app.database import Base
 
@@ -298,6 +300,24 @@ class PhenopacketRevision(Base):
     """
 
     __tablename__ = "phenopacket_revisions"
+    __table_args__ = (
+        CheckConstraint(
+            "actor_role IS NULL OR actor_role IN ('viewer', 'curator', 'admin')",
+            name=conv("ck_phenopacket_revisions_actor_role"),
+        ),
+        CheckConstraint(
+            "content_sha256 IS NULL OR content_sha256 ~ '^sha256:[0-9a-f]{64}$'",
+            name=conv("ck_phenopacket_revisions_content_sha256"),
+        ),
+        CheckConstraint(
+            "ledger_version IS NULL OR ledger_version = 2",
+            name=conv("ck_phenopacket_revisions_ledger_version"),
+        ),
+        CheckConstraint(
+            "decision_metadata IS NULL OR ledger_version = 2",
+            name=conv("ck_phenopacket_revisions_decision_metadata_ledger"),
+        ),
+    )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     record_id: Mapped[uuid.UUID] = mapped_column(
@@ -334,6 +354,12 @@ class PhenopacketRevision(Base):
     projection_version: Mapped[Optional[str]] = mapped_column(String(40))
     ledger_hash: Mapped[Optional[str]] = mapped_column(String(128))
     projection_hash: Mapped[Optional[str]] = mapped_column(String(128))
+    actor_role: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    decision_metadata: Mapped[Optional[Dict[str, Any]]] = mapped_column(
+        JSONB, nullable=True
+    )
+    content_sha256: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    ledger_version: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/backend/app/phenopackets/models.py
+++ b/backend/app/phenopackets/models.py
@@ -39,6 +39,12 @@ class Phenopacket(Base):
     """
 
     __tablename__ = "phenopackets"
+    __table_args__ = (
+        CheckConstraint(
+            "editing_revision_id IS NULL OR draft_owner_id IS NOT NULL",
+            name=conv("ck_phenopackets_active_edit_owner"),
+        ),
+    )
 
     # Primary key
     id: Mapped[uuid.UUID] = mapped_column(

--- a/backend/app/phenopackets/models.py
+++ b/backend/app/phenopackets/models.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from sqlalchemy import (
     BigInteger,
     CheckConstraint,
@@ -720,6 +720,13 @@ class AggregationResult(BaseModel):
 # Wave 7 D.1: state-machine Pydantic schemas (§7.3)
 
 
+class ApprovalAttestation(BaseModel):
+    """Affirmative statements required for an independent approval decision."""
+
+    independent_review: Literal[True]
+    no_unmanaged_conflict: Literal[True]
+
+
 class TransitionRequest(BaseModel):
     """Request body for POST /phenopackets/{id}/transitions.
 
@@ -736,6 +743,55 @@ class TransitionRequest(BaseModel):
     ]
     reason: str = Field(..., min_length=1, max_length=500)
     revision: int
+    candidate_revision_id: Optional[int] = Field(None, gt=0)
+    candidate_content_sha256: Optional[str] = Field(
+        None, pattern=r"^sha256:[0-9a-f]{64}$"
+    )
+    approved_revision_id: Optional[int] = Field(None, gt=0)
+    approved_content_sha256: Optional[str] = Field(
+        None, pattern=r"^sha256:[0-9a-f]{64}$"
+    )
+    attestation: Optional[ApprovalAttestation] = None
+
+    @model_validator(mode="after")
+    def validate_conditional_fields(self) -> "TransitionRequest":
+        """Require only the exact-snapshot fields for the selected transition."""
+        candidate_fields_present = (
+            self.candidate_revision_id is not None
+            or self.candidate_content_sha256 is not None
+            or self.attestation is not None
+        )
+        approved_fields_present = (
+            self.approved_revision_id is not None
+            or self.approved_content_sha256 is not None
+        )
+
+        if self.to_state == "approved":
+            if approved_fields_present:
+                raise ValueError("approval rejects approved snapshot fields")
+            if (
+                self.candidate_revision_id is None
+                or self.candidate_content_sha256 is None
+                or self.attestation is None
+            ):
+                raise ValueError(
+                    "approval requires candidate snapshot fields and attestation"
+                )
+            return self
+
+        if self.to_state == "published":
+            if candidate_fields_present:
+                raise ValueError("publication rejects candidate and attestation fields")
+            if (
+                self.approved_revision_id is None
+                or self.approved_content_sha256 is None
+            ):
+                raise ValueError("publication requires approved snapshot fields")
+            return self
+
+        if candidate_fields_present or approved_fields_present:
+            raise ValueError("conditional snapshot fields are not allowed")
+        return self
 
 
 class RevisionResponse(BaseModel):
@@ -758,7 +814,18 @@ class RevisionResponse(BaseModel):
     change_reason: str
     actor_id: int
     actor_username: Optional[str] = None
+    actor_role: Optional[str] = None
+    actor_role_at_decision_recorded: bool = False
+    decision_metadata: Optional[Dict[str, Any]] = None
+    content_sha256: Optional[str] = None
+    ledger_version: Optional[int] = None
     change_patch: Optional[List[Dict[str, Any]]] = None
     created_at: datetime
     # populated only on /{id}/revisions/{rev_id}
     content_jsonb: Optional[Dict[str, Any]] = None
+
+    @model_validator(mode="after")
+    def derive_recorded_role_flag(self) -> "RevisionResponse":
+        """Label only immutable role snapshots as recorded decision evidence."""
+        self.actor_role_at_decision_recorded = self.actor_role is not None
+        return self

--- a/backend/app/phenopackets/models.py
+++ b/backend/app/phenopackets/models.py
@@ -756,14 +756,20 @@ class TransitionRequest(BaseModel):
     @model_validator(mode="after")
     def validate_conditional_fields(self) -> "TransitionRequest":
         """Require only the exact-snapshot fields for the selected transition."""
-        candidate_fields_present = (
-            self.candidate_revision_id is not None
-            or self.candidate_content_sha256 is not None
-            or self.attestation is not None
+        candidate_fields_present = bool(
+            self.model_fields_set
+            & {
+                "candidate_revision_id",
+                "candidate_content_sha256",
+                "attestation",
+            }
         )
-        approved_fields_present = (
-            self.approved_revision_id is not None
-            or self.approved_content_sha256 is not None
+        approved_fields_present = bool(
+            self.model_fields_set
+            & {
+                "approved_revision_id",
+                "approved_content_sha256",
+            }
         )
 
         if self.to_state == "approved":

--- a/backend/app/phenopackets/review/__init__.py
+++ b/backend/app/phenopackets/review/__init__.py
@@ -1,0 +1,16 @@
+"""Independent phenopacket review policy."""
+
+from app.phenopackets.review.policy import ReviewPolicy, ReviewPolicyError
+from app.phenopackets.review.schemas import (
+    ActionCapability,
+    ReviewBlockCode,
+    ReviewCapabilities,
+)
+
+__all__ = [
+    "ActionCapability",
+    "ReviewBlockCode",
+    "ReviewCapabilities",
+    "ReviewPolicy",
+    "ReviewPolicyError",
+]

--- a/backend/app/phenopackets/review/policy.py
+++ b/backend/app/phenopackets/review/policy.py
@@ -17,6 +17,7 @@ from app.phenopackets.review.schemas import (
 )
 
 DecisionAction = Literal["request_changes", "approve"]
+IssueAction = Literal["create", "resolve", "reopen"]
 _CONTENT_EVENTS = ("created", "draft_created", "draft_saved")
 
 
@@ -173,6 +174,64 @@ class ReviewPolicy:
             else {}
         )
         raise ReviewPolicyError(code, cls._MESSAGES[code], context)
+
+    @classmethod
+    async def require_issue_action(
+        cls,
+        db: AsyncSession,
+        phenopacket: Phenopacket,
+        candidate_revision: PhenopacketRevision,
+        actor: User,
+        *,
+        action: IssueAction,
+    ) -> None:
+        """Require an independent reviewer for an active-cycle issue action.
+
+        Creation is limited to an active ``in_review`` candidate. Resolution
+        and reopening remain available after ``changes_requested`` so the
+        issue ledger can be completed without reopening the whole review.
+        """
+        if not actor.is_active or actor.role not in ("curator", "admin"):
+            raise cls._error("review_closed")
+
+        effective_state, active_revision = await cls._effective_review_state(
+            db, phenopacket
+        )
+        allowed_states = (
+            {"in_review"} if action == "create" else {"in_review", "changes_requested"}
+        )
+        if effective_state not in allowed_states or active_revision is None:
+            raise cls._error("review_closed")
+
+        expected_candidate = active_revision
+        if effective_state == "changes_requested":
+            if active_revision.parent_revision_id is None:
+                raise cls._error("review_author_unknown")
+            parent = await db.get(
+                PhenopacketRevision, active_revision.parent_revision_id
+            )
+            if (
+                parent is None
+                or parent.record_id != phenopacket.id
+                or parent.state != "in_review"
+                or parent.revision_number >= active_revision.revision_number
+            ):
+                raise cls._error("review_author_unknown")
+            expected_candidate = parent
+
+        if (
+            candidate_revision.id != expected_candidate.id
+            or candidate_revision.record_id != phenopacket.id
+            or candidate_revision.state != "in_review"
+        ):
+            raise cls._error("review_closed")
+
+        blockers = await cls._independence_blockers(
+            db, phenopacket, candidate_revision, actor
+        )
+        if blockers:
+            code = blockers[0]
+            raise ReviewPolicyError(code, cls._MESSAGES[code])
 
     @staticmethod
     def _capability(

--- a/backend/app/phenopackets/review/policy.py
+++ b/backend/app/phenopackets/review/policy.py
@@ -82,17 +82,26 @@ class ReviewPolicy:
             db, phenopacket
         )
         cycle_start = await cls._cycle_start_revision(db, phenopacket)
-        candidate_is_active = await cls._candidate_is_active(
-            db,
-            phenopacket,
-            candidate_revision,
-            effective_state,
-            active_revision,
+        candidate_ancestry_unknown = False
+        try:
+            expected_candidate = await cls.active_candidate(
+                db, phenopacket, active_revision
+            )
+        except ReviewPolicyError as exc:
+            expected_candidate = None
+            candidate_ancestry_unknown = exc.code == "review_author_unknown"
+        candidate_is_active = (
+            expected_candidate is not None
+            and expected_candidate.id == candidate_revision.id
         )
 
-        ancestry_unknown = cycle_start is False or (
-            cycle_start is not None
-            and candidate_revision.revision_number <= cycle_start
+        ancestry_unknown = (
+            candidate_ancestry_unknown
+            or cycle_start is False
+            or (
+                cycle_start is not None
+                and candidate_revision.revision_number <= cycle_start
+            )
         )
         if phenopacket.draft_owner_id is None or ancestry_unknown:
             common_blockers: list[ReviewBlockCode] = ["review_author_unknown"]
@@ -173,7 +182,7 @@ class ReviewPolicy:
         return ActionCapability(
             action=action,
             allowed=not blockers,
-            blocked_by=blockers,
+            blocked_by=tuple(blockers),
         )
 
     @staticmethod
@@ -191,43 +200,43 @@ class ReviewPolicy:
         return active_revision.state, active_revision
 
     @classmethod
-    async def _candidate_is_active(
+    async def active_candidate(
         cls,
         db: AsyncSession,
         phenopacket: Phenopacket,
-        candidate: PhenopacketRevision,
-        effective_state: str,
         active_revision: PhenopacketRevision | None,
-    ) -> bool:
-        """Confirm the submission snapshot belongs to the current review cycle."""
-        if (
-            candidate.record_id != phenopacket.id
-            or candidate.state != "in_review"
-            or effective_state not in ("in_review", "approved")
-        ):
-            return False
+    ) -> PhenopacketRevision:
+        """Resolve the inspected candidate from the active revision's direct chain.
 
-        if active_revision is None:
-            return False
-        if effective_state == "in_review":
-            return active_revision.id == candidate.id
+        Raises:
+            ReviewPolicyError: When active review ancestry is missing or invalid,
+                or when the active state is no longer reviewable.
+        """
+        if active_revision is None or active_revision.record_id != phenopacket.id:
+            raise cls._error("review_author_unknown")
+        if active_revision.state == "in_review":
+            return active_revision
+        if active_revision.state != "approved":
+            raise cls._error("review_closed")
+        if active_revision.parent_revision_id is None:
+            raise cls._error("review_author_unknown")
 
-        cycle_start = await cls._cycle_start_revision(db, phenopacket)
-        if cycle_start is False:
-            return False
-        stmt = select(PhenopacketRevision.id).where(
-            PhenopacketRevision.record_id == phenopacket.id,
-            PhenopacketRevision.state == "in_review",
-            PhenopacketRevision.revision_number < active_revision.revision_number,
+        candidate = await db.get(
+            PhenopacketRevision, active_revision.parent_revision_id
         )
-        if cycle_start is not None:
-            stmt = stmt.where(PhenopacketRevision.revision_number > cycle_start)
-        latest_candidate_id = (
-            await db.execute(
-                stmt.order_by(PhenopacketRevision.revision_number.desc()).limit(1)
-            )
-        ).scalar_one_or_none()
-        return latest_candidate_id == candidate.id
+        if (
+            candidate is None
+            or candidate.record_id != phenopacket.id
+            or candidate.state != "in_review"
+            or candidate.revision_number >= active_revision.revision_number
+        ):
+            raise cls._error("review_author_unknown")
+        return candidate
+
+    @classmethod
+    def _error(cls, code: ReviewBlockCode) -> ReviewPolicyError:
+        """Build one typed policy error without duplicating safe messages."""
+        return ReviewPolicyError(code, cls._MESSAGES[code])
 
     @classmethod
     async def _independence_blockers(

--- a/backend/app/phenopackets/review/policy.py
+++ b/backend/app/phenopackets/review/policy.py
@@ -1,0 +1,279 @@
+"""Database-backed independent-review eligibility policy."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, cast
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+from app.phenopackets.models import Phenopacket, PhenopacketRevision
+from app.phenopackets.review.schemas import (
+    ActionCapability,
+    ReviewAction,
+    ReviewBlockCode,
+    ReviewCapabilities,
+)
+
+DecisionAction = Literal["request_changes", "approve"]
+_CONTENT_EVENTS = ("created", "draft_created", "draft_saved")
+
+
+class ReviewPolicyError(PermissionError):
+    """Typed, content-free independent-review denial."""
+
+    def __init__(
+        self,
+        code: ReviewBlockCode,
+        message: str,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize a stable denial suitable for router translation."""
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.context = context or {}
+
+
+class ReviewPolicy:
+    """Evaluate reviewer independence from immutable server-side audit rows."""
+
+    _MESSAGES: dict[ReviewBlockCode, str] = {
+        "self_review_forbidden": "The draft owner cannot review this candidate.",
+        "reviewer_submitted": "The candidate submitter cannot review it.",
+        "reviewer_contributed": (
+            "A content contributor in this edit cycle cannot review the candidate."
+        ),
+        "review_author_unknown": (
+            "Reviewer independence cannot be established from the audit history."
+        ),
+        "unresolved_review_issues": (
+            "All blocking review issues must be resolved before approval."
+        ),
+        "review_closed": "This candidate is not open for the requested review action.",
+    }
+
+    @classmethod
+    async def evaluate(
+        cls,
+        db: AsyncSession,
+        phenopacket: Phenopacket,
+        candidate_revision: PhenopacketRevision,
+        actor: User,
+        unresolved_count: int,
+    ) -> ReviewCapabilities:
+        """Return ordered capabilities without exposing candidate content.
+
+        Args:
+            db: Transaction-bound async session.
+            phenopacket: Locked record whose active cycle is being evaluated.
+            candidate_revision: Immutable ``in_review`` submission snapshot.
+            actor: Authenticated actor.
+            unresolved_count: Server-derived active-cycle blocking issue count.
+
+        Returns:
+            Actor-specific ordered review capabilities.
+        """
+        if not actor.is_active or actor.role not in ("curator", "admin"):
+            return ReviewCapabilities(actions=[])
+
+        effective_state, active_revision = await cls._effective_review_state(
+            db, phenopacket
+        )
+        cycle_start = await cls._cycle_start_revision(db, phenopacket)
+        candidate_is_active = await cls._candidate_is_active(
+            db,
+            phenopacket,
+            candidate_revision,
+            effective_state,
+            active_revision,
+        )
+
+        ancestry_unknown = cycle_start is False or (
+            cycle_start is not None
+            and candidate_revision.revision_number <= cycle_start
+        )
+        if phenopacket.draft_owner_id is None or ancestry_unknown:
+            common_blockers: list[ReviewBlockCode] = ["review_author_unknown"]
+        elif not candidate_is_active:
+            common_blockers = ["review_closed"]
+        else:
+            common_blockers = await cls._independence_blockers(
+                db, phenopacket, candidate_revision, actor
+            )
+
+        actions: list[ActionCapability] = []
+        if effective_state == "in_review":
+            actions.append(cls._capability("request_changes", common_blockers))
+            approval_blockers = list(common_blockers)
+            if unresolved_count > 0:
+                approval_blockers.append("unresolved_review_issues")
+            actions.append(cls._capability("approve", approval_blockers))
+        elif effective_state == "approved":
+            actions.append(cls._capability("request_changes", common_blockers))
+            if actor.role == "admin":
+                actions.append(cls._capability("publish", []))
+        else:
+            actions.extend(
+                [
+                    cls._capability("request_changes", ["review_closed"]),
+                    cls._capability("approve", ["review_closed"]),
+                ]
+            )
+
+        return ReviewCapabilities(actions=actions)
+
+    @classmethod
+    async def require_independent_reviewer(
+        cls,
+        db: AsyncSession,
+        phenopacket: Phenopacket,
+        candidate_revision: PhenopacketRevision,
+        actor: User,
+        unresolved_count: int,
+        *,
+        action: DecisionAction,
+    ) -> None:
+        """Require one allowed independent-review decision capability.
+
+        Raises:
+            ReviewPolicyError: With the first stable blocker code and safe context.
+        """
+        capabilities = await cls.evaluate(
+            db,
+            phenopacket,
+            candidate_revision,
+            actor,
+            unresolved_count,
+        )
+        capability = next(
+            (item for item in capabilities.actions if item.action == action), None
+        )
+        if capability is not None and capability.allowed:
+            return
+
+        code = (
+            capability.blocked_by[0]
+            if capability is not None and capability.blocked_by
+            else "review_closed"
+        )
+        context = (
+            {"unresolved_count": unresolved_count}
+            if code == "unresolved_review_issues"
+            else {}
+        )
+        raise ReviewPolicyError(code, cls._MESSAGES[code], context)
+
+    @staticmethod
+    def _capability(
+        action: ReviewAction, blockers: list[ReviewBlockCode]
+    ) -> ActionCapability:
+        """Build a capability while preserving blocker insertion order."""
+        return ActionCapability(
+            action=action,
+            allowed=not blockers,
+            blocked_by=blockers,
+        )
+
+    @staticmethod
+    async def _effective_review_state(
+        db: AsyncSession, phenopacket: Phenopacket
+    ) -> tuple[str, PhenopacketRevision | None]:
+        """Resolve the authoritative active state without trusting client input."""
+        if phenopacket.editing_revision_id is None:
+            return phenopacket.state, None
+        active_revision = await db.get(
+            PhenopacketRevision, phenopacket.editing_revision_id
+        )
+        if active_revision is None or active_revision.record_id != phenopacket.id:
+            return phenopacket.state, None
+        return active_revision.state, active_revision
+
+    @classmethod
+    async def _candidate_is_active(
+        cls,
+        db: AsyncSession,
+        phenopacket: Phenopacket,
+        candidate: PhenopacketRevision,
+        effective_state: str,
+        active_revision: PhenopacketRevision | None,
+    ) -> bool:
+        """Confirm the submission snapshot belongs to the current review cycle."""
+        if (
+            candidate.record_id != phenopacket.id
+            or candidate.state != "in_review"
+            or effective_state not in ("in_review", "approved")
+        ):
+            return False
+
+        if active_revision is None:
+            return False
+        if effective_state == "in_review":
+            return active_revision.id == candidate.id
+
+        cycle_start = await cls._cycle_start_revision(db, phenopacket)
+        if cycle_start is False:
+            return False
+        stmt = select(PhenopacketRevision.id).where(
+            PhenopacketRevision.record_id == phenopacket.id,
+            PhenopacketRevision.state == "in_review",
+            PhenopacketRevision.revision_number < active_revision.revision_number,
+        )
+        if cycle_start is not None:
+            stmt = stmt.where(PhenopacketRevision.revision_number > cycle_start)
+        latest_candidate_id = (
+            await db.execute(
+                stmt.order_by(PhenopacketRevision.revision_number.desc()).limit(1)
+            )
+        ).scalar_one_or_none()
+        return latest_candidate_id == candidate.id
+
+    @classmethod
+    async def _independence_blockers(
+        cls,
+        db: AsyncSession,
+        phenopacket: Phenopacket,
+        candidate: PhenopacketRevision,
+        actor: User,
+    ) -> list[ReviewBlockCode]:
+        """Derive ordered owner, submitter, and content-contributor blockers."""
+        cycle_start = await cls._cycle_start_revision(db, phenopacket)
+        if (
+            phenopacket.draft_owner_id is None
+            or cycle_start is False
+            or (cycle_start is not None and candidate.revision_number <= cycle_start)
+        ):
+            return ["review_author_unknown"]
+
+        blockers: list[ReviewBlockCode] = []
+        if actor.id == phenopacket.draft_owner_id:
+            blockers.append("self_review_forbidden")
+        if actor.id == candidate.actor_id:
+            blockers.append("reviewer_submitted")
+
+        contributor_stmt = select(PhenopacketRevision.id).where(
+            PhenopacketRevision.record_id == phenopacket.id,
+            PhenopacketRevision.actor_id == actor.id,
+            PhenopacketRevision.event_type.in_(_CONTENT_EVENTS),
+        )
+        if cycle_start is not None:
+            contributor_stmt = contributor_stmt.where(
+                PhenopacketRevision.revision_number > cycle_start
+            )
+        contributed = (await db.execute(contributor_stmt.limit(1))).scalar_one_or_none()
+        if contributed is not None:
+            blockers.append("reviewer_contributed")
+        return blockers
+
+    @staticmethod
+    async def _cycle_start_revision(
+        db: AsyncSession, phenopacket: Phenopacket
+    ) -> int | None | Literal[False]:
+        """Return the public-head number, ``None`` for new, or False if ambiguous."""
+        if phenopacket.head_published_revision_id is None:
+            return None
+        head = await db.get(PhenopacketRevision, phenopacket.head_published_revision_id)
+        if head is None or head.record_id != phenopacket.id:
+            return False
+        return cast(int, head.revision_number)

--- a/backend/app/phenopackets/review/policy.py
+++ b/backend/app/phenopackets/review/policy.py
@@ -203,27 +203,20 @@ class ReviewPolicy:
         if effective_state not in allowed_states or active_revision is None:
             raise cls._error("review_closed")
 
-        expected_candidate = active_revision
-        if effective_state == "changes_requested":
-            if active_revision.parent_revision_id is None:
-                raise cls._error("review_author_unknown")
-            parent = await db.get(
-                PhenopacketRevision, active_revision.parent_revision_id
+        if action == "create":
+            candidate_is_current = (
+                candidate_revision.id == active_revision.id
+                and candidate_revision.record_id == phenopacket.id
+                and candidate_revision.state == "in_review"
             )
-            if (
-                parent is None
-                or parent.record_id != phenopacket.id
-                or parent.state != "in_review"
-                or parent.revision_number >= active_revision.revision_number
-            ):
-                raise cls._error("review_author_unknown")
-            expected_candidate = parent
-
-        if (
-            candidate_revision.id != expected_candidate.id
-            or candidate_revision.record_id != phenopacket.id
-            or candidate_revision.state != "in_review"
-        ):
+        else:
+            candidate_is_current = await cls._candidate_in_active_cycle(
+                db,
+                phenopacket,
+                active_revision,
+                candidate_revision,
+            )
+        if not candidate_is_current:
             raise cls._error("review_closed")
 
         blockers = await cls._independence_blockers(
@@ -232,6 +225,53 @@ class ReviewPolicy:
         if blockers:
             code = blockers[0]
             raise ReviewPolicyError(code, cls._MESSAGES[code])
+
+    @staticmethod
+    async def _candidate_in_active_cycle(
+        db: AsyncSession,
+        phenopacket: Phenopacket,
+        active_revision: PhenopacketRevision,
+        candidate: PhenopacketRevision,
+    ) -> bool:
+        """Return whether an in-review candidate is in the active ancestry."""
+        if candidate.record_id != phenopacket.id or candidate.state != "in_review":
+            return False
+
+        head_id = phenopacket.head_published_revision_id
+        head: PhenopacketRevision | None = None
+        if head_id is not None:
+            head = await db.get(PhenopacketRevision, head_id)
+            if (
+                head is None
+                or head.record_id != phenopacket.id
+                or head.state != "published"
+                or candidate.revision_number <= head.revision_number
+            ):
+                return False
+
+        current = active_revision
+        visited: set[int] = set()
+        candidate_seen = False
+        while True:
+            if current.id in visited or current.record_id != phenopacket.id:
+                return False
+            visited.add(current.id)
+            if current.id == candidate.id:
+                candidate_seen = True
+            if head_id is not None and current.id == head_id:
+                return candidate_seen and current.state == "published"
+            if head_id is None and current.parent_revision_id is None:
+                return candidate_seen and current.event_type == "created"
+            if current.parent_revision_id is None:
+                return False
+            parent = await db.get(PhenopacketRevision, current.parent_revision_id)
+            if (
+                parent is None
+                or parent.record_id != phenopacket.id
+                or parent.revision_number >= current.revision_number
+            ):
+                return False
+            current = parent
 
     @staticmethod
     def _capability(

--- a/backend/app/phenopackets/review/schemas.py
+++ b/backend/app/phenopackets/review/schemas.py
@@ -24,7 +24,7 @@ class ActionCapability(BaseModel):
 
     action: ReviewAction
     allowed: bool
-    blocked_by: list[ReviewBlockCode] = Field(default_factory=list)
+    blocked_by: tuple[ReviewBlockCode, ...] = ()
 
 
 class ReviewCapabilities(BaseModel):

--- a/backend/app/phenopackets/review/schemas.py
+++ b/backend/app/phenopackets/review/schemas.py
@@ -1,0 +1,35 @@
+"""Stable server-authoritative review capability schemas."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ReviewBlockCode = Literal[
+    "self_review_forbidden",
+    "reviewer_submitted",
+    "reviewer_contributed",
+    "review_author_unknown",
+    "unresolved_review_issues",
+    "review_closed",
+]
+ReviewAction = Literal["request_changes", "approve", "publish"]
+
+
+class ActionCapability(BaseModel):
+    """One actor-specific action and its stable, content-free blockers."""
+
+    model_config = ConfigDict(frozen=True)
+
+    action: ReviewAction
+    allowed: bool
+    blocked_by: list[ReviewBlockCode] = Field(default_factory=list)
+
+
+class ReviewCapabilities(BaseModel):
+    """Ordered review actions available for one actor and candidate."""
+
+    model_config = ConfigDict(frozen=True)
+
+    actions: list[ActionCapability] = Field(default_factory=list)

--- a/backend/app/phenopackets/routers/transitions.py
+++ b/backend/app/phenopackets/routers/transitions.py
@@ -36,6 +36,7 @@ from app.phenopackets.models import (
 )
 from app.phenopackets.query_builders import build_phenopacket_response
 from app.phenopackets.repositories import PhenopacketRepository
+from app.phenopackets.review.policy import ReviewPolicyError
 from app.phenopackets.services.state_service import PhenopacketStateService
 
 router = APIRouter(tags=["phenopackets-state"])
@@ -70,6 +71,11 @@ def _build_revision_response(
         change_reason=rev.change_reason,
         actor_id=rev.actor_id,
         actor_username=actor_username,
+        actor_role=rev.actor_role,
+        actor_role_at_decision_recorded=rev.actor_role is not None,
+        decision_metadata=rev.decision_metadata,
+        content_sha256=rev.content_sha256,
+        ledger_version=rev.ledger_version,
         change_patch=rev.change_patch,
         created_at=rev.created_at,
         content_jsonb=rev.content_jsonb if include_content else None,
@@ -128,33 +134,65 @@ async def post_transition(
             reason=body.reason,
             expected_revision=body.revision,
             actor=current_user,
+            candidate_revision_id=body.candidate_revision_id,
+            candidate_content_sha256=body.candidate_content_sha256,
+            approved_revision_id=body.approved_revision_id,
+            approved_content_sha256=body.approved_content_sha256,
+            attestation=body.attestation,
         )
         await db.commit()
     except PhenopacketStateService.RecordNotFound as exc:
+        await db.rollback()
         raise HTTPException(status_code=404, detail="Phenopacket not found") from exc
     except PhenopacketStateService.RevisionMismatch as exc:
+        await db.rollback()
         raise HTTPException(
             status_code=409,
             detail={"code": "revision_mismatch", "message": str(exc)},
         ) from exc
+    except PhenopacketStateService.ReviewRevisionMismatch as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "review_revision_mismatch", "message": str(exc)},
+        ) from exc
     except PhenopacketStateService.InvalidTransition as exc:
+        await db.rollback()
         raise HTTPException(
             status_code=409,
             detail={"code": "invalid_transition", "message": str(exc)},
         ) from exc
     except PhenopacketStateService.ForbiddenNotOwner as exc:
+        await db.rollback()
         raise HTTPException(
             status_code=403,
             detail={"code": "forbidden_not_owner", "message": str(exc)},
         ) from exc
+    except ReviewPolicyError as exc:
+        await db.rollback()
+        status_code = (
+            409
+            if exc.code
+            in {
+                "review_closed",
+                "unresolved_review_issues",
+            }
+            else 403
+        )
+        raise HTTPException(
+            status_code=status_code,
+            detail={"code": exc.code, "message": exc.message, **exc.context},
+        ) from exc
     except PermissionError as exc:
+        await db.rollback()
         raise HTTPException(
             status_code=403,
             detail={"code": "forbidden_role", "message": str(exc)},
         ) from exc
     except RuntimeError as exc:
+        await db.rollback()
         logger.exception("Unexpected error during transition of %s", phenopacket_id)
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail="Transition failed") from exc
 
     # Re-fetch to get eager-loaded actor relationships for the response builder
     repo = PhenopacketRepository(db)

--- a/backend/app/phenopackets/services/phenopacket_service.py
+++ b/backend/app/phenopackets/services/phenopacket_service.py
@@ -41,6 +41,11 @@ from app.phenopackets.models import (
     PhenopacketUpdate,
 )
 from app.phenopackets.repositories import PhenopacketRepository
+from app.phenopackets.services.revision_ledger import (
+    build_ledger_v2_payload,
+    content_sha256,
+    ledger_sha256,
+)
 from app.phenopackets.services.state_service import PhenopacketStateService
 from app.phenopackets.validation.domain import DomainValidator
 from app.phenopackets.validator import PhenopacketSanitizer, PhenopacketValidator
@@ -231,6 +236,11 @@ class PhenopacketService:
             raise ServiceValidationError(domain_errors)
 
         revision_actor_id = await self._resolve_revision_actor_id(actor_id)
+        revision_actor_role = await self._repo.session.scalar(
+            select(User.role).where(User.id == revision_actor_id)
+        )
+        if revision_actor_role is None:
+            raise ServiceDatabaseError("revision actor could not be resolved")
 
         phenopacket = Phenopacket(
             phenopacket_id=sanitized["id"],
@@ -264,19 +274,22 @@ class PhenopacketService:
                     projection_payload, sort_keys=True, separators=(",", ":")
                 ).encode()
             ).hexdigest()
-            ledger_hash = hashlib.sha256(
-                json.dumps(
-                    {
-                        "parent_revision_id": None,
-                        "revision_number": phenopacket.revision,
-                        "state": "draft",
-                        "event_type": "created",
-                        "projection_hash": projection_hash,
-                    },
-                    sort_keys=True,
-                    separators=(",", ":"),
-                ).encode()
-            ).hexdigest()
+            full_content_sha256 = content_sha256(sanitized)
+            ledger_payload = build_ledger_v2_payload(
+                parent_revision_id=None,
+                revision_number=phenopacket.revision,
+                state="draft",
+                event_type="created",
+                from_state=None,
+                to_state="draft",
+                change_reason="Initial creation",
+                change_patch=None,
+                content_sha256=full_content_sha256,
+                projection_hash=projection_hash,
+                actor_id=revision_actor_id,
+                actor_role=revision_actor_role,
+                decision_metadata=None,
+            )
             initial_revision = PhenopacketRevision(
                 record_id=phenopacket.id,
                 revision_number=phenopacket.revision,
@@ -295,8 +308,12 @@ class PhenopacketService:
                     .get("projection", {})
                     .get("algorithmVersion", "legacy")
                 ),
-                ledger_hash=ledger_hash,
+                ledger_hash=ledger_sha256(ledger_payload),
                 projection_hash=projection_hash,
+                actor_role=revision_actor_role,
+                decision_metadata=None,
+                content_sha256=full_content_sha256,
+                ledger_version=2,
             )
             self._repo.session.add(initial_revision)
             await self._repo.session.flush()

--- a/backend/app/phenopackets/services/revision_ledger.py
+++ b/backend/app/phenopackets/services/revision_ledger.py
@@ -1,0 +1,55 @@
+"""Canonical payload and digest helpers for version-two revision ledgers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from app.phenopackets.curation.hashing import sha256_digest
+
+
+def content_sha256(content: Mapping[str, Any]) -> str:
+    """Return the canonical digest of the complete revision content mapping."""
+    return sha256_digest(content)
+
+
+def build_ledger_v2_payload(
+    *,
+    parent_revision_id: int | None,
+    revision_number: int,
+    state: str,
+    event_type: str,
+    from_state: str | None,
+    to_state: str,
+    change_reason: str | None,
+    change_patch: Any | None,
+    content_sha256: str,
+    projection_hash: str | None,
+    actor_id: int,
+    actor_role: str | None,
+    decision_metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the complete canonical evidence payload for a v2 revision ledger."""
+    return {
+        "ledger_version": 2,
+        "parent_revision_id": parent_revision_id,
+        "revision_number": revision_number,
+        "state": state,
+        "event_type": event_type,
+        "from_state": from_state,
+        "to_state": to_state,
+        "change_reason": change_reason,
+        "change_patch": change_patch,
+        "content_sha256": content_sha256,
+        "projection_hash": projection_hash,
+        "actor_id": actor_id,
+        "actor_role": actor_role,
+        "decision_metadata": (
+            dict(decision_metadata) if decision_metadata is not None else None
+        ),
+    }
+
+
+def ledger_sha256(payload: Mapping[str, Any]) -> str:
+    """Return the canonical digest of a complete version-two ledger payload."""
+    return sha256_digest(payload)

--- a/backend/app/phenopackets/services/state_service.py
+++ b/backend/app/phenopackets/services/state_service.py
@@ -654,6 +654,10 @@ class PhenopacketStateService:
             # so the curator can continue owning through the review cycle.
             pp.editing_revision_id = rev.id
 
+        # Persist the projection after the immutable revision insert so any
+        # same-transaction review-issue writer observes the active candidate.
+        # Transaction ownership remains with the router/caller.
+        await self.db.flush()
         return pp, rev
 
     async def _publish(

--- a/backend/app/phenopackets/services/state_service.py
+++ b/backend/app/phenopackets/services/state_service.py
@@ -414,7 +414,7 @@ class PhenopacketStateService:
             ("in_review", "approved"),
             ("approved", "changes_requested"),
         }:
-            candidate = await self._active_review_candidate(pp, effective)
+            candidate = await self._active_review_candidate(pp)
             unresolved_count = (
                 await self._unresolved_review_issue_count(pp)
                 if to_state == "approved"
@@ -434,9 +434,7 @@ class PhenopacketStateService:
 
         return await self._simple_transition(pp, to_state, reason, actor)
 
-    async def _active_review_candidate(
-        self, pp: Phenopacket, effective_state: State
-    ) -> PhenopacketRevision:
+    async def _active_review_candidate(self, pp: Phenopacket) -> PhenopacketRevision:
         """Load the immutable submission snapshot for the active review cycle."""
         if pp.editing_revision_id is None:
             raise ReviewPolicyError(
@@ -449,38 +447,7 @@ class PhenopacketStateService:
                 "review_author_unknown",
                 "Reviewer independence cannot be established from the audit history.",
             )
-        if effective_state == "in_review" and active.state == "in_review":
-            return active
-
-        cycle_start: int | None = None
-        if pp.head_published_revision_id is not None:
-            head = await self.db.get(PhenopacketRevision, pp.head_published_revision_id)
-            if head is None or head.record_id != pp.id:
-                raise ReviewPolicyError(
-                    "review_author_unknown",
-                    "Reviewer independence cannot be established "
-                    "from the audit history.",
-                )
-            cycle_start = head.revision_number
-
-        stmt = select(PhenopacketRevision).where(
-            PhenopacketRevision.record_id == pp.id,
-            PhenopacketRevision.state == "in_review",
-            PhenopacketRevision.revision_number < active.revision_number,
-        )
-        if cycle_start is not None:
-            stmt = stmt.where(PhenopacketRevision.revision_number > cycle_start)
-        candidate = (
-            await self.db.execute(
-                stmt.order_by(PhenopacketRevision.revision_number.desc()).limit(1)
-            )
-        ).scalar_one_or_none()
-        if candidate is None:
-            raise ReviewPolicyError(
-                "review_author_unknown",
-                "Reviewer independence cannot be established from the audit history.",
-            )
-        return candidate
+        return await ReviewPolicy.active_candidate(self.db, pp, active)
 
     async def _unresolved_review_issue_count(self, pp: Phenopacket) -> int:
         """Count live unresolved blocking issues in the active edit cycle."""

--- a/backend/app/phenopackets/services/state_service.py
+++ b/backend/app/phenopackets/services/state_service.py
@@ -17,12 +17,14 @@ from copy import deepcopy
 from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.comments.models import Comment
 from app.models.user import User
 from app.phenopackets.models import Phenopacket, PhenopacketRevision
+from app.phenopackets.review.policy import ReviewPolicy, ReviewPolicyError
 from app.phenopackets.services.transitions import (
     Role,
     State,
@@ -407,10 +409,108 @@ class PhenopacketStateService:
             # forbidden_role
             raise PermissionError(str(exc)) from exc
 
+        if (effective, to_state) in {
+            ("in_review", "changes_requested"),
+            ("in_review", "approved"),
+            ("approved", "changes_requested"),
+        }:
+            candidate = await self._active_review_candidate(pp, effective)
+            unresolved_count = (
+                await self._unresolved_review_issue_count(pp)
+                if to_state == "approved"
+                else 0
+            )
+            await ReviewPolicy.require_independent_reviewer(
+                self.db,
+                pp,
+                candidate,
+                actor,
+                unresolved_count,
+                action=("approve" if to_state == "approved" else "request_changes"),
+            )
+
         if to_state == "published":
             return await self._publish(pp, reason, actor)
 
         return await self._simple_transition(pp, to_state, reason, actor)
+
+    async def _active_review_candidate(
+        self, pp: Phenopacket, effective_state: State
+    ) -> PhenopacketRevision:
+        """Load the immutable submission snapshot for the active review cycle."""
+        if pp.editing_revision_id is None:
+            raise ReviewPolicyError(
+                "review_author_unknown",
+                "Reviewer independence cannot be established from the audit history.",
+            )
+        active = await self.db.get(PhenopacketRevision, pp.editing_revision_id)
+        if active is None or active.record_id != pp.id:
+            raise ReviewPolicyError(
+                "review_author_unknown",
+                "Reviewer independence cannot be established from the audit history.",
+            )
+        if effective_state == "in_review" and active.state == "in_review":
+            return active
+
+        cycle_start: int | None = None
+        if pp.head_published_revision_id is not None:
+            head = await self.db.get(PhenopacketRevision, pp.head_published_revision_id)
+            if head is None or head.record_id != pp.id:
+                raise ReviewPolicyError(
+                    "review_author_unknown",
+                    "Reviewer independence cannot be established "
+                    "from the audit history.",
+                )
+            cycle_start = head.revision_number
+
+        stmt = select(PhenopacketRevision).where(
+            PhenopacketRevision.record_id == pp.id,
+            PhenopacketRevision.state == "in_review",
+            PhenopacketRevision.revision_number < active.revision_number,
+        )
+        if cycle_start is not None:
+            stmt = stmt.where(PhenopacketRevision.revision_number > cycle_start)
+        candidate = (
+            await self.db.execute(
+                stmt.order_by(PhenopacketRevision.revision_number.desc()).limit(1)
+            )
+        ).scalar_one_or_none()
+        if candidate is None:
+            raise ReviewPolicyError(
+                "review_author_unknown",
+                "Reviewer independence cannot be established from the audit history.",
+            )
+        return candidate
+
+    async def _unresolved_review_issue_count(self, pp: Phenopacket) -> int:
+        """Count live unresolved blocking issues in the active edit cycle."""
+        stmt = (
+            select(func.count(Comment.id))
+            .join(
+                PhenopacketRevision,
+                PhenopacketRevision.id == Comment.review_revision_id,
+            )
+            .where(
+                Comment.record_type == "phenopacket",
+                Comment.record_id == pp.id,
+                Comment.review_revision_id.is_not(None),
+                Comment.resolved_at.is_(None),
+                Comment.deleted_at.is_(None),
+                PhenopacketRevision.record_id == pp.id,
+            )
+        )
+        if pp.head_published_revision_id is not None:
+            head = await self.db.get(PhenopacketRevision, pp.head_published_revision_id)
+            if head is None or head.record_id != pp.id:
+                raise ReviewPolicyError(
+                    "review_author_unknown",
+                    "Reviewer independence cannot be established "
+                    "from the audit history.",
+                )
+            stmt = stmt.where(
+                PhenopacketRevision.revision_number > head.revision_number
+            )
+        return int((await self.db.execute(stmt)).scalar_one())
 
     async def _simple_transition(
         self,

--- a/backend/app/phenopackets/services/state_service.py
+++ b/backend/app/phenopackets/services/state_service.py
@@ -18,13 +18,21 @@ from typing import Any, cast
 from uuid import UUID
 
 from sqlalchemy import func, select
-from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.comments.models import Comment
 from app.models.user import User
-from app.phenopackets.models import Phenopacket, PhenopacketRevision
+from app.phenopackets.models import (
+    ApprovalAttestation,
+    Phenopacket,
+    PhenopacketRevision,
+)
 from app.phenopackets.review.policy import ReviewPolicy, ReviewPolicyError
+from app.phenopackets.services.revision_ledger import (
+    build_ledger_v2_payload,
+    content_sha256,
+    ledger_sha256,
+)
 from app.phenopackets.services.transitions import (
     Role,
     State,
@@ -48,6 +56,9 @@ class PhenopacketStateService:
 
     class RevisionMismatch(Exception):
         """Optimistic-lock failure: expected_revision != current revision."""
+
+    class ReviewRevisionMismatch(Exception):
+        """The nominated immutable review snapshot is no longer active or exact."""
 
     class EditInProgress(Exception):
         """Record already has a clone-to-draft edit open (editing_revision_id set)."""
@@ -153,6 +164,7 @@ class PhenopacketStateService:
         event_type: str,
         parent_revision_id: int | None = None,
         import_run_id: UUID | None = None,
+        decision_metadata: dict[str, Any] | None = None,
     ) -> PhenopacketRevision:
         """Append and flush a revision; never update historical revision rows."""
         parent = parent_revision_id
@@ -179,20 +191,22 @@ class PhenopacketStateService:
                 projection_payload, sort_keys=True, separators=(",", ":")
             ).encode()
         ).hexdigest()
-        ledger_payload = {
-            "parent_revision_id": parent,
-            "revision_number": pp.revision,
-            "state": state,
-            "event_type": event_type,
-            "from_state": from_state,
-            "to_state": to_state,
-            "change_reason": change_reason,
-            "change_patch": change_patch,
-            "projection_hash": projection_hash,
-        }
-        ledger_hash = hashlib.sha256(
-            json.dumps(ledger_payload, sort_keys=True, separators=(",", ":")).encode()
-        ).hexdigest()
+        full_content_sha256 = content_sha256(content)
+        ledger_payload = build_ledger_v2_payload(
+            parent_revision_id=parent,
+            revision_number=pp.revision,
+            state=state,
+            event_type=event_type,
+            from_state=from_state,
+            to_state=to_state,
+            change_reason=change_reason,
+            change_patch=change_patch,
+            content_sha256=full_content_sha256,
+            projection_hash=projection_hash,
+            actor_id=actor.id,
+            actor_role=actor.role,
+            decision_metadata=decision_metadata,
+        )
         revision = PhenopacketRevision(
             record_id=pp.id,
             parent_revision_id=parent,
@@ -210,8 +224,12 @@ class PhenopacketStateService:
             projection_version=str(
                 curation.get("projection", {}).get("algorithmVersion", "legacy")
             ),
-            ledger_hash=ledger_hash,
+            ledger_hash=ledger_sha256(ledger_payload),
             projection_hash=projection_hash,
+            actor_role=actor.role,
+            decision_metadata=decision_metadata,
+            content_sha256=full_content_sha256,
+            ledger_version=2,
         )
         self.db.add(revision)
         await self.db.flush()
@@ -381,6 +399,11 @@ class PhenopacketStateService:
         reason: str,
         expected_revision: int,
         actor: User,
+        candidate_revision_id: int | None = None,
+        candidate_content_sha256: str | None = None,
+        approved_revision_id: int | None = None,
+        approved_content_sha256: str | None = None,
+        attestation: ApprovalAttestation | None = None,
     ) -> tuple[Phenopacket, PhenopacketRevision]:
         """Perform a state transition per the §4.1 guard matrix.
 
@@ -409,30 +432,125 @@ class PhenopacketStateService:
             # forbidden_role
             raise PermissionError(str(exc)) from exc
 
+        if to_state == "approved":
+            return await self._approve(
+                pp,
+                reason,
+                actor,
+                candidate_revision_id=candidate_revision_id,
+                candidate_content_sha256=candidate_content_sha256,
+                attestation=attestation,
+            )
+
         if (effective, to_state) in {
             ("in_review", "changes_requested"),
-            ("in_review", "approved"),
             ("approved", "changes_requested"),
         }:
             candidate = await self._active_review_candidate(pp)
-            unresolved_count = (
-                await self._unresolved_review_issue_count(pp)
-                if to_state == "approved"
-                else 0
-            )
             await ReviewPolicy.require_independent_reviewer(
                 self.db,
                 pp,
                 candidate,
                 actor,
-                unresolved_count,
-                action=("approve" if to_state == "approved" else "request_changes"),
+                0,
+                action="request_changes",
             )
 
         if to_state == "published":
-            return await self._publish(pp, reason, actor)
+            return await self._publish(
+                pp,
+                reason,
+                actor,
+                approved_revision_id=approved_revision_id,
+                approved_content_sha256=approved_content_sha256,
+            )
+
+        if to_state == "in_review":
+            pp.phenopacket = self._canonicalize_for_persistence(
+                pp.phenopacket, publish=True
+            )
 
         return await self._simple_transition(pp, to_state, reason, actor)
+
+    async def _approve(
+        self,
+        pp: Phenopacket,
+        reason: str,
+        actor: User,
+        *,
+        candidate_revision_id: int | None,
+        candidate_content_sha256: str | None,
+        attestation: ApprovalAttestation | None,
+    ) -> tuple[Phenopacket, PhenopacketRevision]:
+        """Approve the exact active canonical candidate under the record lock."""
+        if (
+            candidate_revision_id is None
+            or candidate_content_sha256 is None
+            or attestation is None
+            or pp.editing_revision_id != candidate_revision_id
+        ):
+            raise self.ReviewRevisionMismatch(
+                "active review candidate does not match the nominated snapshot"
+            )
+
+        candidate = (
+            await self.db.execute(
+                select(PhenopacketRevision).where(
+                    PhenopacketRevision.id == candidate_revision_id,
+                    PhenopacketRevision.record_id == pp.id,
+                    PhenopacketRevision.state == "in_review",
+                )
+            )
+        ).scalar_one_or_none()
+        if candidate is None:
+            raise self.ReviewRevisionMismatch(
+                "active review candidate does not match the nominated snapshot"
+            )
+        actual_digest = content_sha256(candidate.content_jsonb)
+        if (
+            candidate.content_sha256 != actual_digest
+            or candidate_content_sha256 != actual_digest
+        ):
+            raise self.ReviewRevisionMismatch(
+                "active review candidate does not match the nominated snapshot"
+            )
+
+        unresolved_count = await self._unresolved_review_issue_count(pp)
+        await ReviewPolicy.require_independent_reviewer(
+            self.db,
+            pp,
+            candidate,
+            actor,
+            unresolved_count,
+            action="approve",
+        )
+
+        approved_content = deepcopy(candidate.content_jsonb)
+        decision_metadata = {
+            "candidate_revision_id": candidate.id,
+            "candidate_content_sha256": actual_digest,
+            "attestation": attestation.model_dump(mode="json"),
+            "rationale": reason,
+        }
+        approved = await self._append_revision(
+            pp,
+            state="approved",
+            content=approved_content,
+            change_patch=compute_json_patch(pp.phenopacket, approved_content),
+            change_reason=reason,
+            actor=actor,
+            from_state="in_review",
+            to_state="approved",
+            event_type="state_transition",
+            parent_revision_id=candidate.id,
+            decision_metadata=decision_metadata,
+        )
+
+        if pp.head_published_revision_id is None:
+            pp.state = "approved"
+        pp.phenopacket = approved_content
+        pp.editing_revision_id = approved.id
+        return pp, approved
 
     async def _active_review_candidate(self, pp: Phenopacket) -> PhenopacketRevision:
         """Load the immutable submission snapshot for the active review cycle."""
@@ -543,30 +661,42 @@ class PhenopacketStateService:
         pp: Phenopacket,
         reason: str,
         actor: User,
+        *,
+        approved_revision_id: int | None,
+        approved_content_sha256: str | None,
     ) -> tuple[Phenopacket, PhenopacketRevision]:
         """§6.2 head-swap: promote the approved revision to published + head."""
-        if pp.editing_revision_id is None:
-            raise self.InvalidTransition(
-                "cannot publish: no active approved editing revision"
+        if (
+            approved_revision_id is None
+            or approved_content_sha256 is None
+            or pp.editing_revision_id != approved_revision_id
+        ):
+            raise self.ReviewRevisionMismatch(
+                "active approval does not match the nominated snapshot"
             )
-        try:
-            approved = (
-                await self.db.execute(
-                    select(PhenopacketRevision).where(
-                        PhenopacketRevision.id == pp.editing_revision_id,
-                        PhenopacketRevision.record_id == pp.id,
-                        PhenopacketRevision.state == "approved",
-                    )
+        approved = (
+            await self.db.execute(
+                select(PhenopacketRevision).where(
+                    PhenopacketRevision.id == approved_revision_id,
+                    PhenopacketRevision.record_id == pp.id,
+                    PhenopacketRevision.state == "approved",
                 )
-            ).scalar_one()
-        except NoResultFound:
-            raise self.InvalidTransition(
-                "cannot publish: active editing revision is not an approved revision"
+            )
+        ).scalar_one_or_none()
+        if approved is None:
+            raise self.ReviewRevisionMismatch(
+                "active approval does not match the nominated snapshot"
+            )
+        actual_digest = content_sha256(approved.content_jsonb)
+        if (
+            approved.content_sha256 != actual_digest
+            or approved_content_sha256 != actual_digest
+        ):
+            raise self.ReviewRevisionMismatch(
+                "active approval does not match the nominated snapshot"
             )
 
-        published_content = self._canonicalize_for_persistence(
-            approved.content_jsonb, publish=True
-        )
+        published_content = deepcopy(approved.content_jsonb)
         published = await self._append_revision(
             pp,
             state="published",

--- a/backend/app/phenopackets/services/transitions.py
+++ b/backend/app/phenopackets/services/transitions.py
@@ -1,8 +1,8 @@
-"""Pure-function transition guard matrix for Wave 7/D.1.
+"""Pure structural transition guard matrix.
 
-No I/O. Feeds both the endpoint handler (which validates before mutating)
-and the frontend-mirrored decision-making in TransitionMenu.vue (via an
-API-exposed version of ``allowed_transitions``).
+No I/O. This layer validates state, role, and submit/withdraw ownership.
+Actor-specific reviewer independence and blocking-issue decisions belong to
+``ReviewPolicy`` and are enforced by the state service under its record lock.
 
 Spec reference:
   .planning/specs/2026-04-12-wave-7-d1-state-machine-design.md §4.1.
@@ -55,7 +55,7 @@ class StateTransition:
 
 
 # ---------------------------------------------------------------------------
-# Enumerated rule table — every legal (from_state, to_state) pair from §4.1.
+# Enumerated rule table — every legal structural (from_state, to_state) pair.
 # Any pair NOT in this dict is an invalid transition.
 # ---------------------------------------------------------------------------
 
@@ -74,17 +74,18 @@ _RULES: dict[tuple[State, State], StateTransition] = {
         requires_admin=False,
         requires_ownership_or_admin=True,
     ),
-    # in_review → changes_requested  (request_changes): admin only
+    # in_review → changes_requested: structural role check only; the state
+    # service applies actor-specific independent-review policy under lock.
     ("in_review", "changes_requested"): StateTransition(
         "in_review",
         "changes_requested",
-        requires_admin=True,
+        requires_admin=False,
     ),
-    # in_review → approved  (approve): admin only
+    # in_review → approved: structural role check only; policy is service-side.
     ("in_review", "approved"): StateTransition(
         "in_review",
         "approved",
-        requires_admin=True,
+        requires_admin=False,
     ),
     # changes_requested → in_review  (resubmit): curator must own OR admin
     ("changes_requested", "in_review"): StateTransition(
@@ -92,6 +93,12 @@ _RULES: dict[tuple[State, State], StateTransition] = {
         "in_review",
         requires_admin=False,
         requires_ownership_or_admin=True,
+    ),
+    # approved → changes_requested: an independent reviewer may reopen.
+    ("approved", "changes_requested"): StateTransition(
+        "approved",
+        "changes_requested",
+        requires_admin=False,
     ),
     # approved → published  (publish): admin only; triggers head-swap §6.2
     ("approved", "published"): StateTransition(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -122,6 +122,7 @@ _MUTABLE_TABLES: tuple[str, ...] = (
     "credential_tokens",
     "comment_mentions",
     "comment_edits",
+    "comment_resolution_events",
     "comments",
     "phenopacket_audit",
     # Source-import evidence tables: children must be removed before their

--- a/backend/tests/migration/test_independent_review_activation_migration.py
+++ b/backend/tests/migration/test_independent_review_activation_migration.py
@@ -1,0 +1,576 @@
+"""Real PostgreSQL behavior for independent-review invariant activation."""
+
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import DBAPIError, IntegrityError
+
+from app.core.config import settings
+from app.database import Base
+
+
+def _migration_module(
+    name: str = "e0f422b00006_activate_independent_review_invariants",
+):
+    path = Path(__file__).resolve().parents[2] / f"alembic/versions/{name}.py"
+    assert path.exists(), f"activation migration is missing: {path.name}"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    return migration
+
+
+class _GuardResult:
+    def __init__(self, state: dict[str, int]) -> None:
+        self.state = state
+
+    def mappings(self):
+        return self
+
+    def one(self) -> dict[str, int]:
+        return self.state
+
+
+class _GuardBind:
+    def __init__(self, state: dict[str, int]) -> None:
+        self.state = state
+
+    def execute(self, _statement):
+        return _GuardResult(self.state)
+
+
+_EMPTY_GUARD = {
+    "blocking_issues": 0,
+    "resolution_events": 0,
+    "v2_revisions": 0,
+    "decision_metadata": 0,
+    "actor_roles": 0,
+    "content_digests": 0,
+}
+
+
+def test_activation_revision_extends_exact_expansion_head() -> None:
+    migration = _migration_module()
+    assert migration.revision == "e0f422b00006"
+    assert migration.down_revision == "d0f422b00005"
+
+
+@pytest.mark.parametrize(
+    "migration_name",
+    [
+        "d0f422b00005_expand_independent_review_audit",
+        "e0f422b00006_activate_independent_review_invariants",
+    ],
+)
+@pytest.mark.parametrize("evidence_key", list(_EMPTY_GUARD))
+def test_both_downgrades_refuse_each_audit_evidence_class(
+    migration_name: str, evidence_key: str
+) -> None:
+    migration = _migration_module(migration_name)
+    state = {**_EMPTY_GUARD, evidence_key: 1}
+    with pytest.raises(RuntimeError, match=evidence_key):
+        migration.assert_independent_review_downgrade_safe(_GuardBind(state))
+
+
+@contextmanager
+def _isolated_schema():
+    migration = _migration_module()
+    sync_url = settings.DATABASE_URL.replace("postgresql+asyncpg://", "postgresql://")
+    engine = create_engine(sync_url)
+    schema = f"review_activation_{uuid.uuid4().hex}"
+    try:
+        with engine.connect() as connection:
+            transaction = connection.begin()
+            try:
+                connection.execute(text(f'CREATE SCHEMA "{schema}"'))
+                connection.execute(text(f'SET LOCAL search_path TO "{schema}"'))
+                connection.execute(
+                    text(
+                        """
+                        CREATE TABLE users (id BIGINT PRIMARY KEY, role TEXT NOT NULL);
+                        CREATE TABLE phenopackets (
+                            id UUID PRIMARY KEY, state TEXT NOT NULL,
+                            revision INTEGER NOT NULL, editing_revision_id BIGINT,
+                            head_published_revision_id BIGINT, draft_owner_id BIGINT
+                        );
+                        CREATE TABLE phenopacket_revisions (
+                            id BIGSERIAL PRIMARY KEY, record_id UUID NOT NULL,
+                            parent_revision_id BIGINT, revision_number INTEGER NOT NULL,
+                            state TEXT NOT NULL, event_type TEXT, actor_id BIGINT,
+                            actor_role TEXT, decision_metadata JSONB,
+                            content_sha256 TEXT, ledger_version INTEGER
+                        );
+                        CREATE TABLE comments (
+                            id BIGSERIAL PRIMARY KEY, record_type TEXT NOT NULL,
+                            record_id UUID NOT NULL, author_id BIGINT NOT NULL,
+                            body_markdown TEXT NOT NULL, resolved_at TIMESTAMPTZ,
+                            resolved_by_id BIGINT, deleted_at TIMESTAMPTZ,
+                            deleted_by_id BIGINT, review_revision_id BIGINT
+                        );
+                        CREATE TABLE comment_resolution_events (
+                            id BIGSERIAL PRIMARY KEY, comment_id BIGINT NOT NULL,
+                            action TEXT NOT NULL, disposition TEXT, rationale TEXT NOT NULL,
+                            actor_id BIGINT NOT NULL, actor_role TEXT NOT NULL,
+                            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                        );
+                        """
+                    )
+                )
+                yield connection, schema, migration
+            finally:
+                transaction.rollback()
+    finally:
+        engine.dispose()
+
+
+def _install_existing_triggers(connection) -> None:
+    connection.execute(
+        text(
+            """
+            CREATE FUNCTION validate_phenopacket_revision_pointer()
+            RETURNS trigger AS $$
+            DECLARE packet phenopackets%ROWTYPE;
+            BEGIN
+                SELECT * INTO packet FROM phenopackets WHERE id = NEW.id;
+                IF packet.head_published_revision_id IS NOT NULL AND NOT EXISTS (
+                    SELECT 1 FROM phenopacket_revisions revision
+                    WHERE revision.id = packet.head_published_revision_id
+                      AND revision.record_id = packet.id AND revision.state = 'published'
+                ) THEN RAISE EXCEPTION 'invalid published pointer'; END IF;
+                IF packet.state = 'published' AND packet.head_published_revision_id IS NULL
+                THEN RAISE EXCEPTION 'published phenopacket requires head'; END IF;
+                IF packet.editing_revision_id IS NOT NULL AND NOT EXISTS (
+                    SELECT 1 FROM phenopacket_revisions revision
+                    WHERE revision.id = packet.editing_revision_id
+                      AND revision.record_id = packet.id
+                      AND revision.state IN ('draft','in_review','changes_requested','approved')
+                ) THEN RAISE EXCEPTION 'invalid editing pointer'; END IF;
+                IF packet.state = 'archived' AND packet.editing_revision_id IS NOT NULL
+                THEN RAISE EXCEPTION 'archived pointer'; END IF;
+                RETURN NEW;
+            END; $$ LANGUAGE plpgsql;
+            CREATE CONSTRAINT TRIGGER phenopackets_revision_pointer_owner
+            AFTER INSERT OR UPDATE OF head_published_revision_id, editing_revision_id, state
+            ON phenopackets DEFERRABLE INITIALLY DEFERRED
+            FOR EACH ROW EXECUTE FUNCTION validate_phenopacket_revision_pointer();
+
+            CREATE FUNCTION validate_phenopacket_revision_parent()
+            RETURNS trigger AS $$ BEGIN
+                IF NEW.parent_revision_id IS NOT NULL AND NOT EXISTS (
+                    SELECT 1 FROM phenopacket_revisions parent
+                    WHERE parent.id = NEW.parent_revision_id
+                      AND parent.record_id = NEW.record_id
+                ) THEN RAISE EXCEPTION 'parent revision must belong to its record'; END IF;
+                RETURN NEW;
+            END; $$ LANGUAGE plpgsql;
+            CREATE TRIGGER phenopacket_revisions_parent_owner
+            BEFORE INSERT ON phenopacket_revisions
+            FOR EACH ROW EXECUTE FUNCTION validate_phenopacket_revision_parent();
+
+            CREATE FUNCTION reject_phenopacket_revision_mutation()
+            RETURNS trigger AS $$ BEGIN
+                RAISE EXCEPTION 'phenopacket revisions are append-only';
+            END; $$ LANGUAGE plpgsql;
+            CREATE TRIGGER phenopacket_revisions_immutable
+            BEFORE UPDATE OR DELETE ON phenopacket_revisions
+            FOR EACH ROW EXECUTE FUNCTION reject_phenopacket_revision_mutation();
+            """
+        )
+    )
+
+
+def _bind(connection, migration) -> None:
+    migration.op = Operations(
+        MigrationContext.configure(connection, opts={"target_metadata": Base.metadata})
+    )
+
+
+def _seed_active_review(connection, record_id: uuid.UUID, owner: int | None) -> None:
+    connection.execute(text("INSERT INTO users VALUES (1, 'curator'), (2, 'curator')"))
+    connection.execute(
+        text(
+            """
+            INSERT INTO phenopacket_revisions
+                (id, record_id, parent_revision_id, revision_number, state,
+                 event_type, actor_id)
+            VALUES
+                (1, :id, NULL, 1, 'draft', 'created', 1),
+                (2, :id, 1, 2, 'in_review', 'state_transition', 1)
+            """
+        ),
+        {"id": record_id},
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO phenopackets
+                (id, state, revision, editing_revision_id,
+                 head_published_revision_id, draft_owner_id)
+            VALUES (:id, 'in_review', 2, 2, NULL, :owner)
+            """
+        ),
+        {"id": record_id, "owner": owner},
+    )
+
+
+def _pointer_trigger(connection, schema):
+    return connection.execute(
+        text(
+            """
+            SELECT t.oid, t.tgdeferrable, t.tginitdeferred
+            FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = :schema AND c.relname = 'phenopackets'
+              AND t.tgname = 'phenopackets_revision_pointer_owner'
+            """
+        ),
+        {"schema": schema},
+    ).one()
+
+
+def test_upgrade_backfills_owner_and_preserves_pointer_trigger_identity() -> None:
+    with _isolated_schema() as (connection, schema, migration):
+        record_id = uuid.uuid4()
+        _seed_active_review(connection, record_id, None)
+        _install_existing_triggers(connection)
+        before = _pointer_trigger(connection, schema)
+        _bind(connection, migration)
+        migration.upgrade()
+
+        assert (
+            connection.execute(
+                text("SELECT draft_owner_id FROM phenopackets WHERE id=:id"),
+                {"id": record_id},
+            ).scalar_one()
+            == 1
+        )
+        assert _pointer_trigger(connection, schema) == before
+        triggers = connection.execute(
+            text(
+                """
+                SELECT c.relname, t.tgname, t.tgdeferrable, t.tginitdeferred
+                FROM pg_trigger t JOIN pg_class c ON c.oid=t.tgrelid
+                JOIN pg_namespace n ON n.oid=c.relnamespace
+                WHERE n.nspname=:schema AND NOT t.tgisinternal
+                ORDER BY c.relname, t.tgname
+                """
+            ),
+            {"schema": schema},
+        ).all()
+        names = {(row[0], row[1]) for row in triggers}
+        assert {
+            ("phenopacket_revisions", "phenopacket_revisions_00_lock_record"),
+            ("comments", "comments_review_issue_guard"),
+            ("comments", "comments_review_issue_final_state"),
+            ("comment_resolution_events", "comment_resolution_events_lock_record"),
+            ("comment_resolution_events", "comment_resolution_events_immutable"),
+        } <= names
+        final_trigger = next(
+            row for row in triggers if row[1] == "comments_review_issue_final_state"
+        )
+        assert final_trigger[2:] == (True, True)
+
+        with pytest.raises(IntegrityError, match="active_edit_owner"):
+            with connection.begin_nested():
+                connection.execute(
+                    text("INSERT INTO phenopackets VALUES (:id,'draft',1,2,NULL,NULL)"),
+                    {"id": uuid.uuid4()},
+                )
+
+        migration.downgrade()
+        assert (
+            connection.execute(
+                text("SELECT draft_owner_id FROM phenopackets WHERE id=:id"),
+                {"id": record_id},
+            ).scalar_one()
+            == 1
+        )
+        assert _pointer_trigger(connection, schema) == before
+
+
+def test_database_requires_event_first_and_rejects_issue_erasure() -> None:
+    with _isolated_schema() as (connection, _schema, migration):
+        record_id = uuid.uuid4()
+        _seed_active_review(connection, record_id, 1)
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        migration.upgrade()
+        connection.execute(
+            text(
+                """INSERT INTO comments
+                (id,record_type,record_id,author_id,body_markdown,review_revision_id)
+                VALUES (1,'phenopacket',:id,2,'issue',2)"""
+            ),
+            {"id": record_id},
+        )
+        with pytest.raises(DBAPIError, match="review_issue_resolution_event_required"):
+            with connection.begin_nested():
+                connection.execute(
+                    text(
+                        "UPDATE comments SET resolved_at=now(), resolved_by_id=2 WHERE id=1"
+                    )
+                )
+
+        connection.execute(
+            text(
+                """INSERT INTO comment_resolution_events
+                (comment_id,action,disposition,rationale,actor_id,actor_role)
+                VALUES (1,'resolved','addressed','fixed',2,'curator')"""
+            )
+        )
+        connection.execute(
+            text("UPDATE comments SET resolved_at=now(), resolved_by_id=2 WHERE id=1")
+        )
+        for statement in (
+            "UPDATE comments SET review_revision_id=NULL WHERE id=1",
+            "UPDATE comments SET deleted_at=now() WHERE id=1",
+            "DELETE FROM comments WHERE id=1",
+        ):
+            with pytest.raises(DBAPIError, match="review_issue_mutation_forbidden"):
+                with connection.begin_nested():
+                    connection.execute(text(statement))
+        for statement in (
+            "UPDATE comment_resolution_events SET rationale='tampered' WHERE id=1",
+            "DELETE FROM comment_resolution_events WHERE id=1",
+        ):
+            with pytest.raises(DBAPIError, match="resolution events are append-only"):
+                with connection.begin_nested():
+                    connection.execute(text(statement))
+
+
+def test_unresolved_current_cycle_issue_blocks_approved_revision_insert() -> None:
+    with _isolated_schema() as (connection, _schema, migration):
+        record_id = uuid.uuid4()
+        _seed_active_review(connection, record_id, 1)
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        migration.upgrade()
+        connection.execute(
+            text(
+                """INSERT INTO comments
+                (record_type,record_id,author_id,body_markdown,review_revision_id)
+                VALUES ('phenopacket',:id,2,'issue',2)"""
+            ),
+            {"id": record_id},
+        )
+        with pytest.raises(DBAPIError, match="unresolved_review_issues"):
+            with connection.begin_nested():
+                connection.execute(
+                    text(
+                        """INSERT INTO phenopacket_revisions
+                        (record_id,parent_revision_id,revision_number,state,event_type,actor_id)
+                        VALUES (:id,2,3,'approved','state_transition',2)"""
+                    ),
+                    {"id": record_id},
+                )
+
+
+def test_historical_cycle_issue_does_not_block_current_approval() -> None:
+    """Only review snapshots newer than the exact public head gate approval."""
+    with _isolated_schema() as (connection, _schema, migration):
+        record_id = uuid.uuid4()
+        connection.execute(
+            text("INSERT INTO users VALUES (1, 'curator'), (2, 'curator')")
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO phenopacket_revisions
+                    (id, record_id, parent_revision_id, revision_number, state,
+                     event_type, actor_id)
+                VALUES
+                    (1, :id, NULL, 1, 'in_review', 'state_transition', 1),
+                    (2, :id, 1, 2, 'published', 'state_transition', 2),
+                    (3, :id, 2, 3, 'draft', 'draft_created', 1),
+                    (4, :id, 3, 4, 'in_review', 'state_transition', 1)
+                """
+            ),
+            {"id": record_id},
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO phenopackets
+                    (id, state, revision, editing_revision_id,
+                     head_published_revision_id, draft_owner_id)
+                VALUES (:id, 'in_review', 4, 4, 2, 1)
+                """
+            ),
+            {"id": record_id},
+        )
+        connection.execute(
+            text(
+                """INSERT INTO comments
+                (record_type,record_id,author_id,body_markdown,review_revision_id)
+                VALUES ('phenopacket',:id,2,'historical issue',1)"""
+            ),
+            {"id": record_id},
+        )
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        migration.upgrade()
+
+        connection.execute(
+            text(
+                """INSERT INTO phenopacket_revisions
+                (id,record_id,parent_revision_id,revision_number,state,event_type,actor_id)
+                VALUES (5,:id,4,5,'approved','state_transition',2)"""
+            ),
+            {"id": record_id},
+        )
+        connection.execute(
+            text(
+                """UPDATE phenopackets
+                SET state='approved', revision=5, editing_revision_id=:approved_id
+                WHERE id=:id"""
+            ),
+            {"approved_id": 5, "id": record_id},
+        )
+        connection.execute(text("SET CONSTRAINTS ALL IMMEDIATE"))
+
+
+def test_database_rejects_wrong_record_review_revision_link() -> None:
+    """A client cannot attach another record's immutable review snapshot."""
+    with _isolated_schema() as (connection, _schema, migration):
+        record_id = uuid.uuid4()
+        other_id = uuid.uuid4()
+        _seed_active_review(connection, record_id, 1)
+        connection.execute(
+            text(
+                """INSERT INTO phenopacket_revisions
+                (id,record_id,parent_revision_id,revision_number,state,event_type,actor_id)
+                VALUES (3,:other_id,NULL,1,'in_review','state_transition',2)"""
+            ),
+            {"other_id": other_id},
+        )
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        migration.upgrade()
+
+        with pytest.raises(DBAPIError, match="review_revision_mismatch"):
+            with connection.begin_nested():
+                connection.execute(
+                    text(
+                        """INSERT INTO comments
+                        (record_type,record_id,author_id,body_markdown,review_revision_id)
+                        VALUES ('phenopacket',:id,2,'wrong record',3)"""
+                    ),
+                    {"id": record_id},
+                )
+
+
+def test_deferred_pointer_check_rejects_approved_with_live_issue() -> None:
+    """The augmented final-state trigger catches pointer-only approval bypasses."""
+    with _isolated_schema() as (connection, _schema, migration):
+        record_id = uuid.uuid4()
+        _seed_active_review(connection, record_id, 1)
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        migration.upgrade()
+        connection.execute(
+            text(
+                """INSERT INTO phenopacket_revisions
+                (id,record_id,parent_revision_id,revision_number,state,event_type,actor_id)
+                VALUES (3,:id,2,3,'approved','state_transition',2)"""
+            ),
+            {"id": record_id},
+        )
+        connection.execute(
+            text(
+                """INSERT INTO comments
+                (record_type,record_id,author_id,body_markdown,review_revision_id)
+                VALUES ('phenopacket',:id,2,'live issue',2)"""
+            ),
+            {"id": record_id},
+        )
+        connection.execute(
+            text(
+                """UPDATE phenopackets
+                SET state='approved', revision=3, editing_revision_id=:approved_id
+                WHERE id=:id"""
+            ),
+            {"approved_id": 3, "id": record_id},
+        )
+
+        with pytest.raises(DBAPIError, match="unresolved_review_issues"):
+            with connection.begin_nested():
+                connection.execute(text("SET CONSTRAINTS ALL IMMEDIATE"))
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    [
+        "missing_parent",
+        "cross_record",
+        "cycle",
+        "nondecreasing",
+        "missing_boundary",
+        "multiple_roots",
+    ],
+)
+def test_owner_preflight_refuses_ambiguous_ancestry_before_backfill(
+    corruption: str,
+) -> None:
+    with _isolated_schema() as (connection, _schema, migration):
+        first = uuid.UUID("00000000-0000-0000-0000-000000000001")
+        second = uuid.UUID("00000000-0000-0000-0000-000000000002")
+        connection.execute(text("INSERT INTO users VALUES (1,'curator'),(2,'curator')"))
+        connection.execute(
+            text(
+                """INSERT INTO phenopacket_revisions
+                (id,record_id,parent_revision_id,revision_number,state,event_type,actor_id)
+                VALUES
+                (1,:first,NULL,1,'draft','created',1),
+                (2,:first,1,2,'in_review','state_transition',1),
+                (3,:second,NULL,1,'draft','created',2),
+                (4,:second,3,2,'in_review','state_transition',2)"""
+            ),
+            {"first": first, "second": second},
+        )
+        corrupt_sql = {
+            "missing_parent": "UPDATE phenopacket_revisions SET parent_revision_id=99 WHERE id=2",
+            "cross_record": "UPDATE phenopacket_revisions SET parent_revision_id=3 WHERE id=2",
+            "cycle": "UPDATE phenopacket_revisions SET parent_revision_id=2 WHERE id=1",
+            "nondecreasing": "UPDATE phenopacket_revisions SET revision_number=2 WHERE id=1",
+            "missing_boundary": "UPDATE phenopacket_revisions SET event_type='draft_saved' WHERE id=1",
+            "multiple_roots": "UPDATE phenopacket_revisions SET event_type='created' WHERE id=2",
+        }[corruption]
+        connection.execute(text(corrupt_sql))
+        connection.execute(
+            text(
+                """INSERT INTO phenopackets
+                (id,state,revision,editing_revision_id,draft_owner_id) VALUES
+                (:second,'in_review',2,4,NULL),(:first,'in_review',2,2,NULL)"""
+            ),
+            {"first": first, "second": second},
+        )
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        with pytest.raises(DBAPIError) as exc_info, connection.begin_nested():
+            migration.upgrade()
+        message = str(exc_info.value)
+        assert str(first) in message
+        assert str(second) not in message
+        assert (
+            connection.execute(
+                text("SELECT draft_owner_id FROM phenopackets WHERE id=:id"),
+                {"id": first},
+            ).scalar_one()
+            is None
+        )
+        assert (
+            connection.execute(
+                text("SELECT draft_owner_id FROM phenopackets WHERE id=:id"),
+                {"id": second},
+            ).scalar_one()
+            is None
+        )

--- a/backend/tests/migration/test_independent_review_activation_migration.py
+++ b/backend/tests/migration/test_independent_review_activation_migration.py
@@ -96,7 +96,11 @@ def _isolated_schema():
                 connection.execute(
                     text(
                         """
-                        CREATE TABLE users (id BIGINT PRIMARY KEY, role TEXT NOT NULL);
+                        CREATE TABLE users (
+                            id BIGINT PRIMARY KEY,
+                            role TEXT NOT NULL,
+                            is_active BOOLEAN NOT NULL DEFAULT TRUE
+                        );
                         CREATE TABLE phenopackets (
                             id UUID PRIMARY KEY, state TEXT NOT NULL,
                             revision INTEGER NOT NULL, editing_revision_id BIGINT,
@@ -195,7 +199,9 @@ def _bind(connection, migration) -> None:
 
 
 def _seed_active_review(connection, record_id: uuid.UUID, owner: int | None) -> None:
-    connection.execute(text("INSERT INTO users VALUES (1, 'curator'), (2, 'curator')"))
+    connection.execute(
+        text("INSERT INTO users VALUES (1, 'curator', TRUE), (2, 'curator', TRUE)")
+    )
     connection.execute(
         text(
             """
@@ -219,6 +225,41 @@ def _seed_active_review(connection, record_id: uuid.UUID, owner: int | None) -> 
             """
         ),
         {"id": record_id, "owner": owner},
+    )
+
+
+def _seed_actor_eligibility_review(connection, record_id: uuid.UUID) -> None:
+    """Seed literal reviewer roles and one never-published candidate ancestry."""
+    connection.execute(
+        text(
+            """INSERT INTO users (id,role,is_active) VALUES
+            (1,'admin',TRUE),
+            (2,'curator',TRUE),
+            (3,'admin',TRUE),
+            (4,'curator',FALSE),
+            (5,'viewer',TRUE),
+            (6,'curator',TRUE),
+            (7,'admin',TRUE)"""
+        )
+    )
+    connection.execute(
+        text(
+            """INSERT INTO phenopacket_revisions
+            (id,record_id,parent_revision_id,revision_number,state,event_type,actor_id)
+            VALUES
+            (1,:id,NULL,1,'draft','created',1),
+            (2,:id,1,2,'draft','draft_saved',3),
+            (3,:id,2,3,'in_review','state_transition',2)"""
+        ),
+        {"id": record_id},
+    )
+    connection.execute(
+        text(
+            """INSERT INTO phenopackets
+            (id,state,revision,editing_revision_id,draft_owner_id)
+            VALUES (:id,'in_review',3,3,1)"""
+        ),
+        {"id": record_id},
     )
 
 
@@ -272,12 +313,22 @@ def test_upgrade_backfills_owner_and_preserves_pointer_trigger_identity() -> Non
             ("comments", "comments_review_issue_guard"),
             ("comments", "comments_review_issue_final_state"),
             ("comment_resolution_events", "comment_resolution_events_lock_record"),
+            (
+                "comment_resolution_events",
+                "comment_resolution_events_projection_final_state",
+            ),
             ("comment_resolution_events", "comment_resolution_events_immutable"),
         } <= names
         final_trigger = next(
             row for row in triggers if row[1] == "comments_review_issue_final_state"
         )
         assert final_trigger[2:] == (True, True)
+        event_final_trigger = next(
+            row
+            for row in triggers
+            if row[1] == "comment_resolution_events_projection_final_state"
+        )
+        assert event_final_trigger[2:] == (True, True)
 
         with pytest.raises(IntegrityError, match="active_edit_owner"):
             with connection.begin_nested():
@@ -330,6 +381,7 @@ def test_database_requires_event_first_and_rejects_issue_erasure() -> None:
         connection.execute(
             text("UPDATE comments SET resolved_at=now(), resolved_by_id=2 WHERE id=1")
         )
+        connection.execute(text("SET CONSTRAINTS ALL IMMEDIATE"))
         for statement in (
             "UPDATE comments SET review_revision_id=NULL WHERE id=1",
             "UPDATE comments SET deleted_at=now() WHERE id=1",
@@ -345,6 +397,218 @@ def test_database_requires_event_first_and_rejects_issue_erasure() -> None:
             with pytest.raises(DBAPIError, match="resolution events are append-only"):
                 with connection.begin_nested():
                     connection.execute(text(statement))
+
+
+def test_database_rejects_duplicate_event_before_projection_update() -> None:
+    """The comment re-lock observes an unprojected event in the same transaction."""
+    with _isolated_schema() as (connection, _schema, migration):
+        record_id = uuid.uuid4()
+        _seed_active_review(connection, record_id, 1)
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        migration.upgrade()
+        connection.execute(
+            text(
+                """INSERT INTO comments
+                (id,record_type,record_id,author_id,body_markdown,review_revision_id)
+                VALUES (1,'phenopacket',:id,2,'issue',2)"""
+            ),
+            {"id": record_id},
+        )
+        connection.execute(
+            text(
+                """INSERT INTO comment_resolution_events
+                (comment_id,action,disposition,rationale,actor_id,actor_role)
+                VALUES (1,'resolved','addressed','first',2,'curator')"""
+            )
+        )
+
+        with pytest.raises(
+            DBAPIError, match="review_issue_resolution_projection_mismatch"
+        ):
+            with connection.begin_nested():
+                connection.execute(
+                    text(
+                        """INSERT INTO comment_resolution_events
+                        (comment_id,action,disposition,rationale,actor_id,actor_role)
+                        VALUES (1,'resolved','addressed','duplicate',2,'curator')"""
+                    )
+                )
+
+        connection.execute(
+            text("UPDATE comments SET resolved_at=now(),resolved_by_id=2 WHERE id=1")
+        )
+        connection.execute(
+            text(
+                """INSERT INTO comment_resolution_events
+                (comment_id,action,disposition,rationale,actor_id,actor_role)
+                VALUES (1,'reopened',NULL,'supported reopen',2,'curator')"""
+            )
+        )
+        connection.execute(
+            text("UPDATE comments SET resolved_at=NULL,resolved_by_id=NULL WHERE id=1")
+        )
+        connection.execute(text("SET CONSTRAINTS ALL IMMEDIATE"))
+
+
+@pytest.mark.parametrize(
+    "projection_sql",
+    [None, "UPDATE comments SET resolved_at=now(),resolved_by_id=2 WHERE id=999"],
+    ids=["event-only", "zero-row-projection"],
+)
+def test_deferred_event_projection_check_rejects_unprojected_commit(
+    projection_sql: str | None,
+) -> None:
+    """An event cannot commit unless its target projection reflects it."""
+    with _isolated_schema() as (connection, _schema, migration):
+        record_id = uuid.uuid4()
+        _seed_active_review(connection, record_id, 1)
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        migration.upgrade()
+        connection.execute(
+            text(
+                """INSERT INTO comments
+                (id,record_type,record_id,author_id,body_markdown,review_revision_id)
+                VALUES (1,'phenopacket',:id,2,'issue',2)"""
+            ),
+            {"id": record_id},
+        )
+        with pytest.raises(
+            DBAPIError, match="review_issue_resolution_projection_mismatch"
+        ):
+            with connection.begin_nested():
+                connection.execute(
+                    text(
+                        """INSERT INTO comment_resolution_events
+                        (comment_id,action,disposition,rationale,actor_id,actor_role)
+                        VALUES (1,'resolved','addressed','must project',2,'curator')"""
+                    )
+                )
+                if projection_sql is not None:
+                    connection.execute(text(projection_sql))
+                connection.execute(text("SET CONSTRAINTS ALL IMMEDIATE"))
+        assert (
+            connection.execute(
+                text("SELECT count(*) FROM comment_resolution_events")
+            ).scalar_one()
+            == 0
+        )
+
+
+def test_database_enforces_issue_author_independence_and_role() -> None:
+    """Raw issue insertion applies owner/submitter/contributor/account policy."""
+    with _isolated_schema() as (connection, _schema, migration):
+        record_id = uuid.uuid4()
+        _seed_actor_eligibility_review(connection, record_id)
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        migration.upgrade()
+
+        denied = (
+            (1, "self_review_forbidden"),
+            (2, "reviewer_submitted"),
+            (3, "reviewer_contributed"),
+            (4, "reviewer_not_eligible"),
+            (5, "reviewer_not_eligible"),
+        )
+        for author_id, error in denied:
+            with pytest.raises(DBAPIError, match=error):
+                with connection.begin_nested():
+                    connection.execute(
+                        text(
+                            """INSERT INTO comments
+                            (record_type,record_id,author_id,body_markdown,
+                             review_revision_id)
+                            VALUES ('phenopacket',:id,:author_id,'denied',3)"""
+                        ),
+                        {"id": record_id, "author_id": author_id},
+                    )
+
+        for author_id in (6, 7):
+            connection.execute(
+                text(
+                    """INSERT INTO comments
+                    (record_type,record_id,author_id,body_markdown,review_revision_id)
+                    VALUES ('phenopacket',:id,:author_id,'eligible',3)"""
+                ),
+                {"id": record_id, "author_id": author_id},
+            )
+        assert (
+            connection.execute(text("SELECT count(*) FROM comments")).scalar_one() == 2
+        )
+
+
+def test_database_enforces_resolution_event_actor_independence_and_role() -> None:
+    """Raw issue events verify the stored user, role claim, and independence."""
+    with _isolated_schema() as (connection, _schema, migration):
+        record_id = uuid.uuid4()
+        _seed_actor_eligibility_review(connection, record_id)
+        connection.execute(
+            text(
+                """INSERT INTO comments
+                (id,record_type,record_id,author_id,body_markdown,review_revision_id)
+                VALUES
+                (1,'phenopacket',:id,6,'curator path',3),
+                (2,'phenopacket',:id,7,'admin path',3)"""
+            ),
+            {"id": record_id},
+        )
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        migration.upgrade()
+
+        denied = (
+            (1, "admin", "self_review_forbidden"),
+            (2, "curator", "reviewer_submitted"),
+            (3, "admin", "reviewer_contributed"),
+            (4, "curator", "reviewer_not_eligible"),
+            (5, "viewer", "reviewer_not_eligible"),
+            (7, "curator", "reviewer_actor_role_mismatch"),
+        )
+        for actor_id, actor_role, error in denied:
+            with pytest.raises(DBAPIError, match=error):
+                with connection.begin_nested():
+                    connection.execute(
+                        text(
+                            """INSERT INTO comment_resolution_events
+                            (comment_id,action,disposition,rationale,actor_id,actor_role)
+                            VALUES
+                            (1,'resolved','addressed','denied',:actor_id,:actor_role)"""
+                        ),
+                        {"actor_id": actor_id, "actor_role": actor_role},
+                    )
+
+        for comment_id, actor_id, actor_role in (
+            (1, 6, "curator"),
+            (2, 7, "admin"),
+        ):
+            connection.execute(
+                text(
+                    """INSERT INTO comment_resolution_events
+                    (comment_id,action,disposition,rationale,actor_id,actor_role)
+                    VALUES
+                    (:comment_id,'resolved','addressed','eligible',:actor_id,:actor_role)"""
+                ),
+                {
+                    "comment_id": comment_id,
+                    "actor_id": actor_id,
+                    "actor_role": actor_role,
+                },
+            )
+            connection.execute(
+                text(
+                    """UPDATE comments SET resolved_at=now(),resolved_by_id=:actor_id
+                    WHERE id=:comment_id"""
+                ),
+                {"comment_id": comment_id, "actor_id": actor_id},
+            )
+        assert (
+            connection.execute(
+                text("SELECT count(*) FROM comment_resolution_events")
+            ).scalar_one()
+            == 2
+        )
 
 
 def test_unresolved_current_cycle_issue_blocks_approved_revision_insert() -> None:
@@ -374,12 +638,153 @@ def test_unresolved_current_cycle_issue_blocks_approved_revision_insert() -> Non
                 )
 
 
+def test_old_issue_in_never_published_active_ancestry_can_resolve() -> None:
+    """An earlier candidate in the live ancestry remains an actionable issue."""
+    with _isolated_schema() as (connection, _schema, migration):
+        record_id = uuid.uuid4()
+        connection.execute(
+            text("INSERT INTO users VALUES (1, 'curator', TRUE), (2, 'curator', TRUE)")
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO phenopacket_revisions
+                    (id,record_id,parent_revision_id,revision_number,state,
+                     event_type,actor_id)
+                VALUES
+                    (1,:id,NULL,1,'draft','created',1),
+                    (2,:id,1,2,'in_review','state_transition',1),
+                    (3,:id,2,3,'changes_requested','state_transition',2),
+                    (4,:id,3,4,'draft','draft_saved',1),
+                    (5,:id,4,5,'in_review','state_transition',1)
+                """
+            ),
+            {"id": record_id},
+        )
+        connection.execute(
+            text(
+                """INSERT INTO phenopackets
+                (id,state,revision,editing_revision_id,draft_owner_id)
+                VALUES (:id,'in_review',5,5,1)"""
+            ),
+            {"id": record_id},
+        )
+        connection.execute(
+            text(
+                """INSERT INTO comments
+                (id,record_type,record_id,author_id,body_markdown,review_revision_id)
+                VALUES (1,'phenopacket',:id,2,'old live-cycle issue',2)"""
+            ),
+            {"id": record_id},
+        )
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        migration.upgrade()
+
+        connection.execute(
+            text(
+                """INSERT INTO comment_resolution_events
+                (comment_id,action,disposition,rationale,actor_id,actor_role)
+                VALUES (1,'resolved','addressed','fixed on resubmit',2,'curator')"""
+            )
+        )
+        connection.execute(
+            text("UPDATE comments SET resolved_at=now(),resolved_by_id=2 WHERE id=1")
+        )
+        connection.execute(
+            text(
+                """INSERT INTO comment_resolution_events
+                (comment_id,action,disposition,rationale,actor_id,actor_role)
+                VALUES (1,'reopened',NULL,'verify old issue',2,'curator')"""
+            )
+        )
+        connection.execute(
+            text("UPDATE comments SET resolved_at=NULL,resolved_by_id=NULL WHERE id=1")
+        )
+        connection.execute(
+            text(
+                """INSERT INTO comment_resolution_events
+                (comment_id,action,disposition,rationale,actor_id,actor_role)
+                VALUES (1,'resolved','addressed','verified',2,'curator')"""
+            )
+        )
+        connection.execute(
+            text("UPDATE comments SET resolved_at=now(),resolved_by_id=2 WHERE id=1")
+        )
+        connection.execute(
+            text(
+                """INSERT INTO phenopacket_revisions
+                (id,record_id,parent_revision_id,revision_number,state,event_type,actor_id)
+                VALUES (6,:id,5,6,'approved','state_transition',2)"""
+            ),
+            {"id": record_id},
+        )
+        connection.execute(
+            text(
+                """UPDATE phenopackets
+                SET state='approved',revision=6,editing_revision_id=6 WHERE id=:id"""
+            ),
+            {"id": record_id},
+        )
+        connection.execute(text("SET CONSTRAINTS ALL IMMEDIATE"))
+
+
+def test_resolution_event_rejects_candidate_before_broken_active_cycle_root() -> None:
+    """The event guard must validate ancestry beyond the linked issue candidate."""
+    with _isolated_schema() as (connection, _schema, migration):
+        record_id = uuid.uuid4()
+        connection.execute(
+            text("INSERT INTO users VALUES (1, 'curator', TRUE), (2, 'curator', TRUE)")
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO phenopacket_revisions
+                    (id,record_id,parent_revision_id,revision_number,state,
+                     event_type,actor_id)
+                VALUES
+                    (2,:id,99,2,'in_review','state_transition',1),
+                    (5,:id,2,5,'in_review','state_transition',1)
+                """
+            ),
+            {"id": record_id},
+        )
+        connection.execute(
+            text(
+                """INSERT INTO phenopackets
+                (id,state,revision,editing_revision_id,draft_owner_id)
+                VALUES (:id,'in_review',5,5,1)"""
+            ),
+            {"id": record_id},
+        )
+        connection.execute(
+            text(
+                """INSERT INTO comments
+                (id,record_type,record_id,author_id,body_markdown,review_revision_id)
+                VALUES (1,'phenopacket',:id,2,'issue before broken root',2)"""
+            ),
+            {"id": record_id},
+        )
+        _install_existing_triggers(connection)
+        _bind(connection, migration)
+        migration.upgrade()
+
+        with pytest.raises(DBAPIError, match="review_revision_mismatch"):
+            connection.execute(
+                text(
+                    """INSERT INTO comment_resolution_events
+                    (comment_id,action,disposition,rationale,actor_id,actor_role)
+                    VALUES (1,'resolved','addressed','invalid ancestry',2,'curator')"""
+                )
+            )
+
+
 def test_historical_cycle_issue_does_not_block_current_approval() -> None:
     """Only review snapshots newer than the exact public head gate approval."""
     with _isolated_schema() as (connection, _schema, migration):
         record_id = uuid.uuid4()
         connection.execute(
-            text("INSERT INTO users VALUES (1, 'curator'), (2, 'curator')")
+            text("INSERT INTO users VALUES (1, 'curator', TRUE), (2, 'curator', TRUE)")
         )
         connection.execute(
             text(
@@ -418,6 +823,16 @@ def test_historical_cycle_issue_does_not_block_current_approval() -> None:
         _install_existing_triggers(connection)
         _bind(connection, migration)
         migration.upgrade()
+
+        with pytest.raises(DBAPIError, match="review_revision_mismatch"):
+            with connection.begin_nested():
+                connection.execute(
+                    text(
+                        """INSERT INTO comment_resolution_events
+                        (comment_id,action,disposition,rationale,actor_id,actor_role)
+                        VALUES (1,'resolved','addressed','historical',2,'curator')"""
+                    )
+                )
 
         connection.execute(
             text(
@@ -523,7 +938,9 @@ def test_owner_preflight_refuses_ambiguous_ancestry_before_backfill(
     with _isolated_schema() as (connection, _schema, migration):
         first = uuid.UUID("00000000-0000-0000-0000-000000000001")
         second = uuid.UUID("00000000-0000-0000-0000-000000000002")
-        connection.execute(text("INSERT INTO users VALUES (1,'curator'),(2,'curator')"))
+        connection.execute(
+            text("INSERT INTO users VALUES (1,'curator',TRUE),(2,'curator',TRUE)")
+        )
         connection.execute(
             text(
                 """INSERT INTO phenopacket_revisions

--- a/backend/tests/migration/test_independent_review_expand_migration.py
+++ b/backend/tests/migration/test_independent_review_expand_migration.py
@@ -1,0 +1,489 @@
+"""Database behavior contract for the nullable independent-review expansion."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import uuid
+from pathlib import Path
+
+import pytest
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+
+from app.core.config import settings
+from app.database import Base
+
+
+def _migration_module():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "alembic/versions/d0f422b00005_expand_independent_review_audit.py"
+    )
+    assert path.exists(), (
+        "independent-review expand migration is missing; without it deployed "
+        "databases cannot store review audit evidence"
+    )
+    spec = importlib.util.spec_from_file_location("independent_review_expand", path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    return migration
+
+
+def _normalize_sql(sql: str) -> str:
+    without_reflection_casts = sql.replace("::text", "")
+    return re.sub(r"[()\s]+", " ", without_reflection_casts).strip().lower()
+
+
+def _assert_check_rejects(connection, statement: str, parameters: dict) -> None:
+    with pytest.raises(IntegrityError), connection.begin_nested():
+        connection.execute(text(statement), parameters)
+
+
+def test_expand_migration_catches_wrong_revision_chain():
+    """The additive migration must extend, never rewrite, the current head."""
+    migration = _migration_module()
+
+    assert migration.revision == "d0f422b00005"
+    assert migration.down_revision == "c0f422b00004"
+
+
+def test_expand_migration_catches_missing_database_guards_and_downgrade_cleanup():
+    """Upgrade must enforce audit shape without activating workflow triggers."""
+    migration = _migration_module()
+    sync_url = settings.DATABASE_URL.replace("postgresql+asyncpg://", "postgresql://")
+    engine = create_engine(sync_url)
+    schema = f"review_expand_{uuid.uuid4().hex}"
+
+    try:
+        with engine.connect() as connection:
+            transaction = connection.begin()
+            try:
+                connection.execute(text(f'CREATE SCHEMA "{schema}"'))
+                connection.execute(text(f'SET LOCAL search_path TO "{schema}"'))
+                connection.execute(text("CREATE TABLE users (id BIGINT PRIMARY KEY)"))
+                connection.execute(
+                    text("CREATE TABLE phenopackets (id UUID PRIMARY KEY)")
+                )
+                connection.execute(
+                    text("CREATE TABLE phenopacket_revisions (id BIGINT PRIMARY KEY)")
+                )
+                connection.execute(
+                    text(
+                        """
+                        CREATE FUNCTION prevent_revision_mutation()
+                        RETURNS trigger LANGUAGE plpgsql AS $$
+                        BEGIN
+                            RAISE EXCEPTION 'phenopacket revisions are immutable';
+                        END;
+                        $$
+                        """
+                    )
+                )
+                connection.execute(
+                    text(
+                        """
+                        CREATE TRIGGER phenopacket_revisions_immutable
+                        BEFORE UPDATE OR DELETE ON phenopacket_revisions
+                        FOR EACH ROW EXECUTE FUNCTION prevent_revision_mutation()
+                        """
+                    )
+                )
+                connection.execute(
+                    text(
+                        """
+                        CREATE TABLE comments (
+                            id BIGINT PRIMARY KEY,
+                            record_type TEXT NOT NULL,
+                            record_id UUID NOT NULL,
+                            resolved_at TIMESTAMPTZ,
+                            deleted_at TIMESTAMPTZ
+                        )
+                        """
+                    )
+                )
+                connection.execute(text("INSERT INTO users (id) VALUES (1)"))
+                connection.execute(
+                    text("INSERT INTO phenopacket_revisions (id) VALUES (1)")
+                )
+                record_id = uuid.uuid4()
+                connection.execute(
+                    text(
+                        "INSERT INTO comments (id, record_type, record_id) "
+                        "VALUES (1, 'phenopacket', :record_id)"
+                    ),
+                    {"record_id": record_id},
+                )
+
+                migration.op = Operations(
+                    MigrationContext.configure(
+                        connection, opts={"target_metadata": Base.metadata}
+                    )
+                )
+                migration.upgrade()
+
+                inspector = inspect(connection)
+                revision_columns = {
+                    column["name"]: column
+                    for column in inspector.get_columns(
+                        "phenopacket_revisions", schema=schema
+                    )
+                }
+                assert {
+                    "actor_role",
+                    "decision_metadata",
+                    "content_sha256",
+                    "ledger_version",
+                } <= revision_columns.keys()
+                assert all(
+                    revision_columns[name]["nullable"]
+                    for name in (
+                        "actor_role",
+                        "decision_metadata",
+                        "content_sha256",
+                        "ledger_version",
+                    )
+                )
+                assert connection.execute(
+                    text(
+                        """
+                        SELECT actor_role, decision_metadata,
+                               content_sha256, ledger_version
+                        FROM phenopacket_revisions
+                        WHERE id = 1
+                        """
+                    )
+                ).one() == (None, None, None, None)
+
+                comment_columns = {
+                    column["name"]: column
+                    for column in inspector.get_columns("comments", schema=schema)
+                }
+                assert comment_columns["review_revision_id"]["nullable"]
+                assert (
+                    connection.execute(
+                        text("SELECT review_revision_id FROM comments WHERE id = 1")
+                    ).scalar_one_or_none()
+                    is None
+                )
+                comment_fks = inspector.get_foreign_keys("comments", schema=schema)
+                assert any(
+                    fk["constrained_columns"] == ["review_revision_id"]
+                    and fk["referred_table"] == "phenopacket_revisions"
+                    and fk["options"].get("ondelete") == "RESTRICT"
+                    for fk in comment_fks
+                )
+
+                event_columns = {
+                    column["name"]: column
+                    for column in inspector.get_columns(
+                        "comment_resolution_events", schema=schema
+                    )
+                }
+                assert event_columns.keys() >= {
+                    "id",
+                    "comment_id",
+                    "action",
+                    "disposition",
+                    "rationale",
+                    "actor_id",
+                    "actor_role",
+                    "created_at",
+                }
+                assert event_columns["disposition"]["nullable"]
+                assert all(
+                    not event_columns[name]["nullable"]
+                    for name in (
+                        "id",
+                        "comment_id",
+                        "action",
+                        "rationale",
+                        "actor_id",
+                        "actor_role",
+                        "created_at",
+                    )
+                )
+                event_fks = inspector.get_foreign_keys(
+                    "comment_resolution_events", schema=schema
+                )
+                assert {
+                    (
+                        tuple(fk["constrained_columns"]),
+                        fk["referred_table"],
+                        fk["options"].get("ondelete"),
+                    )
+                    for fk in event_fks
+                } >= {
+                    (("comment_id",), "comments", "RESTRICT"),
+                    (("actor_id",), "users", "RESTRICT"),
+                }
+
+                revision_checks = {
+                    check["name"]: _normalize_sql(check["sqltext"])
+                    for check in inspector.get_check_constraints(
+                        "phenopacket_revisions", schema=schema
+                    )
+                }
+                assert revision_checks.keys() >= {
+                    "ck_phenopacket_revisions_actor_role",
+                    "ck_phenopacket_revisions_content_sha256",
+                    "ck_phenopacket_revisions_ledger_version",
+                    "ck_phenopacket_revisions_decision_metadata_ledger",
+                }
+                event_checks = {
+                    check["name"]: _normalize_sql(check["sqltext"])
+                    for check in inspector.get_check_constraints(
+                        "comment_resolution_events", schema=schema
+                    )
+                }
+                assert event_checks.keys() >= {
+                    "ck_comment_resolution_event_action_disposition",
+                    "ck_comment_resolution_event_rationale",
+                    "ck_comment_resolution_event_actor_role",
+                }
+
+                indexes = {
+                    index["name"]: index
+                    for index in inspector.get_indexes("comments", schema=schema)
+                }
+                blocking_index = indexes[
+                    "ix_comments_live_unresolved_phenopacket_review_issues"
+                ]
+                assert blocking_index["column_names"] == [
+                    "record_id",
+                    "review_revision_id",
+                ]
+                predicate = str(blocking_index["dialect_options"]["postgresql_where"])
+                assert _normalize_sql(predicate) == _normalize_sql(
+                    "record_type = 'phenopacket' AND "
+                    "review_revision_id IS NOT NULL AND resolved_at IS NULL AND "
+                    "deleted_at IS NULL"
+                )
+
+                trigger_enabled = connection.execute(
+                    text(
+                        """
+                        SELECT t.tgenabled
+                        FROM pg_trigger AS t
+                        JOIN pg_class AS c ON c.oid = t.tgrelid
+                        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+                        WHERE n.nspname = :schema
+                          AND c.relname = 'phenopacket_revisions'
+                          AND t.tgname = 'phenopacket_revisions_immutable'
+                        """
+                    ),
+                    {"schema": schema},
+                ).scalar_one()
+                assert trigger_enabled == "O"
+                assert (
+                    connection.execute(
+                        text(
+                            """
+                            SELECT count(*)
+                            FROM pg_trigger AS t
+                            JOIN pg_class AS c ON c.oid = t.tgrelid
+                            JOIN pg_namespace AS n ON n.oid = c.relnamespace
+                            WHERE n.nspname = :schema
+                              AND c.relname IN (
+                                  'comments', 'comment_resolution_events'
+                              )
+                              AND NOT t.tgisinternal
+                            """
+                        ),
+                        {"schema": schema},
+                    ).scalar_one()
+                    == 0
+                )
+
+                valid_revisions = connection.begin_nested()
+                connection.execute(
+                    text(
+                        """
+                        INSERT INTO phenopacket_revisions
+                            (id, actor_role, decision_metadata,
+                             content_sha256, ledger_version)
+                        VALUES
+                            (2, 'viewer', NULL, NULL, 2),
+                            (3, 'curator', '{}'::jsonb,
+                             :digest, 2),
+                            (4, 'admin', NULL, NULL, NULL)
+                        """
+                    ),
+                    {"digest": f"sha256:{'a' * 64}"},
+                )
+                valid_revisions.rollback()
+
+                _assert_check_rejects(
+                    connection,
+                    "INSERT INTO phenopacket_revisions "
+                    "(id, content_sha256) VALUES (2, 'sha256:not-a-digest')",
+                    {},
+                )
+                _assert_check_rejects(
+                    connection,
+                    "INSERT INTO phenopacket_revisions "
+                    "(id, ledger_version) VALUES (2, 1)",
+                    {},
+                )
+                _assert_check_rejects(
+                    connection,
+                    "INSERT INTO phenopacket_revisions "
+                    "(id, decision_metadata, ledger_version) "
+                    "VALUES (2, '{}'::jsonb, 1)",
+                    {},
+                )
+                _assert_check_rejects(
+                    connection,
+                    "INSERT INTO phenopacket_revisions "
+                    "(id, actor_role) VALUES (2, 'superuser')",
+                    {},
+                )
+                _assert_check_rejects(
+                    connection,
+                    """
+                    INSERT INTO comment_resolution_events
+                        (comment_id, action, disposition, rationale, actor_id, actor_role)
+                    VALUES (1, 'reopened', 'addressed', 'reopened', 1, 'curator')
+                    """,
+                    {},
+                )
+                _assert_check_rejects(
+                    connection,
+                    """
+                    INSERT INTO comment_resolution_events
+                        (comment_id, action, disposition, rationale, actor_id, actor_role)
+                    VALUES (1, 'resolved', 'addressed', '   ', 1, 'curator')
+                    """,
+                    {},
+                )
+                _assert_check_rejects(
+                    connection,
+                    """
+                    INSERT INTO comment_resolution_events
+                        (comment_id, action, disposition, rationale, actor_id, actor_role)
+                    VALUES (1, 'resolved', 'addressed', :rationale, 1, 'curator')
+                    """,
+                    {"rationale": "x" * 501},
+                )
+                _assert_check_rejects(
+                    connection,
+                    """
+                    INSERT INTO comment_resolution_events
+                        (comment_id, action, disposition, rationale, actor_id, actor_role)
+                    VALUES (1, 'resolved', 'addressed', 'valid', 1, 'viewer')
+                    """,
+                    {},
+                )
+                _assert_check_rejects(
+                    connection,
+                    """
+                    INSERT INTO comment_resolution_events
+                        (comment_id, action, disposition, rationale, actor_id, actor_role)
+                    VALUES (1, 'deleted', NULL, 'valid', 1, 'curator')
+                    """,
+                    {},
+                )
+                _assert_check_rejects(
+                    connection,
+                    """
+                    INSERT INTO comment_resolution_events
+                        (comment_id, action, disposition, rationale, actor_id, actor_role)
+                    VALUES (1, 'resolved', 'ignored', 'valid', 1, 'curator')
+                    """,
+                    {},
+                )
+                for disposition in (
+                    "addressed",
+                    "accepted_with_rationale",
+                    "retracted",
+                    "superseded",
+                ):
+                    connection.execute(
+                        text(
+                            """
+                            INSERT INTO comment_resolution_events
+                                (comment_id, action, disposition, rationale,
+                                 actor_id, actor_role)
+                            VALUES
+                                (1, 'resolved', :disposition, 'valid', 1, 'curator')
+                            """
+                        ),
+                        {"disposition": disposition},
+                    )
+                connection.execute(
+                    text(
+                        """
+                        INSERT INTO comment_resolution_events
+                            (comment_id, action, disposition, rationale,
+                             actor_id, actor_role)
+                        VALUES (1, 'reopened', NULL, 'valid', 1, 'admin')
+                        """
+                    )
+                )
+                connection.execute(text("DELETE FROM comment_resolution_events"))
+                assert (
+                    connection.execute(
+                        text("SELECT count(*) FROM comment_resolution_events")
+                    ).scalar_one()
+                    == 0
+                )
+                assert (
+                    connection.execute(
+                        text(
+                            """
+                            SELECT count(*) FROM phenopacket_revisions
+                            WHERE actor_role IS NOT NULL
+                               OR decision_metadata IS NOT NULL
+                               OR content_sha256 IS NOT NULL
+                               OR ledger_version IS NOT NULL
+                            """
+                        )
+                    ).scalar_one()
+                    == 0
+                )
+
+                migration.downgrade()
+                inspector = inspect(connection)
+                assert not inspector.has_table(
+                    "comment_resolution_events", schema=schema
+                )
+                assert {
+                    column["name"]
+                    for column in inspector.get_columns(
+                        "phenopacket_revisions", schema=schema
+                    )
+                } == {"id"}
+                assert {
+                    column["name"]
+                    for column in inspector.get_columns("comments", schema=schema)
+                } == {
+                    "id",
+                    "record_type",
+                    "record_id",
+                    "resolved_at",
+                    "deleted_at",
+                }
+                assert (
+                    connection.execute(
+                        text(
+                            """
+                        SELECT t.tgenabled
+                        FROM pg_trigger AS t
+                        JOIN pg_class AS c ON c.oid = t.tgrelid
+                        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+                        WHERE n.nspname = :schema
+                          AND c.relname = 'phenopacket_revisions'
+                          AND t.tgname = 'phenopacket_revisions_immutable'
+                        """
+                        ),
+                        {"schema": schema},
+                    ).scalar_one()
+                    == "O"
+                )
+            finally:
+                transaction.rollback()
+    finally:
+        engine.dispose()

--- a/backend/tests/migration/test_independent_review_expand_migration.py
+++ b/backend/tests/migration/test_independent_review_expand_migration.py
@@ -51,6 +51,80 @@ def test_expand_migration_catches_wrong_revision_chain():
     assert migration.down_revision == "c0f422b00004"
 
 
+@pytest.mark.parametrize(
+    "invalid_insert",
+    [
+        """
+        INSERT INTO phenopacket_revisions
+            (id, decision_metadata, ledger_version)
+        VALUES (1, '{}'::jsonb, NULL)
+        """,
+        """
+        INSERT INTO comment_resolution_events
+            (comment_id, action, disposition, rationale, actor_id, actor_role)
+        VALUES (1, 'resolved', NULL, 'valid rationale', 1, 'curator')
+        """,
+    ],
+    ids=[
+        "decision-metadata-without-v2-ledger",
+        "resolved-event-without-disposition",
+    ],
+)
+def test_expand_migration_rejects_null_values_that_bypass_dependent_checks(
+    invalid_insert: str,
+):
+    """Dependent audit fields must not bypass checks through SQL NULL."""
+    migration = _migration_module()
+    sync_url = settings.DATABASE_URL.replace("postgresql+asyncpg://", "postgresql://")
+    engine = create_engine(sync_url)
+    schema = f"review_null_guard_{uuid.uuid4().hex}"
+
+    try:
+        with engine.connect() as connection:
+            transaction = connection.begin()
+            try:
+                connection.execute(text(f'CREATE SCHEMA "{schema}"'))
+                connection.execute(text(f'SET LOCAL search_path TO "{schema}"'))
+                connection.execute(text("CREATE TABLE users (id BIGINT PRIMARY KEY)"))
+                connection.execute(
+                    text("CREATE TABLE phenopacket_revisions (id BIGINT PRIMARY KEY)")
+                )
+                connection.execute(
+                    text(
+                        """
+                        CREATE TABLE comments (
+                            id BIGINT PRIMARY KEY,
+                            record_type TEXT NOT NULL,
+                            record_id UUID NOT NULL,
+                            resolved_at TIMESTAMPTZ,
+                            deleted_at TIMESTAMPTZ
+                        )
+                        """
+                    )
+                )
+                connection.execute(text("INSERT INTO users (id) VALUES (1)"))
+                connection.execute(
+                    text(
+                        "INSERT INTO comments (id, record_type, record_id) "
+                        "VALUES (1, 'phenopacket', :record_id)"
+                    ),
+                    {"record_id": uuid.uuid4()},
+                )
+                migration.op = Operations(
+                    MigrationContext.configure(
+                        connection, opts={"target_metadata": Base.metadata}
+                    )
+                )
+                migration.upgrade()
+
+                with pytest.raises(IntegrityError):
+                    connection.execute(text(invalid_insert))
+            finally:
+                transaction.rollback()
+    finally:
+        engine.dispose()
+
+
 def test_expand_migration_catches_missing_database_guards_and_downgrade_cleanup():
     """Upgrade must enforce audit shape without activating workflow triggers."""
     migration = _migration_module()

--- a/backend/tests/migration/test_independent_review_sql_races.py
+++ b/backend/tests/migration/test_independent_review_sql_races.py
@@ -74,8 +74,9 @@ async def _insert_issue(connection, record_id, candidate_id, actor_id):
     )
 
 
-async def _approve(connection, record_id, candidate_id, actor_id):
-    approved_id = await connection.scalar(
+async def _insert_approved_revision(connection, record_id, candidate_id, actor_id):
+    """Insert approval evidence; its row trigger must acquire the record lock."""
+    return await connection.scalar(
         text(
             """
             INSERT INTO phenopacket_revisions
@@ -90,6 +91,10 @@ async def _approve(connection, record_id, candidate_id, actor_id):
         ),
         {"record_id": record_id, "candidate_id": candidate_id, "actor_id": actor_id},
     )
+
+
+async def _activate_approval(connection, record_id, approved_id):
+    """Project an already-inserted approval after lock causality is observed."""
     await connection.execute(
         text(
             """
@@ -100,7 +105,6 @@ async def _approve(connection, record_id, candidate_id, actor_id):
         ),
         {"approved_id": approved_id, "record_id": record_id},
     )
-    return approved_id
 
 
 async def _reopen(connection, issue_id, actor_id):
@@ -136,6 +140,23 @@ async def _wait_until_blocked(observer, winner_pid: int, loser_pid: int) -> None
     raise AssertionError(
         f"backend {loser_pid} never blocked behind expected winner {winner_pid}"
     )
+
+
+async def _assert_record_has_for_update_lock(observer, record_id) -> None:
+    """Distinguish the trigger's FOR UPDATE from the revision FK's KEY SHARE."""
+    savepoint = await observer.begin_nested()
+    try:
+        with pytest.raises(DBAPIError, match="could not obtain lock"):
+            await observer.execute(
+                text(
+                    """SELECT id FROM phenopackets WHERE id=:record_id
+                    FOR NO KEY UPDATE NOWAIT"""
+                ),
+                {"record_id": record_id},
+            )
+    finally:
+        if savepoint.is_active:
+            await savepoint.rollback()
 
 
 async def _race(
@@ -195,7 +216,7 @@ async def _race(
 
             async def approval_statement():
                 loser_started.set()
-                return await _approve(
+                return await _insert_approved_revision(
                     approval_conn, record_id, candidate_id, reviewer.id
                 )
 
@@ -213,18 +234,25 @@ async def _race(
                     _wait_until_blocked(observer, issue_pid, approval_pid), timeout=5
                 )
                 await issue_tx.commit()
-                with pytest.raises(DBAPIError, match="unresolved_review_issues"):
+                with pytest.raises(
+                    DBAPIError, match="unresolved_review_issues"
+                ) as exc_info:
                     await asyncio.wait_for(loser_task, timeout=5)
+                assert "INSERT INTO phenopacket_revisions" in str(
+                    exc_info.value.statement
+                )
                 await approval_tx.rollback()
             else:
-                approved_id = await _approve(
+                approved_id = await _insert_approved_revision(
                     approval_conn, record_id, candidate_id, reviewer.id
                 )
+                await _assert_record_has_for_update_lock(observer, record_id)
                 loser_task = asyncio.create_task(issue_statement())
                 await asyncio.wait_for(loser_started.wait(), timeout=5)
                 await asyncio.wait_for(
                     _wait_until_blocked(observer, approval_pid, issue_pid), timeout=5
                 )
+                await _activate_approval(approval_conn, record_id, approved_id)
                 await approval_tx.commit()
                 with pytest.raises(DBAPIError, match="review_closed"):
                     await asyncio.wait_for(loser_task, timeout=5)

--- a/backend/tests/migration/test_independent_review_sql_races.py
+++ b/backend/tests/migration/test_independent_review_sql_races.py
@@ -1,0 +1,304 @@
+"""Two-connection PostgreSQL races for issue gating and approval."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import DBAPIError
+
+from app.comments.models import Comment, CommentResolutionEvent
+from app.comments.service import CommentsService
+from app.database import engine
+from app.phenopackets.models import Phenopacket, PhenopacketRevision
+
+
+async def _seed_candidate(db_session, owner, submitter):
+    packet = Phenopacket(
+        phenopacket_id="sql-race",
+        phenopacket={"id": "sql-race"},
+        state="draft",
+        revision=0,
+        draft_owner_id=owner.id,
+        created_by_id=owner.id,
+    )
+    db_session.add(packet)
+    await db_session.flush()
+    root = PhenopacketRevision(
+        record_id=packet.id,
+        revision_number=1,
+        state="draft",
+        content_jsonb=packet.phenopacket,
+        change_reason="create",
+        actor_id=owner.id,
+        from_state=None,
+        to_state="draft",
+        event_type="created",
+    )
+    db_session.add(root)
+    await db_session.flush()
+    candidate = PhenopacketRevision(
+        record_id=packet.id,
+        parent_revision_id=root.id,
+        revision_number=2,
+        state="in_review",
+        content_jsonb=packet.phenopacket,
+        change_reason="submit",
+        actor_id=submitter.id,
+        from_state="draft",
+        to_state="in_review",
+        event_type="state_transition",
+    )
+    db_session.add(candidate)
+    await db_session.flush()
+    packet.state = "in_review"
+    packet.revision = 2
+    packet.editing_revision_id = candidate.id
+    await db_session.commit()
+    return packet.id, candidate.id
+
+
+async def _insert_issue(connection, record_id, candidate_id, actor_id):
+    return await connection.scalar(
+        text(
+            """
+            INSERT INTO comments
+                (record_type, record_id, author_id, body_markdown,
+                 review_revision_id)
+            VALUES ('phenopacket', :record_id, :actor_id, 'race issue', :candidate_id)
+            RETURNING id
+            """
+        ),
+        {"record_id": record_id, "candidate_id": candidate_id, "actor_id": actor_id},
+    )
+
+
+async def _approve(connection, record_id, candidate_id, actor_id):
+    approved_id = await connection.scalar(
+        text(
+            """
+            INSERT INTO phenopacket_revisions
+                (record_id, parent_revision_id, revision_number, state,
+                 content_jsonb, change_reason, actor_id, actor_role,
+                 from_state, to_state, event_type)
+            VALUES (:record_id, :candidate_id, 3, 'approved',
+                    '{"id":"sql-race"}'::jsonb, 'approve', :actor_id,
+                    'curator', 'in_review', 'approved', 'state_transition')
+            RETURNING id
+            """
+        ),
+        {"record_id": record_id, "candidate_id": candidate_id, "actor_id": actor_id},
+    )
+    await connection.execute(
+        text(
+            """
+            UPDATE phenopackets
+            SET state='approved', revision=3, editing_revision_id=:approved_id
+            WHERE id=:record_id
+            """
+        ),
+        {"approved_id": approved_id, "record_id": record_id},
+    )
+    return approved_id
+
+
+async def _reopen(connection, issue_id, actor_id):
+    await connection.execute(
+        text(
+            """
+            INSERT INTO comment_resolution_events
+                (comment_id, action, disposition, rationale, actor_id, actor_role)
+            VALUES (:issue_id, 'reopened', NULL, 'race reopen', :actor_id, 'curator')
+            """
+        ),
+        {"issue_id": issue_id, "actor_id": actor_id},
+    )
+    await connection.execute(
+        text(
+            """
+            UPDATE comments SET resolved_at=NULL, resolved_by_id=NULL
+            WHERE id=:issue_id
+            """
+        ),
+        {"issue_id": issue_id},
+    )
+
+
+async def _wait_until_blocked(observer, winner_pid: int, loser_pid: int) -> None:
+    """Poll lock metadata through yielding SQL calls; no time-based sleeps."""
+    for _ in range(200):
+        blockers = await observer.scalar(
+            text("SELECT pg_blocking_pids(:loser_pid)"), {"loser_pid": loser_pid}
+        )
+        if winner_pid in blockers:
+            return
+    raise AssertionError(
+        f"backend {loser_pid} never blocked behind expected winner {winner_pid}"
+    )
+
+
+async def _race(
+    db_session,
+    owner,
+    reviewer,
+    *,
+    issue_operation: str,
+    issue_wins: bool,
+) -> None:
+    record_id, candidate_id = await _seed_candidate(db_session, owner, owner)
+    issue_id = None
+    if issue_operation == "reopen":
+        service = CommentsService(db_session)
+        issue = await service.create(
+            record_type="phenopacket",
+            record_id=record_id,
+            body_markdown="resolved seed",
+            mention_user_ids=[],
+            actor=reviewer,
+            record_revision=2,
+            review_revision_id=candidate_id,
+        )
+        issue = await service.resolve(
+            comment_id=issue.id,
+            actor=reviewer,
+            issue_input={
+                "record_revision": 2,
+                "disposition": "addressed",
+                "rationale": "seed resolution",
+            },
+        )
+        issue_id = issue.id
+        await db_session.commit()
+
+    async with (
+        engine.connect() as issue_conn,
+        engine.connect() as approval_conn,
+        engine.connect() as observer,
+    ):
+        issue_tx = await issue_conn.begin()
+        approval_tx = await approval_conn.begin()
+        issue_pid = int(await issue_conn.scalar(text("SELECT pg_backend_pid()")))
+        approval_pid = int(await approval_conn.scalar(text("SELECT pg_backend_pid()")))
+        loser_started = asyncio.Event()
+        try:
+
+            async def issue_statement():
+                loser_started.set()
+                if issue_operation == "insert":
+                    return await _insert_issue(
+                        issue_conn, record_id, candidate_id, reviewer.id
+                    )
+                assert issue_id is not None
+                await _reopen(issue_conn, issue_id, reviewer.id)
+                return issue_id
+
+            async def approval_statement():
+                loser_started.set()
+                return await _approve(
+                    approval_conn, record_id, candidate_id, reviewer.id
+                )
+
+            if issue_wins:
+                if issue_operation == "insert":
+                    issue_id = await _insert_issue(
+                        issue_conn, record_id, candidate_id, reviewer.id
+                    )
+                else:
+                    assert issue_id is not None
+                    await _reopen(issue_conn, issue_id, reviewer.id)
+                loser_task = asyncio.create_task(approval_statement())
+                await asyncio.wait_for(loser_started.wait(), timeout=5)
+                await asyncio.wait_for(
+                    _wait_until_blocked(observer, issue_pid, approval_pid), timeout=5
+                )
+                await issue_tx.commit()
+                with pytest.raises(DBAPIError, match="unresolved_review_issues"):
+                    await asyncio.wait_for(loser_task, timeout=5)
+                await approval_tx.rollback()
+            else:
+                approved_id = await _approve(
+                    approval_conn, record_id, candidate_id, reviewer.id
+                )
+                loser_task = asyncio.create_task(issue_statement())
+                await asyncio.wait_for(loser_started.wait(), timeout=5)
+                await asyncio.wait_for(
+                    _wait_until_blocked(observer, approval_pid, issue_pid), timeout=5
+                )
+                await approval_tx.commit()
+                with pytest.raises(DBAPIError, match="review_closed"):
+                    await asyncio.wait_for(loser_task, timeout=5)
+                await issue_tx.rollback()
+                assert approved_id is not None
+        finally:
+            if issue_tx.is_active:
+                await issue_tx.rollback()
+            if approval_tx.is_active:
+                await approval_tx.rollback()
+
+    db_session.expire_all()
+    packet = await db_session.get(Phenopacket, record_id)
+    assert packet is not None
+    issue_count = int(
+        await db_session.scalar(
+            select(func.count(Comment.id)).where(Comment.record_id == record_id)
+        )
+    )
+    if issue_wins:
+        assert packet.editing_revision_id == candidate_id
+        assert issue_count == 1
+        assert (
+            await db_session.scalar(
+                select(Comment.resolved_at).where(Comment.record_id == record_id)
+            )
+            is None
+        )
+    else:
+        assert packet.editing_revision_id != candidate_id
+        if issue_operation == "insert":
+            assert issue_count == 0
+        else:
+            assert issue_count == 1
+            assert (
+                await db_session.scalar(
+                    select(Comment.resolved_at).where(Comment.id == issue_id)
+                )
+                is not None
+            )
+            reopen_events = int(
+                await db_session.scalar(
+                    select(func.count(CommentResolutionEvent.id)).where(
+                        CommentResolutionEvent.comment_id == issue_id,
+                        CommentResolutionEvent.action == "reopened",
+                    )
+                )
+            )
+            assert reopen_events == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("issue_operation", "issue_wins"),
+    [
+        ("insert", True),
+        ("insert", False),
+        ("reopen", True),
+        ("reopen", False),
+    ],
+    ids=[
+        "issue-insert-wins-approval-loses",
+        "approval-wins-issue-insert-loses",
+        "issue-reopen-wins-approval-loses",
+        "approval-wins-issue-reopen-loses",
+    ],
+)
+async def test_review_issue_approval_races_commit_one_consistent_winner(
+    db_session, curator_user, another_curator, issue_operation, issue_wins
+):
+    await _race(
+        db_session,
+        curator_user,
+        another_curator,
+        issue_operation=issue_operation,
+        issue_wins=issue_wins,
+    )

--- a/backend/tests/test_alembic_env_autogenerate.py
+++ b/backend/tests/test_alembic_env_autogenerate.py
@@ -68,6 +68,27 @@ _RAW_SQL_TABLES = {
 }
 
 
+def _env_imported_model_names() -> set[str]:
+    """Return ORM class names explicitly registered by Alembic's env module."""
+    env_py = Path(__file__).resolve().parents[1] / "alembic" / "env.py"
+    assert env_py.exists(), f"alembic env.py not found at {env_py}"
+
+    tree = ast.parse(env_py.read_text(encoding="utf-8"))
+    return {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module
+        and node.module.startswith("app.")
+        for alias in node.names
+    }
+
+
+def test_env_py_catches_unregistered_resolution_event_metadata():
+    """Autogenerate must load the resolution-event table before comparison."""
+    assert "CommentResolutionEvent" in _env_imported_model_names()
+
+
 def test_alembic_autogenerate_does_not_drop_tables():
     """No ``remove_table`` ops allowed in ``compare_metadata`` output.
 
@@ -128,21 +149,7 @@ def test_env_py_imports_all_orm_models():
     appears there. That way, adding a new ORM model without also updating
     env.py fails the test loudly.
     """
-    env_py = (
-        Path(__file__).resolve().parents[1] / "alembic" / "env.py"
-    )  # backend/alembic/env.py
-    assert env_py.exists(), f"alembic env.py not found at {env_py}"
-
-    tree = ast.parse(env_py.read_text(encoding="utf-8"))
-    imported_names: set[str] = set()
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.ImportFrom)
-            and node.module
-            and node.module.startswith("app.")
-        ):
-            for alias in node.names:
-                imported_names.add(alias.name)
+    imported_names = _env_imported_model_names()
 
     # Discover every ORM model class currently known to Base.metadata and
     # map table-name back to its Python class name. Any class in this set

--- a/backend/tests/test_api_transitions.py
+++ b/backend/tests/test_api_transitions.py
@@ -68,23 +68,46 @@ async def test_transition_endpoint_end_to_end(
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["phenopacket"]["state"] == "in_review"
+    candidate = data["revision"]
+    assert candidate["actor_role"] == "curator"
+    assert candidate["actor_role_at_decision_recorded"] is True
+    assert candidate["decision_metadata"] is None
+    assert candidate["content_sha256"].startswith("sha256:")
+    assert candidate["ledger_version"] == 2
     rev = data["phenopacket"]["revision"]
 
     # Step 2: admin approves in_review → approved
     resp = await async_client.post(
         _transitions_url(pid),
-        json={"to_state": "approved", "reason": "looks good", "revision": rev},
+        json={
+            "to_state": "approved",
+            "reason": "looks good",
+            "revision": rev,
+            "candidate_revision_id": candidate["id"],
+            "candidate_content_sha256": candidate["content_sha256"],
+            "attestation": {
+                "independent_review": True,
+                "no_unmanaged_conflict": True,
+            },
+        },
         headers=admin_headers,
     )
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["phenopacket"]["state"] == "approved"
+    approved = data["revision"]
     rev = data["phenopacket"]["revision"]
 
     # Step 3: admin publishes approved → published
     resp = await async_client.post(
         _transitions_url(pid),
-        json={"to_state": "published", "reason": "go live", "revision": rev},
+        json={
+            "to_state": "published",
+            "reason": "go live",
+            "revision": rev,
+            "approved_revision_id": approved["id"],
+            "approved_content_sha256": approved["content_sha256"],
+        },
         headers=admin_headers,
     )
     assert resp.status_code == 200, resp.text
@@ -96,10 +119,10 @@ async def test_transition_endpoint_end_to_end(
 
 
 @pytest.mark.asyncio
-async def test_transition_forbidden_role_returns_403(
+async def test_transition_self_review_returns_specific_403(
     async_client, draft_record, curator_user, curator_headers
 ):
-    """Curator trying an admin-only transition gets 403 with forbidden_role code."""
+    """A submitting curator receives the specific independence blocker code."""
     pid = draft_record.phenopacket_id
 
     # First get to in_review
@@ -109,6 +132,7 @@ async def test_transition_forbidden_role_returns_403(
         headers=curator_headers,
     )
     assert resp.status_code == 200
+    candidate = resp.json()["revision"]
 
     # Now curator tries to approve (admin-only)
     resp = await async_client.post(
@@ -117,13 +141,18 @@ async def test_transition_forbidden_role_returns_403(
             "to_state": "approved",
             "reason": "self-approve",
             "revision": resp.json()["phenopacket"]["revision"],
+            "candidate_revision_id": candidate["id"],
+            "candidate_content_sha256": candidate["content_sha256"],
+            "attestation": {
+                "independent_review": True,
+                "no_unmanaged_conflict": True,
+            },
         },
         headers=curator_headers,
     )
     assert resp.status_code == 403
     body = resp.json()
-    # The error envelope wraps detail: body["detail"]["code"]
-    assert body["detail"]["code"] == "forbidden_role"
+    assert body["detail"]["code"] == "self_review_forbidden"
 
 
 @pytest.mark.asyncio
@@ -135,7 +164,13 @@ async def test_invalid_transition_returns_409(
 
     resp = await async_client.post(
         _transitions_url(pid),
-        json={"to_state": "published", "reason": "skip steps", "revision": 1},
+        json={
+            "to_state": "published",
+            "reason": "skip steps",
+            "revision": 1,
+            "approved_revision_id": 999,
+            "approved_content_sha256": "sha256:" + "0" * 64,
+        },
         headers=admin_headers,
     )
     assert resp.status_code == 409
@@ -158,6 +193,111 @@ async def test_transition_revision_mismatch_returns_409(
     assert resp.status_code == 409
     body = resp.json()
     assert body["detail"]["code"] == "revision_mismatch"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"to_state": "approved"},
+        {
+            "to_state": "approved",
+            "candidate_revision_id": 1,
+            "candidate_content_sha256": "sha256:" + "1" * 64,
+        },
+        {
+            "to_state": "approved",
+            "candidate_revision_id": 1,
+            "candidate_content_sha256": "sha256:" + "1" * 64,
+            "attestation": {
+                "independent_review": False,
+                "no_unmanaged_conflict": True,
+            },
+        },
+        {
+            "to_state": "approved",
+            "candidate_revision_id": 1,
+            "candidate_content_sha256": "sha256:" + "1" * 64,
+            "attestation": {
+                "independent_review": True,
+                "no_unmanaged_conflict": False,
+            },
+        },
+        {
+            "to_state": "approved",
+            "candidate_revision_id": 1,
+            "candidate_content_sha256": "sha256:" + "1" * 64,
+            "approved_revision_id": 2,
+            "approved_content_sha256": "sha256:" + "2" * 64,
+            "attestation": {
+                "independent_review": True,
+                "no_unmanaged_conflict": True,
+            },
+        },
+        {"to_state": "published"},
+        {
+            "to_state": "published",
+            "approved_revision_id": 2,
+            "approved_content_sha256": "sha256:" + "2" * 64,
+            "candidate_revision_id": 1,
+        },
+        {
+            "to_state": "in_review",
+            "candidate_revision_id": 1,
+            "candidate_content_sha256": "sha256:" + "1" * 64,
+        },
+    ],
+)
+async def test_transition_conditional_fields_are_discriminated_with_422(
+    async_client,
+    draft_record,
+    admin_headers,
+    payload,
+):
+    """Missing, false, or irrelevant exact-review fields are malformed input."""
+    response = await async_client.post(
+        _transitions_url(draft_record.phenopacket_id),
+        json={"reason": "invalid conditional body", "revision": 1, **payload},
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_stale_well_formed_candidate_digest_returns_stable_409(
+    async_client,
+    draft_record,
+    curator_headers,
+    admin_headers,
+):
+    """A syntactically valid but stale exact candidate is a workflow conflict."""
+    submitted = await async_client.post(
+        _transitions_url(draft_record.phenopacket_id),
+        json={"to_state": "in_review", "reason": "submit", "revision": 1},
+        headers=curator_headers,
+    )
+    assert submitted.status_code == 200, submitted.text
+    candidate = submitted.json()["revision"]
+
+    response = await async_client.post(
+        _transitions_url(draft_record.phenopacket_id),
+        json={
+            "to_state": "approved",
+            "reason": "stale exact candidate",
+            "revision": submitted.json()["phenopacket"]["revision"],
+            "candidate_revision_id": candidate["id"],
+            "candidate_content_sha256": "sha256:" + "0" * 64,
+            "attestation": {
+                "independent_review": True,
+                "no_unmanaged_conflict": True,
+            },
+        },
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "review_revision_mismatch"
 
 
 # ---------------------------------------------------------------------------
@@ -253,3 +393,69 @@ async def test_revision_detail_includes_content(
     assert body["id"] == revision_id
     assert body["content_jsonb"] is not None
     assert isinstance(body["content_jsonb"], dict)
+
+
+@pytest.mark.asyncio
+async def test_revision_detail_labels_legacy_role_snapshot_as_unrecorded(
+    async_client,
+    published_record,
+    admin_headers,
+):
+    """A current actor relationship never masquerades as historic role evidence."""
+    legacy_revision_id = published_record.head_published_revision_id
+    assert legacy_revision_id is not None
+
+    response = await async_client.get(
+        _revision_detail_url(published_record.phenopacket_id, legacy_revision_id),
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["actor_username"] is not None
+    assert body["actor_role"] is None
+    assert body["actor_role_at_decision_recorded"] is False
+    assert body["decision_metadata"] is None
+    assert body["content_sha256"] is None
+    assert body["ledger_version"] is None
+
+
+@pytest.mark.asyncio
+async def test_independence_policy_error_preserves_specific_403_code(
+    async_client,
+    db_session,
+    draft_record,
+    admin_user,
+    admin_headers,
+):
+    """An independence denial is not collapsed into generic forbidden_role."""
+    draft_record.draft_owner_id = admin_user.id
+    draft_record.created_by_id = admin_user.id
+    await db_session.commit()
+
+    submitted = await async_client.post(
+        _transitions_url(draft_record.phenopacket_id),
+        json={"to_state": "in_review", "reason": "self submit", "revision": 1},
+        headers=admin_headers,
+    )
+    assert submitted.status_code == 200, submitted.text
+    candidate = submitted.json()["revision"]
+
+    response = await async_client.post(
+        _transitions_url(draft_record.phenopacket_id),
+        json={
+            "to_state": "approved",
+            "reason": "self approve",
+            "revision": submitted.json()["phenopacket"]["revision"],
+            "candidate_revision_id": candidate["id"],
+            "candidate_content_sha256": candidate["content_sha256"],
+            "attestation": {
+                "independent_review": True,
+                "no_unmanaged_conflict": True,
+            },
+        },
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "self_review_forbidden"

--- a/backend/tests/test_api_transitions.py
+++ b/backend/tests/test_api_transitions.py
@@ -265,6 +265,87 @@ async def test_transition_conditional_fields_are_discriminated_with_422(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("base_payload", "irrelevant_field"),
+    [
+        (
+            {
+                "to_state": "approved",
+                "candidate_revision_id": 1,
+                "candidate_content_sha256": "sha256:" + "1" * 64,
+                "attestation": {
+                    "independent_review": True,
+                    "no_unmanaged_conflict": True,
+                },
+            },
+            "approved_revision_id",
+        ),
+        (
+            {
+                "to_state": "approved",
+                "candidate_revision_id": 1,
+                "candidate_content_sha256": "sha256:" + "1" * 64,
+                "attestation": {
+                    "independent_review": True,
+                    "no_unmanaged_conflict": True,
+                },
+            },
+            "approved_content_sha256",
+        ),
+        (
+            {
+                "to_state": "published",
+                "approved_revision_id": 2,
+                "approved_content_sha256": "sha256:" + "2" * 64,
+            },
+            "candidate_revision_id",
+        ),
+        (
+            {
+                "to_state": "published",
+                "approved_revision_id": 2,
+                "approved_content_sha256": "sha256:" + "2" * 64,
+            },
+            "candidate_content_sha256",
+        ),
+        (
+            {
+                "to_state": "published",
+                "approved_revision_id": 2,
+                "approved_content_sha256": "sha256:" + "2" * 64,
+            },
+            "attestation",
+        ),
+        ({"to_state": "in_review"}, "candidate_revision_id"),
+        ({"to_state": "in_review"}, "candidate_content_sha256"),
+        ({"to_state": "in_review"}, "approved_revision_id"),
+        ({"to_state": "in_review"}, "approved_content_sha256"),
+        ({"to_state": "in_review"}, "attestation"),
+    ],
+)
+async def test_transition_explicit_null_irrelevant_fields_return_422(
+    async_client,
+    draft_record,
+    admin_headers,
+    base_payload,
+    irrelevant_field,
+):
+    """Explicit null cannot bypass the transition request discriminant."""
+    response = await async_client.post(
+        _transitions_url(draft_record.phenopacket_id),
+        json={
+            "reason": "reject irrelevant null",
+            "revision": 1,
+            **base_payload,
+            irrelevant_field: None,
+        },
+        headers=admin_headers,
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_stale_well_formed_candidate_digest_returns_stable_409(
     async_client,
     draft_record,

--- a/backend/tests/test_blocking_review_issues.py
+++ b/backend/tests/test_blocking_review_issues.py
@@ -1,0 +1,507 @@
+"""Blocking review-issue service and API behavior."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import event, select
+
+from app.comments.models import CommentResolutionEvent
+from app.comments.schemas import (
+    CommentCreate,
+    ReviewIssueReopenRequest,
+    ReviewIssueResolveRequest,
+)
+from app.comments.service import CommentsService
+from app.phenopackets.models import Phenopacket, PhenopacketRevision
+from app.phenopackets.review.policy import ReviewPolicyError
+
+
+async def _seed_review_cycle(db_session, *, owner, submitter):
+    """Persist a never-published active review candidate."""
+    record = Phenopacket(
+        phenopacket_id=f"blocking-review-{owner.id}-{submitter.id}",
+        phenopacket={"id": "blocking-review"},
+        state="draft",
+        revision=0,
+        draft_owner_id=owner.id,
+        created_by_id=owner.id,
+    )
+    db_session.add(record)
+    await db_session.flush()
+    root = PhenopacketRevision(
+        record_id=record.id,
+        revision_number=1,
+        state="draft",
+        content_jsonb=record.phenopacket,
+        change_reason="create",
+        actor_id=owner.id,
+        from_state=None,
+        to_state="draft",
+        event_type="created",
+    )
+    db_session.add(root)
+    await db_session.flush()
+    candidate = PhenopacketRevision(
+        record_id=record.id,
+        parent_revision_id=root.id,
+        revision_number=2,
+        state="in_review",
+        content_jsonb=record.phenopacket,
+        change_reason="submit",
+        actor_id=submitter.id,
+        from_state="draft",
+        to_state="in_review",
+        event_type="state_transition",
+    )
+    db_session.add(candidate)
+    await db_session.flush()
+    record.state = "in_review"
+    record.revision = 2
+    record.editing_revision_id = candidate.id
+    await db_session.flush()
+    return record, candidate
+
+
+async def _headers_for(client, username: str, password: str) -> dict[str, str]:
+    response = await client.post(
+        "/api/v2/auth/login",
+        json={"username": username, "password": password},
+    )
+    assert response.status_code == 200, response.json()
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+async def _post_issue(client, headers, record, candidate):
+    return await client.post(
+        "/api/v2/comments",
+        headers=headers,
+        json={
+            "record_type": "phenopacket",
+            "record_id": str(record.id),
+            "body_markdown": "Blocking review concern",
+            "mention_user_ids": [],
+            "record_revision": record.revision,
+            "review_revision_id": candidate.id,
+        },
+    )
+
+
+def test_review_issue_request_schemas_are_strict_trimmed_and_literal() -> None:
+    """Conditional issue inputs reject missing evidence and normalize rationale."""
+    resolved = ReviewIssueResolveRequest(
+        record_revision=4,
+        disposition="retracted",
+        rationale="  duplicate concern  ",
+    )
+    reopened = ReviewIssueReopenRequest(
+        record_revision=5,
+        rationale="  regression returned  ",
+    )
+
+    assert resolved.rationale == "duplicate concern"
+    assert reopened.rationale == "regression returned"
+    with pytest.raises(ValidationError):
+        ReviewIssueResolveRequest(
+            record_revision=4,
+            disposition="ignored",
+            rationale="not allowed",
+        )
+    with pytest.raises(ValidationError):
+        ReviewIssueResolveRequest(
+            record_revision=4,
+            disposition="addressed",
+            rationale="   ",
+        )
+    with pytest.raises(ValidationError):
+        ReviewIssueReopenRequest(record_revision=-1, rationale="valid")
+
+
+def test_comment_create_accepts_paired_review_issue_identity() -> None:
+    """Blocking create can carry exact record and candidate revisions."""
+    request = CommentCreate(
+        record_type="phenopacket",
+        record_id="79e6dd86-e399-48dc-bb20-797231582df7",
+        body_markdown="This must be addressed.",
+        record_revision=8,
+        review_revision_id=11,
+    )
+
+    assert request.record_revision == 8
+    assert request.review_revision_id == 11
+
+
+@pytest.mark.asyncio
+async def test_blocking_issue_lifecycle_appends_events_and_keeps_identity(
+    db_session, curator_user, another_curator
+):
+    """Resolve, reopen, and retract append evidence before updating projection."""
+    record, candidate = await _seed_review_cycle(
+        db_session, owner=curator_user, submitter=curator_user
+    )
+    await db_session.commit()
+    service = CommentsService(db_session)
+    issue = await service.create(
+        record_type="phenopacket",
+        record_id=record.id,
+        body_markdown="Address this concern.",
+        mention_user_ids=[],
+        actor=another_curator,
+        record_revision=record.revision,
+        review_revision_id=candidate.id,
+    )
+
+    resolved = await service.resolve(
+        comment_id=issue.id,
+        actor=another_curator,
+        issue_input={
+            "record_revision": record.revision,
+            "disposition": "addressed",
+            "rationale": "  corrected in source  ",
+        },
+    )
+    assert resolved.resolved_at is not None
+    assert resolved.review_revision_id == candidate.id
+
+    reopened = await service.unresolve(
+        comment_id=issue.id,
+        actor=another_curator,
+        issue_input={
+            "record_revision": record.revision,
+            "rationale": "  concern returned  ",
+        },
+    )
+    assert reopened.resolved_at is None
+    assert reopened.review_revision_id == candidate.id
+
+    retracted = await service.resolve(
+        comment_id=issue.id,
+        actor=another_curator,
+        issue_input={
+            "record_revision": record.revision,
+            "disposition": "retracted",
+            "rationale": "  report was mistaken  ",
+        },
+    )
+    assert retracted.resolved_at is not None
+    assert retracted.deleted_at is None
+
+    events = list(
+        (
+            await db_session.execute(
+                select(CommentResolutionEvent)
+                .where(CommentResolutionEvent.comment_id == issue.id)
+                .order_by(CommentResolutionEvent.id)
+            )
+        ).scalars()
+    )
+    assert [(item.action, item.disposition, item.rationale) for item in events] == [
+        ("resolved", "addressed", "corrected in source"),
+        ("reopened", None, "concern returned"),
+        ("resolved", "retracted", "report was mistaken"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_blocking_issue_rejects_stale_unrelated_and_partial_identity(
+    db_session, curator_user, another_curator
+):
+    """Client-nominated revisions never escape exact locked-record validation."""
+    record, candidate = await _seed_review_cycle(
+        db_session, owner=curator_user, submitter=curator_user
+    )
+    other, other_candidate = await _seed_review_cycle(
+        db_session, owner=another_curator, submitter=another_curator
+    )
+    service = CommentsService(db_session)
+
+    with pytest.raises(CommentsService.RevisionMismatch):
+        await service.create(
+            record_type="phenopacket",
+            record_id=record.id,
+            body_markdown="stale",
+            mention_user_ids=[],
+            actor=another_curator,
+            record_revision=record.revision - 1,
+            review_revision_id=candidate.id,
+        )
+    with pytest.raises(CommentsService.ReviewRevisionMismatch):
+        await service.create(
+            record_type="phenopacket",
+            record_id=record.id,
+            body_markdown="wrong record",
+            mention_user_ids=[],
+            actor=another_curator,
+            record_revision=record.revision,
+            review_revision_id=other_candidate.id,
+        )
+    with pytest.raises(CommentsService.IssueInputInvalid):
+        await service.create(
+            record_type="phenopacket",
+            record_id=record.id,
+            body_markdown="partial",
+            mention_user_ids=[],
+            actor=another_curator,
+            review_revision_id=candidate.id,
+        )
+    assert other.id != record.id
+
+
+@pytest.mark.asyncio
+async def test_blocking_issue_owner_cannot_resolve_reopen_or_delete(
+    db_session, curator_user, another_curator, admin_user
+):
+    """Neither authorship nor admin status bypasses issue policy or deletion ban."""
+    record, candidate = await _seed_review_cycle(
+        db_session, owner=admin_user, submitter=curator_user
+    )
+    service = CommentsService(db_session)
+    issue = await service.create(
+        record_type="phenopacket",
+        record_id=record.id,
+        body_markdown="independent issue",
+        mention_user_ids=[],
+        actor=another_curator,
+        record_revision=record.revision,
+        review_revision_id=candidate.id,
+    )
+
+    with pytest.raises(ReviewPolicyError) as exc_info:
+        await service.resolve(
+            comment_id=issue.id,
+            actor=admin_user,
+            issue_input={
+                "record_revision": record.revision,
+                "disposition": "addressed",
+                "rationale": "owner attempt",
+            },
+        )
+    assert exc_info.value.code == "self_review_forbidden"
+
+    with pytest.raises(CommentsService.ReviewIssueDeleteForbidden):
+        await service.soft_delete(comment_id=issue.id, actor=another_curator)
+    with pytest.raises(CommentsService.ReviewIssueDeleteForbidden):
+        await service.soft_delete(comment_id=issue.id, actor=admin_user)
+
+
+@pytest.mark.asyncio
+async def test_comment_mutation_lock_order_includes_soft_deleted_owner(
+    db_session, published_record, curator_user
+):
+    """Identity probe precedes record lock and comment lock for every mutation."""
+    service = CommentsService(db_session)
+    comment = await service.create(
+        record_type="phenopacket",
+        record_id=published_record.id,
+        body_markdown="ordinary",
+        mention_user_ids=[],
+        actor=curator_user,
+    )
+    published_record.deleted_at = published_record.created_at
+    await db_session.flush()
+
+    statements: list[str] = []
+
+    def capture_statement(_conn, _cursor, statement, _params, _context, _many):
+        normalized = " ".join(statement.lower().split())
+        if " from comments " in normalized or " from phenopackets " in normalized:
+            statements.append(normalized)
+
+    bind = db_session.get_bind()
+    event.listen(bind, "before_cursor_execute", capture_statement)
+    try:
+        await service.resolve(comment_id=comment.id, actor=curator_user)
+    finally:
+        event.remove(bind, "before_cursor_execute", capture_statement)
+
+    lock_queries = [
+        statement
+        for statement in statements
+        if "where comments.id" in statement or "where phenopackets.id" in statement
+    ]
+    assert "from comments" in lock_queries[0]
+    assert "for update" not in lock_queries[0]
+    assert "from phenopackets" in lock_queries[1]
+    assert "for update" in lock_queries[1]
+    assert "from comments" in lock_queries[2]
+    assert "for update" in lock_queries[2]
+
+
+@pytest.mark.asyncio
+async def test_blocking_issue_routes_require_conditional_evidence_and_independence(
+    async_client,
+    db_session,
+    curator_user,
+    curator_headers,
+    another_curator,
+    admin_headers,
+):
+    """API maps issue validation, policy denial, and deletion uniformly."""
+    reviewer_headers = await _headers_for(
+        async_client, another_curator.username, "CuratorPass123!"
+    )
+    record, candidate = await _seed_review_cycle(
+        db_session, owner=curator_user, submitter=curator_user
+    )
+    record_revision = record.revision
+    created = await _post_issue(async_client, reviewer_headers, record, candidate)
+    assert created.status_code == 201, created.json()
+    issue_id = created.json()["id"]
+
+    missing = await async_client.post(
+        f"/api/v2/comments/{issue_id}/resolve",
+        headers=reviewer_headers,
+    )
+    assert missing.status_code == 422
+    assert missing.json()["detail"]["code"] == "review_issue_input_invalid"
+
+    owner_resolve = await async_client.post(
+        f"/api/v2/comments/{issue_id}/resolve",
+        headers=curator_headers,
+        json={
+            "record_revision": record_revision,
+            "disposition": "addressed",
+            "rationale": "owner cannot do this",
+        },
+    )
+    assert owner_resolve.status_code == 403
+    assert owner_resolve.json()["detail"]["code"] == "self_review_forbidden"
+
+    for headers in (curator_headers, reviewer_headers, admin_headers):
+        deleted = await async_client.delete(
+            f"/api/v2/comments/{issue_id}", headers=headers
+        )
+        assert deleted.status_code == 409
+        assert deleted.json()["detail"]["code"] == "review_issue_delete_forbidden"
+
+    resolved = await async_client.post(
+        f"/api/v2/comments/{issue_id}/resolve",
+        headers=reviewer_headers,
+        json={
+            "record_revision": record_revision,
+            "disposition": "retracted",
+            "rationale": "concern withdrawn",
+        },
+    )
+    assert resolved.status_code == 200, resolved.json()
+    assert resolved.json()["resolved_at"] is not None
+    assert resolved.json()["deleted_at"] is None
+
+    reopened = await async_client.post(
+        f"/api/v2/comments/{issue_id}/unresolve",
+        headers=reviewer_headers,
+        json={
+            "record_revision": record_revision,
+            "rationale": "new evidence",
+        },
+    )
+    assert reopened.status_code == 200, reopened.json()
+    assert reopened.json()["resolved_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_blocking_issue_create_route_rejects_partial_stale_and_closed_inputs(
+    async_client, db_session, curator_user, another_curator
+):
+    """Create conflict codes distinguish malformed, stale, and closed review input."""
+    reviewer_headers = await _headers_for(
+        async_client, another_curator.username, "CuratorPass123!"
+    )
+    record, candidate = await _seed_review_cycle(
+        db_session, owner=curator_user, submitter=curator_user
+    )
+    record_id = record.id
+    candidate_id = candidate.id
+    record_revision = record.revision
+    curator_id = curator_user.id
+    await db_session.commit()
+    payload = {
+        "record_type": "phenopacket",
+        "record_id": str(record_id),
+        "body_markdown": "Blocking review concern",
+        "mention_user_ids": [],
+        "record_revision": record_revision,
+        "review_revision_id": candidate_id,
+    }
+
+    partial = await async_client.post(
+        "/api/v2/comments",
+        headers=reviewer_headers,
+        json={key: value for key, value in payload.items() if key != "record_revision"},
+    )
+    assert partial.status_code == 422
+    assert partial.json()["detail"]["code"] == "review_issue_input_invalid"
+
+    stale = await async_client.post(
+        "/api/v2/comments",
+        headers=reviewer_headers,
+        json={**payload, "record_revision": record_revision - 1},
+    )
+    assert stale.status_code == 409
+    assert stale.json()["detail"]["code"] == "revision_mismatch"
+
+    record = await db_session.get(Phenopacket, record_id)
+    candidate = await db_session.get(PhenopacketRevision, candidate_id)
+    assert record is not None and candidate is not None
+    active_draft = PhenopacketRevision(
+        record_id=record_id,
+        parent_revision_id=candidate_id,
+        revision_number=3,
+        state="draft",
+        content_jsonb=record.phenopacket,
+        change_reason="review closed",
+        actor_id=curator_id,
+        from_state="in_review",
+        to_state="draft",
+        event_type="state_transition",
+    )
+    db_session.add(active_draft)
+    await db_session.flush()
+    record.state = "draft"
+    record.revision = 3
+    record.editing_revision_id = active_draft.id
+    closed_revision = record.revision
+    await db_session.commit()
+    closed = await async_client.post(
+        "/api/v2/comments",
+        headers=reviewer_headers,
+        json={**payload, "record_revision": closed_revision},
+    )
+    assert closed.status_code == 409
+    assert closed.json()["detail"]["code"] == "review_closed"
+
+
+@pytest.mark.asyncio
+async def test_ordinary_comment_routes_remain_bodyless_and_authorized(
+    async_client, curator_headers, admin_headers, published_record
+):
+    """Legacy ordinary resolve, unresolve, and author/admin delete stay intact."""
+    created = await async_client.post(
+        "/api/v2/comments",
+        headers=curator_headers,
+        json={
+            "record_type": "phenopacket",
+            "record_id": str(published_record.id),
+            "body_markdown": "ordinary",
+            "mention_user_ids": [],
+        },
+    )
+    assert created.status_code == 201, created.json()
+    comment_id = created.json()["id"]
+    assert (
+        await async_client.post(
+            f"/api/v2/comments/{comment_id}/resolve", headers=curator_headers
+        )
+    ).status_code == 200
+    assert (
+        await async_client.post(
+            f"/api/v2/comments/{comment_id}/unresolve",
+            headers=curator_headers,
+            json={},
+        )
+    ).status_code == 200
+    assert (
+        await async_client.delete(
+            f"/api/v2/comments/{comment_id}", headers=admin_headers
+        )
+    ).status_code == 204

--- a/backend/tests/test_blocking_review_issues.py
+++ b/backend/tests/test_blocking_review_issues.py
@@ -13,8 +13,14 @@ from app.comments.schemas import (
     ReviewIssueResolveRequest,
 )
 from app.comments.service import CommentsService
-from app.phenopackets.models import Phenopacket, PhenopacketRevision
+from app.models.user import User
+from app.phenopackets.models import (
+    ApprovalAttestation,
+    Phenopacket,
+    PhenopacketRevision,
+)
 from app.phenopackets.review.policy import ReviewPolicyError
+from app.phenopackets.services.state_service import PhenopacketStateService
 
 
 async def _seed_review_cycle(db_session, *, owner, submitter):
@@ -397,6 +403,217 @@ async def test_blocking_issue_routes_require_conditional_evidence_and_independen
     )
     assert reopened.status_code == 200, reopened.json()
     assert reopened.json()["resolved_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_old_issue_in_current_cycle_remains_actionable_after_resubmit(
+    async_client,
+    db_session,
+    curator_user,
+    another_curator,
+):
+    """Resubmission must not strand an issue linked to the earlier candidate."""
+    reviewer_headers = await _headers_for(
+        async_client, another_curator.username, "CuratorPass123!"
+    )
+    record, first_candidate = await _seed_review_cycle(
+        db_session, owner=curator_user, submitter=curator_user
+    )
+    created = await _post_issue(async_client, reviewer_headers, record, first_candidate)
+    assert created.status_code == 201, created.json()
+    issue_id = created.json()["id"]
+
+    state_service = PhenopacketStateService(db_session)
+    record, _ = await state_service.transition(
+        record.id,
+        to_state="changes_requested",
+        reason="address the blocking issue",
+        expected_revision=record.revision,
+        actor=another_curator,
+    )
+    record, resubmitted = await state_service.transition(
+        record.id,
+        to_state="in_review",
+        reason="resubmit after changes",
+        expected_revision=record.revision,
+        actor=curator_user,
+    )
+    assert resubmitted.id != first_candidate.id
+
+    resolved = await async_client.post(
+        f"/api/v2/comments/{issue_id}/resolve",
+        headers=reviewer_headers,
+        json={
+            "record_revision": record.revision,
+            "disposition": "addressed",
+            "rationale": "fixed during resubmission",
+        },
+    )
+    assert resolved.status_code == 200, resolved.json()
+    reopened = await async_client.post(
+        f"/api/v2/comments/{issue_id}/unresolve",
+        headers=reviewer_headers,
+        json={
+            "record_revision": record.revision,
+            "rationale": "verify one remaining concern",
+        },
+    )
+    assert reopened.status_code == 200, reopened.json()
+    resolved_again = await async_client.post(
+        f"/api/v2/comments/{issue_id}/resolve",
+        headers=reviewer_headers,
+        json={
+            "record_revision": record.revision,
+            "disposition": "accepted_with_rationale",
+            "rationale": "remaining concern accepted",
+        },
+    )
+    assert resolved_again.status_code == 200, resolved_again.json()
+
+    record = await db_session.get(Phenopacket, record.id)
+    assert record is not None
+    approved, _ = await state_service.transition(
+        record.id,
+        to_state="approved",
+        reason="all current-cycle issues handled",
+        expected_revision=record.revision,
+        actor=another_curator,
+        candidate_revision_id=resubmitted.id,
+        candidate_content_sha256=resubmitted.content_sha256,
+        attestation=ApprovalAttestation(
+            independent_review=True,
+            no_unmanaged_conflict=True,
+        ),
+    )
+    assert approved.state == "approved"
+
+
+@pytest.mark.asyncio
+async def test_published_cycle_issue_is_non_actionable_and_does_not_gate_next_cycle(
+    async_client,
+    db_session,
+    draft_record,
+    curator_user,
+    another_curator,
+    admin_user,
+):
+    """A resolved prior-cycle issue cannot reopen or gate the next approval."""
+    reviewer_headers = await _headers_for(
+        async_client, another_curator.username, "CuratorPass123!"
+    )
+    state_service = PhenopacketStateService(db_session)
+    root = PhenopacketRevision(
+        record_id=draft_record.id,
+        revision_number=draft_record.revision,
+        state="draft",
+        content_jsonb=draft_record.phenopacket,
+        change_reason="create",
+        actor_id=curator_user.id,
+        from_state=None,
+        to_state="draft",
+        event_type="created",
+    )
+    db_session.add(root)
+    await db_session.flush()
+    draft_record.editing_revision_id = root.id
+    await db_session.flush()
+    record, first_candidate = await state_service.transition(
+        draft_record.id,
+        to_state="in_review",
+        reason="first cycle submission",
+        expected_revision=draft_record.revision,
+        actor=curator_user,
+    )
+    created = await _post_issue(async_client, reviewer_headers, record, first_candidate)
+    assert created.status_code == 201, created.json()
+    issue_id = created.json()["id"]
+    resolved = await async_client.post(
+        f"/api/v2/comments/{issue_id}/resolve",
+        headers=reviewer_headers,
+        json={
+            "record_revision": record.revision,
+            "disposition": "addressed",
+            "rationale": "first cycle fixed",
+        },
+    )
+    assert resolved.status_code == 200, resolved.json()
+
+    record = await db_session.get(Phenopacket, record.id)
+    assert record is not None and first_candidate.content_sha256 is not None
+    record, approved = await state_service.transition(
+        record.id,
+        to_state="approved",
+        reason="approve first cycle",
+        expected_revision=record.revision,
+        actor=another_curator,
+        candidate_revision_id=first_candidate.id,
+        candidate_content_sha256=first_candidate.content_sha256,
+        attestation=ApprovalAttestation(
+            independent_review=True,
+            no_unmanaged_conflict=True,
+        ),
+    )
+    assert approved.content_sha256 is not None
+    record, _ = await state_service.transition(
+        record.id,
+        to_state="published",
+        reason="publish first cycle",
+        expected_revision=record.revision,
+        actor=admin_user,
+        approved_revision_id=approved.id,
+        approved_content_sha256=approved.content_sha256,
+    )
+    record = await state_service.edit_record(
+        record.id,
+        new_content=record.phenopacket,
+        change_reason="open second cycle",
+        expected_revision=record.revision,
+        actor=curator_user,
+    )
+    record, next_candidate = await state_service.transition(
+        record.id,
+        to_state="in_review",
+        reason="submit second cycle",
+        expected_revision=record.revision,
+        actor=curator_user,
+    )
+    record_id = record.id
+    reviewer_id = another_curator.id
+    next_candidate_id = next_candidate.id
+    next_candidate_digest = next_candidate.content_sha256
+    next_record_revision = record.revision
+    await db_session.commit()
+
+    historical_reopen = await async_client.post(
+        f"/api/v2/comments/{issue_id}/unresolve",
+        headers=reviewer_headers,
+        json={
+            "record_revision": next_record_revision,
+            "rationale": "must not reopen a published cycle",
+        },
+    )
+    assert historical_reopen.status_code == 409, historical_reopen.json()
+    assert historical_reopen.json()["detail"]["code"] == "review_closed"
+
+    record = await db_session.get(Phenopacket, record_id)
+    reviewer = await db_session.get(User, reviewer_id)
+    assert record is not None and reviewer is not None
+    assert next_candidate_digest is not None
+    record, next_approval = await state_service.transition(
+        record.id,
+        to_state="approved",
+        reason="prior-cycle issue is non-gating",
+        expected_revision=record.revision,
+        actor=reviewer,
+        candidate_revision_id=next_candidate_id,
+        candidate_content_sha256=next_candidate_digest,
+        attestation=ApprovalAttestation(
+            independent_review=True,
+            no_unmanaged_conflict=True,
+        ),
+    )
+    assert next_approval.state == "approved"
+    assert record.editing_revision_id == next_approval.id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_comments_router.py
+++ b/backend/tests/test_comments_router.py
@@ -1,5 +1,7 @@
 """Comments router smoke test. Full permissions matrix lands in Task 32."""
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 
@@ -16,3 +18,51 @@ async def test_post_comment_201(async_client, curator_headers, published_record)
         headers=curator_headers,
     )
     assert resp.status_code == 201, resp.json()
+
+
+@pytest.mark.asyncio
+async def test_mutation_router_commits_once_on_success(
+    monkeypatch, async_client, db_session, curator_headers, published_record
+):
+    """A successful mutation commits exactly once after response construction."""
+    commit = AsyncMock(wraps=db_session.commit)
+    monkeypatch.setattr(db_session, "commit", commit)
+
+    response = await async_client.post(
+        "/api/v2/comments",
+        json={
+            "record_type": "phenopacket",
+            "record_id": str(published_record.id),
+            "body_markdown": "router transaction",
+            "mention_user_ids": [],
+        },
+        headers=curator_headers,
+    )
+
+    assert response.status_code == 201, response.json()
+    assert commit.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_mutation_router_rolls_back_domain_failure(
+    monkeypatch, async_client, db_session, curator_headers, published_record
+):
+    """Every caught service/domain failure explicitly rolls back the session."""
+    rollback = AsyncMock(wraps=db_session.rollback)
+    monkeypatch.setattr(db_session, "rollback", rollback)
+
+    response = await async_client.post(
+        "/api/v2/comments",
+        json={
+            "record_type": "phenopacket",
+            "record_id": str(published_record.id),
+            "body_markdown": "stale issue",
+            "mention_user_ids": [],
+            "record_revision": published_record.revision - 1,
+            "review_revision_id": 999999,
+        },
+        headers=curator_headers,
+    )
+
+    assert response.status_code == 409
+    assert rollback.await_count == 1

--- a/backend/tests/test_comments_service_mutations.py
+++ b/backend/tests/test_comments_service_mutations.py
@@ -1,8 +1,39 @@
 """CommentsService mutation methods (update_body, resolve, unresolve, soft_delete)."""
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from app.comments.service import CommentsService
+
+
+@pytest.mark.asyncio
+async def test_service_mutations_flush_but_never_commit(
+    monkeypatch, db_session, published_record, curator_user
+):
+    """The router is the sole transaction owner for every mutation."""
+    commit = AsyncMock(side_effect=AssertionError("service must not commit"))
+    monkeypatch.setattr(db_session, "commit", commit)
+    svc = CommentsService(db_session)
+
+    comment = await svc.create(
+        record_type="phenopacket",
+        record_id=published_record.id,
+        body_markdown="original",
+        mention_user_ids=[],
+        actor=curator_user,
+    )
+    await svc.update_body(
+        comment_id=comment.id,
+        body_markdown="edited",
+        mention_user_ids=[],
+        actor=curator_user,
+    )
+    await svc.resolve(comment_id=comment.id, actor=curator_user)
+    await svc.unresolve(comment_id=comment.id, actor=curator_user)
+    await svc.soft_delete(comment_id=comment.id, actor=curator_user)
+
+    commit.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_exact_review_snapshot.py
+++ b/backend/tests/test_exact_review_snapshot.py
@@ -154,6 +154,69 @@ async def test_submit_freezes_publish_canonical_content_once_and_publish_copies_
 
 
 @pytest.mark.asyncio
+async def test_resubmit_refreezes_once_before_candidate_and_not_during_decisions(
+    db_session,
+    draft_record,
+    curator_user,
+    another_curator,
+    admin_user,
+    monkeypatch,
+):
+    """Changes-requested resubmission freezes once before the new candidate."""
+    service = PhenopacketStateService(db_session)
+    record, first_candidate = await _submit(service, draft_record, curator_user)
+    record, _ = await service.transition(
+        record.id,
+        to_state="changes_requested",
+        reason="revise extension evidence",
+        expected_revision=record.revision,
+        actor=another_curator,
+    )
+    record = await service.edit_record(
+        record.id,
+        new_content={
+            "id": draft_record.phenopacket_id,
+            "hnf1bCuration": {"extensionOnlyEvidence": {"status": "revised"}},
+        },
+        change_reason="address review",
+        expected_revision=record.revision,
+        actor=curator_user,
+    )
+
+    calls: list[bool] = []
+
+    def canonicalize(content, *, publish=False):
+        calls.append(publish)
+        canonical = deepcopy(content)
+        canonical["hnf1bCuration"]["extensionOnlyEvidence"]["status"] = (
+            "frozen-resubmission"
+        )
+        return canonical
+
+    monkeypatch.setattr(
+        PhenopacketStateService,
+        "_canonicalize_for_persistence",
+        staticmethod(canonicalize),
+    )
+
+    record, resubmitted = await _submit(service, record, curator_user)
+
+    assert calls == [True]
+    assert resubmitted.id != first_candidate.id
+    assert resubmitted.content_jsonb["hnf1bCuration"] == {
+        "extensionOnlyEvidence": {"status": "frozen-resubmission"}
+    }
+    assert record.phenopacket == resubmitted.content_jsonb
+
+    record, approved = await _approve(service, record, resubmitted, admin_user)
+    record, published = await _publish(service, record, approved, admin_user)
+
+    assert calls == [True]
+    assert approved.content_jsonb == resubmitted.content_jsonb
+    assert published.content_jsonb == approved.content_jsonb
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("stale_field", ["candidate_revision_id", "digest"])
 async def test_approval_rejects_stale_exact_candidate_without_mutation(
     db_session,

--- a/backend/tests/test_exact_review_snapshot.py
+++ b/backend/tests/test_exact_review_snapshot.py
@@ -1,0 +1,434 @@
+"""Exact candidate approval and publication snapshot regression coverage."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from sqlalchemy import select
+
+from app.phenopackets.models import (
+    ApprovalAttestation,
+    PhenopacketCreate,
+    PhenopacketRevision,
+)
+from app.phenopackets.repositories import PhenopacketRepository
+from app.phenopackets.services.phenopacket_service import PhenopacketService
+from app.phenopackets.services.revision_ledger import (
+    build_ledger_v2_payload,
+    content_sha256,
+    ledger_sha256,
+)
+from app.phenopackets.services.state_service import PhenopacketStateService
+
+
+def _attestation() -> ApprovalAttestation:
+    """Return the complete affirmative approval attestation."""
+    return ApprovalAttestation(
+        independent_review=True,
+        no_unmanaged_conflict=True,
+    )
+
+
+async def _submit(
+    service: PhenopacketStateService,
+    record,
+    actor,
+) -> tuple[object, PhenopacketRevision]:
+    """Submit the fixture's active working copy and return its candidate."""
+    return await service.transition(
+        record.id,
+        to_state="in_review",
+        reason="freeze exact candidate",
+        expected_revision=record.revision,
+        actor=actor,
+    )
+
+
+async def _approve(
+    service: PhenopacketStateService,
+    record,
+    candidate: PhenopacketRevision,
+    actor,
+    *,
+    reason: str = "independent review complete",
+) -> tuple[object, PhenopacketRevision]:
+    """Approve by echoing the exact server-returned candidate identity."""
+    assert candidate.content_sha256 is not None
+    return await service.transition(
+        record.id,
+        to_state="approved",
+        reason=reason,
+        expected_revision=record.revision,
+        actor=actor,
+        candidate_revision_id=candidate.id,
+        candidate_content_sha256=candidate.content_sha256,
+        attestation=_attestation(),
+    )
+
+
+async def _publish(
+    service: PhenopacketStateService,
+    record,
+    approved: PhenopacketRevision,
+    actor,
+) -> tuple[object, PhenopacketRevision]:
+    """Publish by echoing the exact server-returned approval identity."""
+    assert approved.content_sha256 is not None
+    return await service.transition(
+        record.id,
+        to_state="published",
+        reason="publish exact approval",
+        expected_revision=record.revision,
+        actor=actor,
+        approved_revision_id=approved.id,
+        approved_content_sha256=approved.content_sha256,
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_freezes_publish_canonical_content_once_and_publish_copies_it(
+    db_session,
+    draft_record,
+    curator_user,
+    admin_user,
+    monkeypatch,
+):
+    """Submission canonicalizes once; approval and publication copy exact bytes."""
+    calls: list[bool] = []
+
+    def canonicalize(content, *, publish=False):
+        calls.append(publish)
+        canonical = deepcopy(content)
+        canonical["hnf1bCuration"] = {
+            **canonical.get("hnf1bCuration", {}),
+            "extensionOnlyEvidence": {"status": "frozen"},
+        }
+        return canonical
+
+    monkeypatch.setattr(
+        PhenopacketStateService,
+        "_canonicalize_for_persistence",
+        staticmethod(canonicalize),
+    )
+    draft_record.phenopacket = {
+        "id": draft_record.phenopacket_id,
+        "hnf1bCuration": {"extensionOnlyEvidence": {"status": "draft"}},
+    }
+    service = PhenopacketStateService(db_session)
+
+    record, candidate = await _submit(service, draft_record, curator_user)
+
+    assert calls == [True]
+    assert candidate.content_jsonb["hnf1bCuration"] == {
+        "extensionOnlyEvidence": {"status": "frozen"}
+    }
+    assert candidate.content_sha256 == content_sha256(candidate.content_jsonb)
+    assert record.phenopacket == candidate.content_jsonb
+
+    record.phenopacket = deepcopy(candidate.content_jsonb)
+    record.phenopacket["hnf1bCuration"]["extensionOnlyEvidence"]["status"] = (
+        "unreviewed-working-copy-mutation"
+    )
+    record, approved = await _approve(service, record, candidate, admin_user)
+    record, published = await _publish(service, record, approved, admin_user)
+    await db_session.flush()
+
+    assert calls == [True]
+    assert approved.content_jsonb == candidate.content_jsonb
+    assert approved.content_sha256 == candidate.content_sha256
+    assert approved.parent_revision_id == candidate.id
+    assert published.content_jsonb == approved.content_jsonb
+    assert published.content_sha256 == approved.content_sha256
+    assert published.parent_revision_id == approved.id
+    assert record.phenopacket == approved.content_jsonb
+    assert record.head_published_revision_id == published.id
+    assert record.editing_revision_id is None
+
+    public_head = await db_session.get(
+        PhenopacketRevision, record.head_published_revision_id
+    )
+    assert public_head is not None
+    assert public_head.id == published.id
+    assert public_head.content_jsonb == approved.content_jsonb
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stale_field", ["candidate_revision_id", "digest"])
+async def test_approval_rejects_stale_exact_candidate_without_mutation(
+    db_session,
+    draft_record,
+    curator_user,
+    admin_user,
+    stale_field,
+):
+    """A stale ID or extension-only digest change cannot approve a candidate."""
+    service = PhenopacketStateService(db_session)
+    draft_record.phenopacket = {
+        "id": draft_record.phenopacket_id,
+        "hnf1bCuration": {"extensionOnlyEvidence": {"status": "candidate"}},
+    }
+    record, candidate = await _submit(service, draft_record, curator_user)
+    assert candidate.content_sha256 is not None
+    original_pointer = record.editing_revision_id
+    original_revision = record.revision
+    original_content = deepcopy(record.phenopacket)
+
+    changed_extension = deepcopy(candidate.content_jsonb)
+    changed_extension["hnf1bCuration"]["extensionOnlyEvidence"]["status"] = "stale"
+    supplied_id = (
+        candidate.id + 1 if stale_field == "candidate_revision_id" else candidate.id
+    )
+    supplied_digest = (
+        content_sha256(changed_extension)
+        if stale_field == "digest"
+        else candidate.content_sha256
+    )
+
+    with pytest.raises(PhenopacketStateService.ReviewRevisionMismatch):
+        await service.transition(
+            record.id,
+            to_state="approved",
+            reason="stale review",
+            expected_revision=record.revision,
+            actor=admin_user,
+            candidate_revision_id=supplied_id,
+            candidate_content_sha256=supplied_digest,
+            attestation=_attestation(),
+        )
+
+    assert record.editing_revision_id == original_pointer
+    assert record.revision == original_revision
+    assert record.phenopacket == original_content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stale_field", ["approved_revision_id", "digest"])
+async def test_publication_rejects_stale_exact_approval_without_head_swap(
+    db_session,
+    draft_record,
+    curator_user,
+    admin_user,
+    stale_field,
+):
+    """A stale approval ID or extension-only digest leaves all pointers intact."""
+    service = PhenopacketStateService(db_session)
+    draft_record.phenopacket = {
+        "id": draft_record.phenopacket_id,
+        "hnf1bCuration": {"extensionOnlyEvidence": {"status": "approved"}},
+    }
+    record, candidate = await _submit(service, draft_record, curator_user)
+    record, approved = await _approve(service, record, candidate, admin_user)
+    assert approved.content_sha256 is not None
+    original_pointer = record.editing_revision_id
+    original_revision = record.revision
+    original_content = deepcopy(record.phenopacket)
+
+    changed_extension = deepcopy(approved.content_jsonb)
+    changed_extension["hnf1bCuration"]["extensionOnlyEvidence"]["status"] = "stale"
+    supplied_id = (
+        approved.id + 1 if stale_field == "approved_revision_id" else approved.id
+    )
+    supplied_digest = (
+        content_sha256(changed_extension)
+        if stale_field == "digest"
+        else approved.content_sha256
+    )
+
+    with pytest.raises(PhenopacketStateService.ReviewRevisionMismatch):
+        await service.transition(
+            record.id,
+            to_state="published",
+            reason="stale publish",
+            expected_revision=record.revision,
+            actor=admin_user,
+            approved_revision_id=supplied_id,
+            approved_content_sha256=supplied_digest,
+        )
+
+    assert record.head_published_revision_id is None
+    assert record.editing_revision_id == original_pointer
+    assert record.revision == original_revision
+    assert record.phenopacket == original_content
+
+
+@pytest.mark.asyncio
+async def test_approval_records_exact_decision_metadata_and_hashes_role_and_metadata(
+    db_session,
+    draft_record,
+    curator_user,
+    admin_user,
+):
+    """The v2 approval ledger binds the exact rationale, attestation, and role."""
+    service = PhenopacketStateService(db_session)
+    record, candidate = await _submit(service, draft_record, curator_user)
+    record, approved = await _approve(
+        service,
+        record,
+        candidate,
+        admin_user,
+        reason="approved after independent review",
+    )
+
+    expected_metadata = {
+        "candidate_revision_id": candidate.id,
+        "candidate_content_sha256": candidate.content_sha256,
+        "attestation": {
+            "independent_review": True,
+            "no_unmanaged_conflict": True,
+        },
+        "rationale": "approved after independent review",
+    }
+    assert approved.actor_role == "admin"
+    assert approved.decision_metadata == expected_metadata
+    assert approved.content_sha256 == content_sha256(approved.content_jsonb)
+    assert approved.ledger_version == 2
+
+    payload = build_ledger_v2_payload(
+        parent_revision_id=approved.parent_revision_id,
+        revision_number=approved.revision_number,
+        state=approved.state,
+        event_type=approved.event_type,
+        from_state=approved.from_state,
+        to_state=approved.to_state,
+        change_reason=approved.change_reason,
+        change_patch=approved.change_patch,
+        content_sha256=approved.content_sha256,
+        projection_hash=approved.projection_hash,
+        actor_id=approved.actor_id,
+        actor_role=approved.actor_role,
+        decision_metadata=expected_metadata,
+    )
+    assert approved.ledger_hash == ledger_sha256(payload)
+    assert approved.ledger_hash != ledger_sha256({**payload, "actor_role": "curator"})
+    assert approved.ledger_hash != ledger_sha256(
+        {**payload, "decision_metadata": {**expected_metadata, "rationale": "tampered"}}
+    )
+
+
+@pytest.mark.asyncio
+async def test_every_new_state_revision_is_v2_while_legacy_head_remains_unchanged(
+    db_session,
+    published_record,
+    curator_user,
+    admin_user,
+):
+    """Draft, review, approval, and publication writes use v2 without backfill."""
+    service = PhenopacketStateService(db_session)
+    legacy_head_id = published_record.head_published_revision_id
+    legacy_head = await db_session.get(PhenopacketRevision, legacy_head_id)
+    assert legacy_head is not None
+    assert legacy_head.ledger_version is None
+
+    record = await service.edit_record(
+        published_record.id,
+        new_content={
+            **published_record.phenopacket,
+            "hnf1bCuration": {"extensionOnlyEvidence": {"status": "draft"}},
+        },
+        change_reason="create replacement draft",
+        expected_revision=published_record.revision,
+        actor=curator_user,
+    )
+    record = await service.edit_record(
+        record.id,
+        new_content={
+            **record.phenopacket,
+            "hnf1bCuration": {"extensionOnlyEvidence": {"status": "saved"}},
+        },
+        change_reason="save replacement draft",
+        expected_revision=record.revision,
+        actor=curator_user,
+    )
+    record, candidate = await _submit(service, record, curator_user)
+    record, approved = await _approve(service, record, candidate, admin_user)
+    record, published = await _publish(service, record, approved, admin_user)
+    await db_session.flush()
+
+    rows = list(
+        (
+            await db_session.execute(
+                select(PhenopacketRevision)
+                .where(PhenopacketRevision.record_id == record.id)
+                .order_by(PhenopacketRevision.revision_number)
+            )
+        ).scalars()
+    )
+    assert rows[0].id == legacy_head_id
+    assert rows[0].actor_role is None
+    assert rows[0].content_sha256 is None
+    assert rows[0].ledger_version is None
+    for revision in rows[1:]:
+        assert revision.actor_role in {"curator", "admin"}
+        assert revision.content_sha256 == content_sha256(revision.content_jsonb)
+        assert revision.ledger_version == 2
+    assert [revision.event_type for revision in rows[1:]] == [
+        "draft_created",
+        "draft_saved",
+        "state_transition",
+        "state_transition",
+        "published",
+    ]
+    assert record.head_published_revision_id == published.id
+
+
+@pytest.mark.asyncio
+async def test_initial_creation_records_complete_v2_evidence(
+    db_session,
+    curator_user,
+):
+    """The creation-only revision constructor emits the same v2 evidence."""
+    service = PhenopacketService(PhenopacketRepository(db_session))
+    content = {
+        "id": "exact-snapshot-created",
+        "subject": {"id": "exact-snapshot-subject", "sex": "FEMALE"},
+        "phenotypicFeatures": [{"type": {"id": "HP:0000107", "label": "Renal cyst"}}],
+        "metaData": {
+            "created": "2026-08-14T00:00:00Z",
+            "createdBy": "exact-snapshot-test",
+            "phenopacketSchemaVersion": "2.0",
+            "resources": [
+                {
+                    "id": "hp",
+                    "name": "Human Phenotype Ontology",
+                    "namespacePrefix": "HP",
+                    "url": "http://purl.obolibrary.org/obo/hp.owl",
+                    "version": "2024-01-01",
+                    "iriPrefix": "http://purl.obolibrary.org/obo/HP_",
+                }
+            ],
+        },
+    }
+
+    record = await service.create(
+        PhenopacketCreate(phenopacket=content),
+        actor_id=curator_user.id,
+    )
+    revision = (
+        await db_session.execute(
+            select(PhenopacketRevision).where(
+                PhenopacketRevision.record_id == record.id
+            )
+        )
+    ).scalar_one()
+
+    assert revision.actor_role == "curator"
+    assert revision.decision_metadata is None
+    assert revision.content_sha256 == content_sha256(revision.content_jsonb)
+    assert revision.ledger_version == 2
+    payload = build_ledger_v2_payload(
+        parent_revision_id=None,
+        revision_number=revision.revision_number,
+        state="draft",
+        event_type="created",
+        from_state=None,
+        to_state="draft",
+        change_reason="Initial creation",
+        change_patch=None,
+        content_sha256=revision.content_sha256,
+        projection_hash=revision.projection_hash,
+        actor_id=revision.actor_id,
+        actor_role="curator",
+        decision_metadata=None,
+    )
+    assert revision.ledger_hash == ledger_sha256(payload)

--- a/backend/tests/test_review_models.py
+++ b/backend/tests/test_review_models.py
@@ -14,6 +14,13 @@ def _check_names(table) -> set[str]:
     }
 
 
+def _check_sql(table, name: str) -> str:
+    for constraint in table.constraints:
+        if isinstance(constraint, CheckConstraint) and constraint.name == name:
+            return str(constraint.sqltext)
+    raise AssertionError(f"missing check constraint {name}")
+
+
 def test_revision_model_catches_missing_nullable_v2_audit_storage():
     """A revision must expose nullable storage for every v2 audit component."""
     columns = PhenopacketRevision.__table__.c
@@ -39,6 +46,16 @@ def test_revision_model_catches_missing_nullable_v2_audit_storage():
         "ck_phenopacket_revisions_ledger_version",
         "ck_phenopacket_revisions_decision_metadata_ledger",
     } <= _check_names(PhenopacketRevision.__table__)
+
+
+def test_revision_model_catches_decision_metadata_with_null_ledger_version():
+    """ORM metadata must require an explicit v2 ledger for decision metadata."""
+    check_sql = _check_sql(
+        PhenopacketRevision.__table__,
+        "ck_phenopacket_revisions_decision_metadata_ledger",
+    )
+
+    assert "ledger_version IS NOT NULL" in check_sql
 
 
 def test_review_issue_model_catches_missing_restrictive_revision_link():
@@ -74,3 +91,13 @@ def test_resolution_event_model_catches_missing_append_only_audit_links():
         "ck_comment_resolution_event_rationale",
         "ck_comment_resolution_event_actor_role",
     } <= _check_names(event.__table__)
+
+
+def test_resolution_event_model_catches_resolved_event_with_null_disposition():
+    """ORM metadata must require a disposition for every resolved event."""
+    event = getattr(comments_models, "CommentResolutionEvent")
+    check_sql = _check_sql(
+        event.__table__, "ck_comment_resolution_event_action_disposition"
+    )
+
+    assert "disposition IS NOT NULL" in check_sql

--- a/backend/tests/test_review_models.py
+++ b/backend/tests/test_review_models.py
@@ -3,7 +3,7 @@
 from sqlalchemy import CheckConstraint
 
 from app.comments import models as comments_models
-from app.phenopackets.models import PhenopacketRevision
+from app.phenopackets.models import Phenopacket, PhenopacketRevision
 
 
 def _check_names(table) -> set[str]:
@@ -101,3 +101,10 @@ def test_resolution_event_model_catches_resolved_event_with_null_disposition():
     )
 
     assert "disposition IS NOT NULL" in check_sql
+
+
+def test_active_edit_owner_constraint_is_in_orm_metadata():
+    """ORM metadata mirrors the activated editing-pointer owner invariant."""
+    assert _check_sql(Phenopacket.__table__, "ck_phenopackets_active_edit_owner") == (
+        "editing_revision_id IS NULL OR draft_owner_id IS NOT NULL"
+    )

--- a/backend/tests/test_review_models.py
+++ b/backend/tests/test_review_models.py
@@ -1,0 +1,76 @@
+"""ORM contracts for independent-review persistence."""
+
+from sqlalchemy import CheckConstraint
+
+from app.comments import models as comments_models
+from app.phenopackets.models import PhenopacketRevision
+
+
+def _check_names(table) -> set[str]:
+    return {
+        constraint.name
+        for constraint in table.constraints
+        if isinstance(constraint, CheckConstraint) and constraint.name is not None
+    }
+
+
+def test_revision_model_catches_missing_nullable_v2_audit_storage():
+    """A revision must expose nullable storage for every v2 audit component."""
+    columns = PhenopacketRevision.__table__.c
+
+    assert {
+        "actor_role",
+        "decision_metadata",
+        "content_sha256",
+        "ledger_version",
+    } <= set(columns.keys())
+    assert all(
+        columns[name].nullable
+        for name in (
+            "actor_role",
+            "decision_metadata",
+            "content_sha256",
+            "ledger_version",
+        )
+    )
+    assert {
+        "ck_phenopacket_revisions_actor_role",
+        "ck_phenopacket_revisions_content_sha256",
+        "ck_phenopacket_revisions_ledger_version",
+        "ck_phenopacket_revisions_decision_metadata_ledger",
+    } <= _check_names(PhenopacketRevision.__table__)
+
+
+def test_review_issue_model_catches_missing_restrictive_revision_link():
+    """Blocking issues must reference the reviewed immutable revision."""
+    comment = comments_models.Comment
+    column = comment.__table__.c.review_revision_id
+
+    assert column.nullable
+    foreign_key = next(iter(column.foreign_keys))
+    assert foreign_key.target_fullname == "phenopacket_revisions.id"
+    assert foreign_key.ondelete == "RESTRICT"
+    assert comment.review_revision.property.mapper.class_ is PhenopacketRevision
+
+
+def test_resolution_event_model_catches_missing_append_only_audit_links():
+    """Resolution history must retain restrictive comment and actor links."""
+    event = getattr(comments_models, "CommentResolutionEvent")
+    columns = event.__table__.c
+
+    assert {
+        "comment_id",
+        "action",
+        "disposition",
+        "rationale",
+        "actor_id",
+        "actor_role",
+        "created_at",
+    } <= set(columns.keys())
+    assert next(iter(columns.comment_id.foreign_keys)).ondelete == "RESTRICT"
+    assert next(iter(columns.actor_id.foreign_keys)).ondelete == "RESTRICT"
+    assert {
+        "ck_comment_resolution_event_action_disposition",
+        "ck_comment_resolution_event_rationale",
+        "ck_comment_resolution_event_actor_role",
+    } <= _check_names(event.__table__)

--- a/backend/tests/test_review_policy.py
+++ b/backend/tests/test_review_policy.py
@@ -1,0 +1,424 @@
+"""Independent-review policy tests against real revision rows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.phenopackets.models import Phenopacket, PhenopacketRevision
+from app.phenopackets.review.policy import ReviewPolicy, ReviewPolicyError
+
+
+async def _review_candidate(
+    db_session: Any,
+    *,
+    owner_id: int | None,
+    submitter_id: int,
+    contributor_id: int | None = None,
+    contributor_event: str = "draft_saved",
+    effective_state: str = "in_review",
+) -> tuple[Phenopacket, PhenopacketRevision]:
+    """Persist one active review cycle and return its submitted candidate."""
+    record = Phenopacket(
+        phenopacket_id=f"review-policy-{owner_id}-{submitter_id}-{contributor_id}",
+        phenopacket={"id": "review-policy"},
+        state="draft",
+        revision=0,
+        draft_owner_id=owner_id,
+        created_by_id=owner_id,
+    )
+    db_session.add(record)
+    await db_session.flush()
+
+    parent_id = None
+    if contributor_id is not None:
+        contribution = PhenopacketRevision(
+            record_id=record.id,
+            revision_number=1,
+            state="draft",
+            content_jsonb={"id": "review-policy", "saved": True},
+            change_reason="content contribution",
+            actor_id=contributor_id,
+            from_state="draft",
+            to_state="draft",
+            event_type=contributor_event,
+        )
+        db_session.add(contribution)
+        await db_session.flush()
+        parent_id = contribution.id
+
+    candidate = PhenopacketRevision(
+        record_id=record.id,
+        parent_revision_id=parent_id,
+        revision_number=2 if contributor_id is not None else 1,
+        state="in_review",
+        content_jsonb={"id": "review-policy", "saved": contributor_id is not None},
+        change_reason="submit for review",
+        actor_id=submitter_id,
+        from_state="draft",
+        to_state="in_review",
+        event_type="state_transition",
+    )
+    db_session.add(candidate)
+    await db_session.flush()
+
+    record.state = effective_state
+    record.revision = candidate.revision_number
+    if owner_id is not None:
+        record.editing_revision_id = candidate.id
+    await db_session.flush()
+    return record, candidate
+
+
+def _capability(capabilities: Any, action: str) -> Any:
+    """Select an action capability without deriving its expected result."""
+    return next(item for item in capabilities.actions if item.action == action)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("role", "is_owner", "submitted", "contributed", "allowed", "code"),
+    [
+        ("curator", False, False, False, True, None),
+        ("admin", False, False, False, True, None),
+        ("curator", True, False, True, False, "self_review_forbidden"),
+        ("admin", False, True, False, False, "reviewer_submitted"),
+        ("admin", False, False, True, False, "reviewer_contributed"),
+    ],
+)
+async def test_review_eligibility_matrix(
+    db_session,
+    curator_user,
+    another_curator,
+    admin_user,
+    role,
+    is_owner,
+    submitted,
+    contributed,
+    allowed,
+    code,
+):
+    """Owner, submitter, and contributor status cannot be bypassed by admins."""
+    actor = admin_user if role == "admin" else another_curator
+    owner_id = actor.id if is_owner else curator_user.id
+    submitter_id = actor.id if submitted else curator_user.id
+    contributor_id = actor.id if contributed else None
+    record, candidate = await _review_candidate(
+        db_session,
+        owner_id=owner_id,
+        submitter_id=submitter_id,
+        contributor_id=contributor_id,
+    )
+
+    capabilities = await ReviewPolicy.evaluate(
+        db_session,
+        record,
+        candidate,
+        actor,
+        unresolved_count=0,
+    )
+    approve = _capability(capabilities, "approve")
+
+    assert approve.allowed is allowed
+    assert (approve.blocked_by[0] if approve.blocked_by else None) == code
+    if is_owner and contributed:
+        assert approve.blocked_by == [
+            "self_review_forbidden",
+            "reviewer_contributed",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_null_owner_fails_closed(db_session, curator_user, another_curator):
+    """A missing owner is uncertainty, never proof of reviewer independence."""
+    record, candidate = await _review_candidate(
+        db_session,
+        owner_id=None,
+        submitter_id=curator_user.id,
+    )
+
+    capabilities = await ReviewPolicy.evaluate(
+        db_session,
+        record,
+        candidate,
+        another_curator,
+        unresolved_count=0,
+    )
+
+    assert _capability(capabilities, "approve").blocked_by == ["review_author_unknown"]
+    with pytest.raises(ReviewPolicyError) as exc_info:
+        await ReviewPolicy.require_independent_reviewer(
+            db_session,
+            record,
+            candidate,
+            another_curator,
+            unresolved_count=0,
+            action="approve",
+        )
+    assert exc_info.value.code == "review_author_unknown"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "allowed"),
+    [
+        ("created", False),
+        ("draft_created", False),
+        ("draft_saved", False),
+        ("state_transition", True),
+    ],
+)
+async def test_only_content_events_create_contributor_blockers(
+    db_session,
+    curator_user,
+    another_curator,
+    event_type,
+    allowed,
+):
+    """Discussion and lifecycle events never turn an actor into a contributor."""
+    record, candidate = await _review_candidate(
+        db_session,
+        owner_id=curator_user.id,
+        submitter_id=curator_user.id,
+        contributor_id=another_curator.id,
+        contributor_event=event_type,
+    )
+
+    capabilities = await ReviewPolicy.evaluate(
+        db_session,
+        record,
+        candidate,
+        another_curator,
+        unresolved_count=0,
+    )
+
+    approve = _capability(capabilities, "approve")
+    assert approve.allowed is allowed
+    assert approve.blocked_by == ([] if allowed else ["reviewer_contributed"])
+
+
+@pytest.mark.asyncio
+async def test_viewer_has_no_review_actions(db_session, curator_user, viewer_user):
+    """Active viewers receive no private review mutation capabilities."""
+    record, candidate = await _review_candidate(
+        db_session,
+        owner_id=curator_user.id,
+        submitter_id=curator_user.id,
+    )
+
+    capabilities = await ReviewPolicy.evaluate(
+        db_session,
+        record,
+        candidate,
+        viewer_user,
+        unresolved_count=0,
+    )
+
+    assert capabilities.actions == []
+
+
+@pytest.mark.asyncio
+async def test_unresolved_issues_block_only_approval(
+    db_session, curator_user, another_curator
+):
+    """An eligible reviewer may request changes despite unresolved issues."""
+    record, candidate = await _review_candidate(
+        db_session,
+        owner_id=curator_user.id,
+        submitter_id=curator_user.id,
+    )
+
+    capabilities = await ReviewPolicy.evaluate(
+        db_session,
+        record,
+        candidate,
+        another_curator,
+        unresolved_count=3,
+    )
+
+    assert _capability(capabilities, "request_changes").allowed is True
+    assert _capability(capabilities, "request_changes").blocked_by == []
+    assert _capability(capabilities, "approve").allowed is False
+    assert _capability(capabilities, "approve").blocked_by == [
+        "unresolved_review_issues"
+    ]
+
+    with pytest.raises(ReviewPolicyError) as exc_info:
+        await ReviewPolicy.require_independent_reviewer(
+            db_session,
+            record,
+            candidate,
+            another_curator,
+            unresolved_count=3,
+            action="approve",
+        )
+    assert exc_info.value.context == {"unresolved_count": 3}
+
+
+@pytest.mark.asyncio
+async def test_contributor_scope_begins_after_published_head(
+    db_session, curator_user, another_curator
+):
+    """Content work at or before the public head does not poison a new cycle."""
+    record = Phenopacket(
+        phenopacket_id="review-policy-published-boundary",
+        phenopacket={"id": "review-policy-published-boundary"},
+        state="draft",
+        revision=1,
+        draft_owner_id=curator_user.id,
+        created_by_id=curator_user.id,
+    )
+    db_session.add(record)
+    await db_session.flush()
+    old_head = PhenopacketRevision(
+        record_id=record.id,
+        revision_number=1,
+        state="published",
+        content_jsonb={"id": "review-policy-published-boundary"},
+        change_reason="old cycle contribution",
+        actor_id=another_curator.id,
+        from_state="draft",
+        to_state="published",
+        event_type="draft_saved",
+    )
+    db_session.add(old_head)
+    await db_session.flush()
+    record.state = "published"
+    record.head_published_revision_id = old_head.id
+    await db_session.flush()
+
+    contribution = PhenopacketRevision(
+        record_id=record.id,
+        parent_revision_id=old_head.id,
+        revision_number=2,
+        state="draft",
+        content_jsonb={"id": "wave7-published-1", "changed": True},
+        change_reason="new cycle edit",
+        actor_id=curator_user.id,
+        from_state="published",
+        to_state="draft",
+        event_type="draft_created",
+    )
+    db_session.add(contribution)
+    await db_session.flush()
+    candidate = PhenopacketRevision(
+        record_id=record.id,
+        parent_revision_id=contribution.id,
+        revision_number=3,
+        state="in_review",
+        content_jsonb=contribution.content_jsonb,
+        change_reason="submit",
+        actor_id=curator_user.id,
+        from_state="draft",
+        to_state="in_review",
+        event_type="state_transition",
+    )
+    db_session.add(candidate)
+    await db_session.flush()
+    record.editing_revision_id = candidate.id
+    record.revision = 3
+    await db_session.flush()
+
+    capabilities = await ReviewPolicy.evaluate(
+        db_session,
+        record,
+        candidate,
+        another_curator,
+        unresolved_count=0,
+    )
+
+    assert _capability(capabilities, "approve").allowed is True
+
+
+@pytest.mark.asyncio
+async def test_closed_candidate_has_stable_review_closed_blocker(
+    db_session, curator_user, another_curator
+):
+    """A stale candidate is denied without exposing its content."""
+    record, candidate = await _review_candidate(
+        db_session,
+        owner_id=curator_user.id,
+        submitter_id=curator_user.id,
+        effective_state="changes_requested",
+    )
+    closed = PhenopacketRevision(
+        record_id=record.id,
+        parent_revision_id=candidate.id,
+        revision_number=2,
+        state="changes_requested",
+        content_jsonb=candidate.content_jsonb,
+        change_reason="review closed",
+        actor_id=another_curator.id,
+        from_state="in_review",
+        to_state="changes_requested",
+        event_type="state_transition",
+    )
+    db_session.add(closed)
+    await db_session.flush()
+    record.revision = 2
+    record.editing_revision_id = closed.id
+    await db_session.flush()
+
+    capabilities = await ReviewPolicy.evaluate(
+        db_session,
+        record,
+        candidate,
+        another_curator,
+        unresolved_count=0,
+    )
+
+    assert _capability(capabilities, "approve").blocked_by == ["review_closed"]
+
+
+@pytest.mark.asyncio
+async def test_approved_capabilities_allow_reopen_and_admin_publish(
+    db_session, curator_user, another_curator, admin_user
+):
+    """Approved candidates may be reopened; publication stays admin-only."""
+    record, candidate = await _review_candidate(
+        db_session,
+        owner_id=curator_user.id,
+        submitter_id=curator_user.id,
+    )
+    approved = PhenopacketRevision(
+        record_id=record.id,
+        parent_revision_id=candidate.id,
+        revision_number=2,
+        state="approved",
+        content_jsonb=candidate.content_jsonb,
+        change_reason="approve",
+        actor_id=admin_user.id,
+        from_state="in_review",
+        to_state="approved",
+        event_type="state_transition",
+    )
+    db_session.add(approved)
+    await db_session.flush()
+    record.state = "approved"
+    record.revision = 2
+    record.editing_revision_id = approved.id
+    await db_session.flush()
+
+    curator_capabilities = await ReviewPolicy.evaluate(
+        db_session,
+        record,
+        candidate,
+        another_curator,
+        unresolved_count=0,
+    )
+    admin_capabilities = await ReviewPolicy.evaluate(
+        db_session,
+        record,
+        candidate,
+        admin_user,
+        unresolved_count=0,
+    )
+
+    assert [item.action for item in curator_capabilities.actions] == ["request_changes"]
+    assert _capability(curator_capabilities, "request_changes").allowed is True
+    assert [item.action for item in admin_capabilities.actions] == [
+        "request_changes",
+        "publish",
+    ]
+    assert _capability(admin_capabilities, "publish").allowed is True

--- a/backend/tests/test_review_policy.py
+++ b/backend/tests/test_review_policy.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.phenopackets.models import Phenopacket, PhenopacketRevision
 from app.phenopackets.review.policy import ReviewPolicy, ReviewPolicyError
+from app.phenopackets.review.schemas import ActionCapability
 
 
 async def _review_candidate(
@@ -123,10 +124,10 @@ async def test_review_eligibility_matrix(
     assert approve.allowed is allowed
     assert (approve.blocked_by[0] if approve.blocked_by else None) == code
     if is_owner and contributed:
-        assert approve.blocked_by == [
+        assert approve.blocked_by == (
             "self_review_forbidden",
             "reviewer_contributed",
-        ]
+        )
 
 
 @pytest.mark.asyncio
@@ -146,7 +147,7 @@ async def test_null_owner_fails_closed(db_session, curator_user, another_curator
         unresolved_count=0,
     )
 
-    assert _capability(capabilities, "approve").blocked_by == ["review_author_unknown"]
+    assert _capability(capabilities, "approve").blocked_by == ("review_author_unknown",)
     with pytest.raises(ReviewPolicyError) as exc_info:
         await ReviewPolicy.require_independent_reviewer(
             db_session,
@@ -195,7 +196,28 @@ async def test_only_content_events_create_contributor_blockers(
 
     approve = _capability(capabilities, "approve")
     assert approve.allowed is allowed
-    assert approve.blocked_by == ([] if allowed else ["reviewer_contributed"])
+    assert approve.blocked_by == (() if allowed else ("reviewer_contributed",))
+
+
+def test_action_capability_blockers_are_deeply_immutable_and_serialize_as_array():
+    """The Python collection cannot mutate while the wire DTO stays an array."""
+    capability = ActionCapability(
+        action="approve",
+        allowed=False,
+        blocked_by=["self_review_forbidden", "reviewer_contributed"],
+    )
+
+    with pytest.raises(AttributeError):
+        capability.blocked_by.append("review_closed")
+
+    assert capability.blocked_by == (
+        "self_review_forbidden",
+        "reviewer_contributed",
+    )
+    assert capability.model_dump(mode="json")["blocked_by"] == [
+        "self_review_forbidden",
+        "reviewer_contributed",
+    ]
 
 
 @pytest.mark.asyncio
@@ -238,11 +260,11 @@ async def test_unresolved_issues_block_only_approval(
     )
 
     assert _capability(capabilities, "request_changes").allowed is True
-    assert _capability(capabilities, "request_changes").blocked_by == []
+    assert _capability(capabilities, "request_changes").blocked_by == ()
     assert _capability(capabilities, "approve").allowed is False
-    assert _capability(capabilities, "approve").blocked_by == [
-        "unresolved_review_issues"
-    ]
+    assert _capability(capabilities, "approve").blocked_by == (
+        "unresolved_review_issues",
+    )
 
     with pytest.raises(ReviewPolicyError) as exc_info:
         await ReviewPolicy.require_independent_reviewer(
@@ -368,7 +390,7 @@ async def test_closed_candidate_has_stable_review_closed_blocker(
         unresolved_count=0,
     )
 
-    assert _capability(capabilities, "approve").blocked_by == ["review_closed"]
+    assert _capability(capabilities, "approve").blocked_by == ("review_closed",)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_review_policy.py
+++ b/backend/tests/test_review_policy.py
@@ -444,3 +444,98 @@ async def test_approved_capabilities_allow_reopen_and_admin_publish(
         "publish",
     ]
     assert _capability(admin_capabilities, "publish").allowed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("effective_state", "action", "allowed"),
+    [
+        ("in_review", "create", True),
+        ("in_review", "resolve", True),
+        ("in_review", "reopen", True),
+        ("changes_requested", "create", False),
+        ("changes_requested", "resolve", True),
+        ("changes_requested", "reopen", True),
+        ("approved", "resolve", False),
+    ],
+)
+async def test_issue_action_policy_uses_effective_state_and_exact_candidate(
+    db_session,
+    curator_user,
+    another_curator,
+    effective_state,
+    action,
+    allowed,
+):
+    """Issue actions stay open only in their specified active-cycle states."""
+    record, candidate = await _review_candidate(
+        db_session,
+        owner_id=curator_user.id,
+        submitter_id=curator_user.id,
+    )
+    if effective_state != "in_review":
+        active = PhenopacketRevision(
+            record_id=record.id,
+            parent_revision_id=candidate.id,
+            revision_number=2,
+            state=effective_state,
+            content_jsonb=candidate.content_jsonb,
+            change_reason=effective_state,
+            actor_id=another_curator.id,
+            from_state="in_review",
+            to_state=effective_state,
+            event_type="state_transition",
+        )
+        db_session.add(active)
+        await db_session.flush()
+        record.revision = 2
+        record.editing_revision_id = active.id
+        await db_session.flush()
+
+    if allowed:
+        await ReviewPolicy.require_issue_action(
+            db_session,
+            record,
+            candidate,
+            another_curator,
+            action=action,
+        )
+    else:
+        with pytest.raises(ReviewPolicyError) as exc_info:
+            await ReviewPolicy.require_issue_action(
+                db_session,
+                record,
+                candidate,
+                another_curator,
+                action=action,
+            )
+        assert exc_info.value.code == "review_closed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_admin", [False, True], ids=["curator", "admin"])
+async def test_issue_action_policy_never_allows_owner_admin_bypass(
+    db_session,
+    curator_user,
+    another_curator,
+    admin_user,
+    use_admin,
+):
+    """Draft ownership blocks issue actions even when the owner is an admin."""
+    actor = admin_user if use_admin else curator_user
+    record, candidate = await _review_candidate(
+        db_session,
+        owner_id=actor.id,
+        submitter_id=another_curator.id,
+    )
+
+    with pytest.raises(ReviewPolicyError) as exc_info:
+        await ReviewPolicy.require_issue_action(
+            db_session,
+            record,
+            candidate,
+            actor,
+            action="resolve",
+        )
+
+    assert exc_info.value.code == "self_review_forbidden"

--- a/backend/tests/test_review_policy.py
+++ b/backend/tests/test_review_policy.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import uuid
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -32,11 +35,26 @@ async def _review_candidate(
     db_session.add(record)
     await db_session.flush()
 
-    parent_id = None
+    root = PhenopacketRevision(
+        record_id=record.id,
+        revision_number=1,
+        state="draft",
+        content_jsonb={"id": "review-policy"},
+        change_reason="create",
+        actor_id=owner_id or submitter_id,
+        from_state=None,
+        to_state="draft",
+        event_type="created",
+    )
+    db_session.add(root)
+    await db_session.flush()
+
+    parent_id = root.id
     if contributor_id is not None:
         contribution = PhenopacketRevision(
             record_id=record.id,
-            revision_number=1,
+            parent_revision_id=parent_id,
+            revision_number=2,
             state="draft",
             content_jsonb={"id": "review-policy", "saved": True},
             change_reason="content contribution",
@@ -52,7 +70,7 @@ async def _review_candidate(
     candidate = PhenopacketRevision(
         record_id=record.id,
         parent_revision_id=parent_id,
-        revision_number=2 if contributor_id is not None else 1,
+        revision_number=3 if contributor_id is not None else 2,
         state="in_review",
         content_jsonb={"id": "review-policy", "saved": contributor_id is not None},
         change_reason="submit for review",
@@ -367,7 +385,7 @@ async def test_closed_candidate_has_stable_review_closed_blocker(
     closed = PhenopacketRevision(
         record_id=record.id,
         parent_revision_id=candidate.id,
-        revision_number=2,
+        revision_number=candidate.revision_number + 1,
         state="changes_requested",
         content_jsonb=candidate.content_jsonb,
         change_reason="review closed",
@@ -378,7 +396,7 @@ async def test_closed_candidate_has_stable_review_closed_blocker(
     )
     db_session.add(closed)
     await db_session.flush()
-    record.revision = 2
+    record.revision = closed.revision_number
     record.editing_revision_id = closed.id
     await db_session.flush()
 
@@ -406,7 +424,7 @@ async def test_approved_capabilities_allow_reopen_and_admin_publish(
     approved = PhenopacketRevision(
         record_id=record.id,
         parent_revision_id=candidate.id,
-        revision_number=2,
+        revision_number=candidate.revision_number + 1,
         state="approved",
         content_jsonb=candidate.content_jsonb,
         change_reason="approve",
@@ -418,7 +436,7 @@ async def test_approved_capabilities_allow_reopen_and_admin_publish(
     db_session.add(approved)
     await db_session.flush()
     record.state = "approved"
-    record.revision = 2
+    record.revision = approved.revision_number
     record.editing_revision_id = approved.id
     await db_session.flush()
 
@@ -477,7 +495,7 @@ async def test_issue_action_policy_uses_effective_state_and_exact_candidate(
         active = PhenopacketRevision(
             record_id=record.id,
             parent_revision_id=candidate.id,
-            revision_number=2,
+            revision_number=candidate.revision_number + 1,
             state=effective_state,
             content_jsonb=candidate.content_jsonb,
             change_reason=effective_state,
@@ -488,7 +506,7 @@ async def test_issue_action_policy_uses_effective_state_and_exact_candidate(
         )
         db_session.add(active)
         await db_session.flush()
-        record.revision = 2
+        record.revision = active.revision_number
         record.editing_revision_id = active.id
         await db_session.flush()
 
@@ -539,3 +557,54 @@ async def test_issue_action_policy_never_allows_owner_admin_bypass(
         )
 
     assert exc_info.value.code == "self_review_forbidden"
+
+
+@pytest.mark.asyncio
+async def test_issue_action_rejects_candidate_before_broken_active_cycle_root():
+    """Seeing the issue candidate is insufficient if its remaining ancestry is bad."""
+    record_id = uuid.uuid4()
+    candidate = SimpleNamespace(
+        id=2,
+        record_id=record_id,
+        parent_revision_id=99,
+        revision_number=2,
+        state="in_review",
+        event_type="state_transition",
+        actor_id=1,
+    )
+    active = SimpleNamespace(
+        id=5,
+        record_id=record_id,
+        parent_revision_id=2,
+        revision_number=5,
+        state="in_review",
+        event_type="state_transition",
+        actor_id=1,
+    )
+    record = SimpleNamespace(
+        id=record_id,
+        state="in_review",
+        editing_revision_id=active.id,
+        head_published_revision_id=None,
+        draft_owner_id=1,
+    )
+    actor = SimpleNamespace(id=2, is_active=True, role="curator")
+    query_result = MagicMock()
+    query_result.scalar_one_or_none.return_value = None
+    db = SimpleNamespace(
+        get=AsyncMock(
+            side_effect=lambda _model, key: {2: candidate, 5: active}.get(key)
+        ),
+        execute=AsyncMock(return_value=query_result),
+    )
+
+    with pytest.raises(ReviewPolicyError) as exc_info:
+        await ReviewPolicy.require_issue_action(
+            db,
+            record,
+            candidate,
+            actor,
+            action="resolve",
+        )
+
+    assert exc_info.value.code == "review_closed"

--- a/backend/tests/test_revision_immutability.py
+++ b/backend/tests/test_revision_immutability.py
@@ -3,8 +3,26 @@
 import pytest
 from sqlalchemy import select
 
-from app.phenopackets.models import PhenopacketRevision
+from app.phenopackets.models import ApprovalAttestation, PhenopacketRevision
 from app.phenopackets.services.state_service import PhenopacketStateService
+
+
+def _approval_fields(candidate: PhenopacketRevision) -> dict:
+    return {
+        "candidate_revision_id": candidate.id,
+        "candidate_content_sha256": candidate.content_sha256,
+        "attestation": ApprovalAttestation(
+            independent_review=True,
+            no_unmanaged_conflict=True,
+        ),
+    }
+
+
+def _publication_fields(approved: PhenopacketRevision) -> dict:
+    return {
+        "approved_revision_id": approved.id,
+        "approved_content_sha256": approved.content_sha256,
+    }
 
 
 @pytest.mark.asyncio
@@ -65,7 +83,7 @@ async def test_publish_appends_a_new_head_without_rewriting_approved_revision(
         expected_revision=published_record.revision,
         actor=curator_user,
     )
-    record, _ = await service.transition(
+    record, candidate = await service.transition(
         record.id,
         to_state="in_review",
         reason="review",
@@ -78,6 +96,7 @@ async def test_publish_appends_a_new_head_without_rewriting_approved_revision(
         reason="approve",
         expected_revision=record.revision,
         actor=admin_user,
+        **_approval_fields(candidate),
     )
     approved_id = approved.id
     record, published = await service.transition(
@@ -86,6 +105,7 @@ async def test_publish_appends_a_new_head_without_rewriting_approved_revision(
         reason="publish",
         expected_revision=record.revision,
         actor=admin_user,
+        **_publication_fields(approved),
     )
 
     reloaded_approved = (
@@ -98,6 +118,10 @@ async def test_publish_appends_a_new_head_without_rewriting_approved_revision(
     assert record.head_published_revision_id != original_head_id
     assert reloaded_approved.state == "approved"
     assert reloaded_approved.to_state == "approved"
+    assert approved.parent_revision_id == candidate.id
+    assert approved.content_jsonb == candidate.content_jsonb
+    assert published.parent_revision_id == approved.id
+    assert published.content_jsonb == approved.content_jsonb
 
 
 @pytest.mark.asyncio
@@ -152,7 +176,7 @@ async def test_publish_uses_the_current_editing_revision_not_historic_approval(
         expected_revision=published_record.revision,
         actor=curator_user,
     )
-    record, _ = await service.transition(
+    record, candidate = await service.transition(
         record.id,
         to_state="in_review",
         reason="review",
@@ -165,6 +189,7 @@ async def test_publish_uses_the_current_editing_revision_not_historic_approval(
         reason="approve",
         expected_revision=record.revision,
         actor=admin_user,
+        **_approval_fields(candidate),
     )
 
     record, published = await service.transition(
@@ -173,6 +198,7 @@ async def test_publish_uses_the_current_editing_revision_not_historic_approval(
         reason="publish",
         expected_revision=record.revision,
         actor=admin_user,
+        **_publication_fields(approved),
     )
 
     assert published.parent_revision_id == approved.id

--- a/backend/tests/test_revision_ledger_v2.py
+++ b/backend/tests/test_revision_ledger_v2.py
@@ -50,12 +50,21 @@ def test_content_digest_covers_extension_fields_and_ignores_key_order() -> None:
         "hnf1bCuration": {"flag": False},
         "unknownExtension": {"source": "registry"},
     }
+    changed_unknown_extension = {
+        "subject": {"id": "1"},
+        "hnf1bCuration": {"flag": True},
+        "unknownExtension": {"source": "publication"},
+    }
 
     digest = content_sha256(left)
 
     assert re.fullmatch(r"sha256:[0-9a-f]{64}", digest)
+    assert content_sha256({"label": "Müller", "subject": {"id": "1"}}) == (
+        "sha256:ebbb266d0272fd333d6b903df186114ae41449fd2c5c3c25a893c5c90d859e17"
+    )
     assert digest == content_sha256(reordered)
     assert digest != content_sha256(changed)
+    assert digest != content_sha256(changed_unknown_extension)
 
 
 def test_builder_returns_complete_v2_payload_with_explicit_optional_fields() -> None:

--- a/backend/tests/test_revision_ledger_v2.py
+++ b/backend/tests/test_revision_ledger_v2.py
@@ -1,0 +1,111 @@
+"""Regression tests for the version-two revision ledger payload."""
+
+from __future__ import annotations
+
+import re
+
+from app.phenopackets.services.revision_ledger import (
+    build_ledger_v2_payload,
+    content_sha256,
+    ledger_sha256,
+)
+
+
+def build_fixture_payload() -> dict[str, object]:
+    """Build a complete, representative version-two ledger payload."""
+    return build_ledger_v2_payload(
+        parent_revision_id=41,
+        revision_number=42,
+        state="approved",
+        event_type="approve",
+        from_state="in_review",
+        to_state="approved",
+        change_reason="Independent review approved the candidate.",
+        change_patch=[{"op": "replace", "path": "/subject/id", "value": "P-42"}],
+        content_sha256="sha256:" + "a" * 64,
+        projection_hash="legacy-projection-hash",
+        actor_id=7,
+        actor_role="curator",
+        decision_metadata={
+            "attestation": {"reviewer": "reviewer-7", "accepted": True},
+            "independentReview": True,
+        },
+    )
+
+
+def test_content_digest_covers_extension_fields_and_ignores_key_order() -> None:
+    """Full content, including extensions, is canonicalized before hashing."""
+    left = {
+        "subject": {"id": "1"},
+        "hnf1bCuration": {"flag": True},
+        "unknownExtension": {"source": "registry"},
+    }
+    reordered = {
+        "unknownExtension": {"source": "registry"},
+        "hnf1bCuration": {"flag": True},
+        "subject": {"id": "1"},
+    }
+    changed = {
+        "subject": {"id": "1"},
+        "hnf1bCuration": {"flag": False},
+        "unknownExtension": {"source": "registry"},
+    }
+
+    digest = content_sha256(left)
+
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", digest)
+    assert digest == content_sha256(reordered)
+    assert digest != content_sha256(changed)
+
+
+def test_builder_returns_complete_v2_payload_with_explicit_optional_fields() -> None:
+    """The builder fixes the complete, versioned payload contract."""
+    payload = build_ledger_v2_payload(
+        parent_revision_id=None,
+        revision_number=1,
+        state="draft",
+        event_type="created",
+        from_state=None,
+        to_state="draft",
+        change_reason="Initial creation",
+        change_patch=None,
+        content_sha256="sha256:" + "b" * 64,
+        projection_hash=None,
+        actor_id=7,
+        actor_role=None,
+        decision_metadata=None,
+    )
+
+    assert payload == {
+        "ledger_version": 2,
+        "parent_revision_id": None,
+        "revision_number": 1,
+        "state": "draft",
+        "event_type": "created",
+        "from_state": None,
+        "to_state": "draft",
+        "change_reason": "Initial creation",
+        "change_patch": None,
+        "content_sha256": "sha256:" + "b" * 64,
+        "projection_hash": None,
+        "actor_id": 7,
+        "actor_role": None,
+        "decision_metadata": None,
+    }
+
+
+def test_v2_ledger_hash_changes_with_role_or_decision_metadata() -> None:
+    """Actor role and canonical decision metadata are ledger evidence."""
+    base = build_fixture_payload()
+    reordered_metadata = {
+        "independentReview": True,
+        "attestation": {"accepted": True, "reviewer": "reviewer-7"},
+    }
+
+    assert ledger_sha256(base) == ledger_sha256(
+        {**base, "decision_metadata": reordered_metadata}
+    )
+    assert ledger_sha256(base) != ledger_sha256({**base, "actor_role": "admin"})
+    assert ledger_sha256(base) != ledger_sha256(
+        {**base, "decision_metadata": {"independentReview": True}}
+    )

--- a/backend/tests/test_state_flows.py
+++ b/backend/tests/test_state_flows.py
@@ -15,7 +15,7 @@ import pytest
 from sqlalchemy import select
 
 from app.comments.models import Comment
-from app.phenopackets.models import PhenopacketRevision
+from app.phenopackets.models import Phenopacket, PhenopacketRevision
 from app.phenopackets.review.policy import ReviewPolicyError
 from app.phenopackets.services.state_service import PhenopacketStateService
 
@@ -523,6 +523,173 @@ async def test_approved_candidate_can_be_reopened_by_independent_curator(
 
     assert reopened.from_state == "approved"
     assert reopened.to_state == "changes_requested"
+
+
+async def _approved_chain_with_competing_submission(
+    db_session,
+    *,
+    owner,
+    candidate_submitter,
+    approver,
+    parent_case: str,
+):
+    """Persist an approved row plus a disconnected, later-numbered submission."""
+    record = Phenopacket(
+        phenopacket_id=f"approved-parent-{parent_case}",
+        phenopacket={"id": f"approved-parent-{parent_case}"},
+        state="draft",
+        revision=0,
+        draft_owner_id=owner.id,
+        created_by_id=owner.id,
+    )
+    db_session.add(record)
+    await db_session.flush()
+
+    created = PhenopacketRevision(
+        record_id=record.id,
+        revision_number=1,
+        state="draft",
+        content_jsonb=record.phenopacket,
+        change_reason="created",
+        actor_id=owner.id,
+        from_state=None,
+        to_state="draft",
+        event_type="created",
+    )
+    db_session.add(created)
+    await db_session.flush()
+    inspected = PhenopacketRevision(
+        record_id=record.id,
+        parent_revision_id=created.id,
+        revision_number=2,
+        state="in_review",
+        content_jsonb=record.phenopacket,
+        change_reason="actual candidate",
+        actor_id=candidate_submitter.id,
+        from_state="draft",
+        to_state="in_review",
+        event_type="state_transition",
+    )
+    db_session.add(inspected)
+    await db_session.flush()
+    disconnected = PhenopacketRevision(
+        record_id=record.id,
+        parent_revision_id=created.id,
+        revision_number=3,
+        state="in_review",
+        content_jsonb=record.phenopacket,
+        change_reason="disconnected candidate",
+        actor_id=owner.id,
+        from_state="draft",
+        to_state="in_review",
+        event_type="state_transition",
+    )
+    db_session.add(disconnected)
+    await db_session.flush()
+
+    if parent_case == "valid":
+        approved_parent_id = inspected.id
+    elif parent_case == "missing":
+        approved_parent_id = None
+    elif parent_case == "wrong_state":
+        approved_parent_id = created.id
+    elif parent_case == "non_prior":
+        non_prior = PhenopacketRevision(
+            record_id=record.id,
+            parent_revision_id=disconnected.id,
+            revision_number=100,
+            state="in_review",
+            content_jsonb=record.phenopacket,
+            change_reason="non-prior parent",
+            actor_id=owner.id,
+            from_state="draft",
+            to_state="in_review",
+            event_type="state_transition",
+        )
+        db_session.add(non_prior)
+        await db_session.flush()
+        approved_parent_id = non_prior.id
+    else:
+        raise AssertionError(f"unknown parent case: {parent_case}")
+
+    approved = PhenopacketRevision(
+        record_id=record.id,
+        parent_revision_id=approved_parent_id,
+        revision_number=4,
+        state="approved",
+        content_jsonb=record.phenopacket,
+        change_reason="approved",
+        actor_id=approver.id,
+        from_state="in_review",
+        to_state="approved",
+        event_type="state_transition",
+    )
+    db_session.add(approved)
+    await db_session.flush()
+    record.state = "approved"
+    record.revision = 4
+    record.editing_revision_id = approved.id
+    await db_session.flush()
+    return record
+
+
+@pytest.mark.asyncio
+async def test_approved_reopen_uses_direct_parent_candidate_submitter(
+    db_session, curator_user, another_curator, admin_user
+):
+    """A disconnected later submission cannot hide the inspected submitter."""
+    record = await _approved_chain_with_competing_submission(
+        db_session,
+        owner=curator_user,
+        candidate_submitter=admin_user,
+        approver=another_curator,
+        parent_case="valid",
+    )
+    svc = PhenopacketStateService(db_session)
+
+    with pytest.raises(ReviewPolicyError) as exc_info:
+        await svc.transition(
+            record.id,
+            to_state="changes_requested",
+            reason="attempt submitter reopen",
+            expected_revision=4,
+            actor=admin_user,
+        )
+
+    assert exc_info.value.code == "reviewer_submitted"
+    assert record.revision == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("parent_case", ["missing", "wrong_state", "non_prior"])
+async def test_approved_reopen_fails_closed_for_invalid_direct_parent(
+    db_session,
+    curator_user,
+    another_curator,
+    admin_user,
+    parent_case,
+):
+    """Approved ancestry is never reconstructed from revision ordering."""
+    record = await _approved_chain_with_competing_submission(
+        db_session,
+        owner=curator_user,
+        candidate_submitter=curator_user,
+        approver=admin_user,
+        parent_case=parent_case,
+    )
+    svc = PhenopacketStateService(db_session)
+
+    with pytest.raises(ReviewPolicyError) as exc_info:
+        await svc.transition(
+            record.id,
+            to_state="changes_requested",
+            reason="invalid ancestry",
+            expected_revision=4,
+            actor=another_curator,
+        )
+
+    assert exc_info.value.code == "review_author_unknown"
+    assert record.revision == 4
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_state_flows.py
+++ b/backend/tests/test_state_flows.py
@@ -14,7 +14,9 @@ and shared with test_state_invariants.py (Nit #3).
 import pytest
 from sqlalchemy import select
 
+from app.comments.models import Comment
 from app.phenopackets.models import PhenopacketRevision
+from app.phenopackets.review.policy import ReviewPolicyError
 from app.phenopackets.services.state_service import PhenopacketStateService
 
 # ---------------------------------------------------------------------------
@@ -402,13 +404,10 @@ async def test_transition_revision_mismatch(db_session, draft_record, curator_us
 
 
 @pytest.mark.asyncio
-async def test_transition_forbidden_role(db_session, draft_record, curator_user):
-    """§6.4: curator cannot approve — raises PermissionError (forbidden_role).
-
-    The guard-matrix maps curator→approve to the 'forbidden_role' code, which
-    the service translates to PermissionError (not ForbiddenNotOwner, which is
-    reserved for the 'forbidden_not_owner' code path).
-    """
+async def test_direct_transition_cannot_bypass_independent_review(
+    db_session, draft_record, curator_user
+):
+    """The state service rejects an owner's direct self-approval attempt."""
     svc = PhenopacketStateService(db_session)
     # submit first to reach in_review
     await svc.transition(
@@ -418,7 +417,7 @@ async def test_transition_forbidden_role(db_session, draft_record, curator_user)
         expected_revision=1,
         actor=curator_user,
     )
-    with pytest.raises(PermissionError):
+    with pytest.raises(ReviewPolicyError) as exc_info:
         await svc.transition(
             draft_record.id,
             to_state="approved",
@@ -426,6 +425,104 @@ async def test_transition_forbidden_role(db_session, draft_record, curator_user)
             expected_revision=2,
             actor=curator_user,
         )
+    assert exc_info.value.code == "self_review_forbidden"
+    assert draft_record.revision == 2
+
+
+@pytest.mark.asyncio
+async def test_eligible_curator_can_request_changes_directly(
+    db_session, draft_record, curator_user, another_curator
+):
+    """A non-contributing curator may make a review decision through the service."""
+    svc = PhenopacketStateService(db_session)
+    await svc.transition(
+        draft_record.id,
+        to_state="in_review",
+        reason="ready",
+        expected_revision=1,
+        actor=curator_user,
+    )
+
+    _, decision = await svc.transition(
+        draft_record.id,
+        to_state="changes_requested",
+        reason="clarify evidence",
+        expected_revision=2,
+        actor=another_curator,
+    )
+
+    assert decision.state == "changes_requested"
+    assert decision.actor_id == another_curator.id
+
+
+@pytest.mark.asyncio
+async def test_unresolved_review_issue_blocks_direct_approval(
+    db_session, draft_record, curator_user, another_curator
+):
+    """The locked service derives the unresolved count from real issue rows."""
+    svc = PhenopacketStateService(db_session)
+    _, candidate = await svc.transition(
+        draft_record.id,
+        to_state="in_review",
+        reason="ready",
+        expected_revision=1,
+        actor=curator_user,
+    )
+    db_session.add(
+        Comment(
+            record_type="phenopacket",
+            record_id=draft_record.id,
+            author_id=another_curator.id,
+            body_markdown="Blocking review issue",
+            review_revision_id=candidate.id,
+        )
+    )
+    await db_session.flush()
+
+    with pytest.raises(ReviewPolicyError) as exc_info:
+        await svc.transition(
+            draft_record.id,
+            to_state="approved",
+            reason="cannot approve yet",
+            expected_revision=2,
+            actor=another_curator,
+        )
+
+    assert exc_info.value.code == "unresolved_review_issues"
+    assert exc_info.value.context == {"unresolved_count": 1}
+
+
+@pytest.mark.asyncio
+async def test_approved_candidate_can_be_reopened_by_independent_curator(
+    db_session, draft_record, curator_user, another_curator, admin_user
+):
+    """An eligible independent curator can reopen approval before publication."""
+    svc = PhenopacketStateService(db_session)
+    await svc.transition(
+        draft_record.id,
+        to_state="in_review",
+        reason="ready",
+        expected_revision=1,
+        actor=curator_user,
+    )
+    await svc.transition(
+        draft_record.id,
+        to_state="approved",
+        reason="reviewed",
+        expected_revision=2,
+        actor=admin_user,
+    )
+
+    _, reopened = await svc.transition(
+        draft_record.id,
+        to_state="changes_requested",
+        reason="new concern",
+        expected_revision=3,
+        actor=another_curator,
+    )
+
+    assert reopened.from_state == "approved"
+    assert reopened.to_state == "changes_requested"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_state_flows.py
+++ b/backend/tests/test_state_flows.py
@@ -15,9 +15,34 @@ import pytest
 from sqlalchemy import select
 
 from app.comments.models import Comment
-from app.phenopackets.models import Phenopacket, PhenopacketRevision
+from app.phenopackets.models import (
+    ApprovalAttestation,
+    Phenopacket,
+    PhenopacketRevision,
+)
 from app.phenopackets.review.policy import ReviewPolicyError
 from app.phenopackets.services.state_service import PhenopacketStateService
+
+
+def _approval_fields(candidate: PhenopacketRevision) -> dict:
+    """Echo the exact candidate identity and affirmative review attestation."""
+    return {
+        "candidate_revision_id": candidate.id,
+        "candidate_content_sha256": candidate.content_sha256,
+        "attestation": ApprovalAttestation(
+            independent_review=True,
+            no_unmanaged_conflict=True,
+        ),
+    }
+
+
+def _publication_fields(approved: PhenopacketRevision) -> dict:
+    """Echo the exact approved snapshot identity."""
+    return {
+        "approved_revision_id": approved.id,
+        "approved_content_sha256": approved.content_sha256,
+    }
+
 
 # ---------------------------------------------------------------------------
 # §6.1 — clone-to-draft on a published record
@@ -312,7 +337,7 @@ async def test_full_lifecycle(db_session, draft_record, curator_user, admin_user
     svc = PhenopacketStateService(db_session)
 
     # submit
-    await svc.transition(
+    _, candidate = await svc.transition(
         draft_record.id,
         to_state="in_review",
         reason="ready",
@@ -325,12 +350,13 @@ async def test_full_lifecycle(db_session, draft_record, curator_user, admin_user
     assert draft_record.draft_owner_id == curator_user.id  # preserved through submit
 
     # approve
-    await svc.transition(
+    _, approved = await svc.transition(
         draft_record.id,
         to_state="approved",
         reason="ok",
         expected_revision=draft_record.revision,
         actor=admin_user,
+        **_approval_fields(candidate),
     )
     await db_session.flush()
     await db_session.refresh(draft_record)
@@ -343,6 +369,7 @@ async def test_full_lifecycle(db_session, draft_record, curator_user, admin_user
         reason="go live",
         expected_revision=draft_record.revision,
         actor=admin_user,
+        **_publication_fields(approved),
     )
     await db_session.flush()
     await db_session.refresh(draft_record)
@@ -410,7 +437,7 @@ async def test_direct_transition_cannot_bypass_independent_review(
     """The state service rejects an owner's direct self-approval attempt."""
     svc = PhenopacketStateService(db_session)
     # submit first to reach in_review
-    await svc.transition(
+    _, candidate = await svc.transition(
         draft_record.id,
         to_state="in_review",
         reason="go",
@@ -424,6 +451,7 @@ async def test_direct_transition_cannot_bypass_independent_review(
             reason="self-approve",
             expected_revision=2,
             actor=curator_user,
+            **_approval_fields(candidate),
         )
     assert exc_info.value.code == "self_review_forbidden"
     assert draft_record.revision == 2
@@ -486,6 +514,7 @@ async def test_unresolved_review_issue_blocks_direct_approval(
             reason="cannot approve yet",
             expected_revision=2,
             actor=another_curator,
+            **_approval_fields(candidate),
         )
 
     assert exc_info.value.code == "unresolved_review_issues"
@@ -498,7 +527,7 @@ async def test_approved_candidate_can_be_reopened_by_independent_curator(
 ):
     """An eligible independent curator can reopen approval before publication."""
     svc = PhenopacketStateService(db_session)
-    await svc.transition(
+    _, candidate = await svc.transition(
         draft_record.id,
         to_state="in_review",
         reason="ready",
@@ -511,6 +540,7 @@ async def test_approved_candidate_can_be_reopened_by_independent_curator(
         reason="reviewed",
         expected_revision=2,
         actor=admin_user,
+        **_approval_fields(candidate),
     )
 
     _, reopened = await svc.transition(

--- a/backend/tests/test_state_invariants.py
+++ b/backend/tests/test_state_invariants.py
@@ -23,8 +23,31 @@ from app.phenopackets.curation.import_models import (
     SourceImportRun,
     SourceSnapshot,
 )
-from app.phenopackets.models import Phenopacket, PhenopacketRevision
+from app.phenopackets.models import (
+    ApprovalAttestation,
+    Phenopacket,
+    PhenopacketRevision,
+)
 from app.phenopackets.services.state_service import PhenopacketStateService
+
+
+def _approval_fields(candidate: PhenopacketRevision) -> dict:
+    return {
+        "candidate_revision_id": candidate.id,
+        "candidate_content_sha256": candidate.content_sha256,
+        "attestation": ApprovalAttestation(
+            independent_review=True,
+            no_unmanaged_conflict=True,
+        ),
+    }
+
+
+def _publication_fields(approved: PhenopacketRevision) -> dict:
+    return {
+        "approved_revision_id": approved.id,
+        "approved_content_sha256": approved.content_sha256,
+    }
+
 
 # ---------------------------------------------------------------------------
 # I1 — state='published' does NOT imply working copy == public copy
@@ -127,7 +150,7 @@ async def test_I2_at_most_one_head_published_per_record(
     svc = PhenopacketStateService(db_session)
 
     # submit → approve → publish
-    await svc.transition(
+    _, candidate = await svc.transition(
         draft_record.id,
         to_state="in_review",
         reason="r",
@@ -136,12 +159,13 @@ async def test_I2_at_most_one_head_published_per_record(
     )
     await db_session.flush()
     await db_session.refresh(draft_record)
-    await svc.transition(
+    _, approved = await svc.transition(
         draft_record.id,
         to_state="approved",
         reason="r",
         expected_revision=draft_record.revision,
         actor=admin_user,
+        **_approval_fields(candidate),
     )
     await db_session.flush()
     await db_session.refresh(draft_record)
@@ -151,6 +175,7 @@ async def test_I2_at_most_one_head_published_per_record(
         reason="r",
         expected_revision=draft_record.revision,
         actor=admin_user,
+        **_publication_fields(approved),
     )
     await db_session.flush()
 
@@ -245,7 +270,7 @@ async def test_I5b_draft_owner_cleared_on_publish(
     """I5b: publishing clears draft_owner_id (per spec §6.2 step 11)."""
     svc = PhenopacketStateService(db_session)
 
-    await svc.transition(
+    _, candidate = await svc.transition(
         draft_record.id,
         to_state="in_review",
         reason="r",
@@ -254,12 +279,13 @@ async def test_I5b_draft_owner_cleared_on_publish(
     )
     await db_session.flush()
     await db_session.refresh(draft_record)
-    await svc.transition(
+    _, approved = await svc.transition(
         draft_record.id,
         to_state="approved",
         reason="r",
         expected_revision=draft_record.revision,
         actor=admin_user,
+        **_approval_fields(candidate),
     )
     await db_session.flush()
     await db_session.refresh(draft_record)
@@ -269,6 +295,7 @@ async def test_I5b_draft_owner_cleared_on_publish(
         reason="r",
         expected_revision=draft_record.revision,
         actor=admin_user,
+        **_publication_fields(approved),
     )
     await db_session.flush()
     await db_session.refresh(draft_record)

--- a/backend/tests/test_state_model.py
+++ b/backend/tests/test_state_model.py
@@ -184,6 +184,80 @@ def test_transition_request_rejects_bad_state() -> None:
         TransitionRequest(to_state="not_a_state", reason="x", revision=1)  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize(
+    ("base_payload", "irrelevant_field"),
+    [
+        (
+            {
+                "to_state": "approved",
+                "candidate_revision_id": 1,
+                "candidate_content_sha256": "sha256:" + "1" * 64,
+                "attestation": {
+                    "independent_review": True,
+                    "no_unmanaged_conflict": True,
+                },
+            },
+            "approved_revision_id",
+        ),
+        (
+            {
+                "to_state": "approved",
+                "candidate_revision_id": 1,
+                "candidate_content_sha256": "sha256:" + "1" * 64,
+                "attestation": {
+                    "independent_review": True,
+                    "no_unmanaged_conflict": True,
+                },
+            },
+            "approved_content_sha256",
+        ),
+        (
+            {
+                "to_state": "published",
+                "approved_revision_id": 2,
+                "approved_content_sha256": "sha256:" + "2" * 64,
+            },
+            "candidate_revision_id",
+        ),
+        (
+            {
+                "to_state": "published",
+                "approved_revision_id": 2,
+                "approved_content_sha256": "sha256:" + "2" * 64,
+            },
+            "candidate_content_sha256",
+        ),
+        (
+            {
+                "to_state": "published",
+                "approved_revision_id": 2,
+                "approved_content_sha256": "sha256:" + "2" * 64,
+            },
+            "attestation",
+        ),
+        ({"to_state": "in_review"}, "candidate_revision_id"),
+        ({"to_state": "in_review"}, "candidate_content_sha256"),
+        ({"to_state": "in_review"}, "approved_revision_id"),
+        ({"to_state": "in_review"}, "approved_content_sha256"),
+        ({"to_state": "in_review"}, "attestation"),
+    ],
+)
+def test_transition_request_rejects_explicit_null_irrelevant_fields(
+    base_payload: dict,
+    irrelevant_field: str,
+) -> None:
+    """Explicit null is still field presence and cannot cross discriminants."""
+    with pytest.raises(ValueError):
+        TransitionRequest.model_validate(
+            {
+                "reason": "reject irrelevant null",
+                "revision": 1,
+                **base_payload,
+                irrelevant_field: None,
+            }
+        )
+
+
 def test_revision_response_schema() -> None:
     """RevisionResponse accepts a full set of fields."""
     from datetime import datetime

--- a/backend/tests/test_state_service_clone_cycle_full.py
+++ b/backend/tests/test_state_service_clone_cycle_full.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from app.phenopackets.models import ApprovalAttestation
 from app.phenopackets.services.state_service import PhenopacketStateService
 
 
@@ -23,7 +24,7 @@ async def test_full_clone_cycle_republish(
         actor=curator_user,
     )
     # Submit
-    pp, _ = await svc.transition(
+    pp, candidate = await svc.transition(
         pp.id,
         to_state="in_review",
         reason="r",
@@ -31,12 +32,18 @@ async def test_full_clone_cycle_republish(
         actor=curator_user,
     )
     # Approve
-    pp, _ = await svc.transition(
+    pp, approved = await svc.transition(
         pp.id,
         to_state="approved",
         reason="ok",
         expected_revision=pp.revision,
         actor=admin_user,
+        candidate_revision_id=candidate.id,
+        candidate_content_sha256=candidate.content_sha256,
+        attestation=ApprovalAttestation(
+            independent_review=True,
+            no_unmanaged_conflict=True,
+        ),
     )
     # Publish
     pp, rev = await svc.transition(
@@ -45,6 +52,8 @@ async def test_full_clone_cycle_republish(
         reason="shipping",
         expected_revision=pp.revision,
         actor=admin_user,
+        approved_revision_id=approved.id,
+        approved_content_sha256=approved.content_sha256,
     )
 
     # Record-level state converges

--- a/backend/tests/test_state_service_invariant_i8.py
+++ b/backend/tests/test_state_service_invariant_i8.py
@@ -10,6 +10,8 @@ Spec reference:
 
 import pytest
 
+from app.phenopackets.models import ApprovalAttestation, PhenopacketRevision
+
 
 @pytest.mark.parametrize(
     "to_state",
@@ -62,14 +64,38 @@ async def test_pp_state_never_exits_published_or_archived_post_first_publish(
         ],
     }
 
+    candidate: PhenopacketRevision | None = None
+    approved: PhenopacketRevision | None = None
     for state_target, actor in sequence_to_target[to_state]:
-        pp, _ = await svc.transition(
+        exact_fields = {}
+        if state_target == "approved":
+            assert candidate is not None
+            exact_fields = {
+                "candidate_revision_id": candidate.id,
+                "candidate_content_sha256": candidate.content_sha256,
+                "attestation": ApprovalAttestation(
+                    independent_review=True,
+                    no_unmanaged_conflict=True,
+                ),
+            }
+        elif state_target == "published":
+            assert approved is not None
+            exact_fields = {
+                "approved_revision_id": approved.id,
+                "approved_content_sha256": approved.content_sha256,
+            }
+        pp, transition_revision = await svc.transition(
             pp.id,
             to_state=state_target,
             reason="r",
             expected_revision=pp.revision,
             actor=actor,  # type: ignore[arg-type]
+            **exact_fields,
         )
+        if state_target == "in_review":
+            candidate = transition_revision
+        elif state_target == "approved":
+            approved = transition_revision
 
     # I8: pp.state must never advance for a previously-published record
     # (unless the transition is 'archived', which is terminal).

--- a/backend/tests/test_state_transitions.py
+++ b/backend/tests/test_state_transitions.py
@@ -1,7 +1,7 @@
-"""Pure-function guard matrix — no I/O.
+"""Pure structural guard matrix — no I/O.
 
-Wave 7 D.1 Task 6: tests for ``app.phenopackets.services.transitions``.
-Spec reference: .planning/specs/2026-04-12-wave-7-d1-state-machine-design.md §4.1.
+Actor-specific reviewer independence is intentionally tested at the policy and
+state-service layers rather than duplicated here.
 """
 
 import pytest
@@ -26,7 +26,13 @@ VIEWER = "viewer"
         ("in_review", "draft", CURATOR, True, True),  # withdraw
         ("in_review", "changes_requested", ADMIN, False, True),
         ("in_review", "approved", ADMIN, False, True),
+        ("in_review", "changes_requested", CURATOR, False, True),
+        ("in_review", "approved", CURATOR, False, True),
+        ("in_review", "changes_requested", CURATOR, True, True),
+        ("in_review", "approved", CURATOR, True, True),
         ("changes_requested", "in_review", CURATOR, True, True),  # resubmit
+        ("approved", "changes_requested", CURATOR, False, True),
+        ("approved", "changes_requested", ADMIN, False, True),
         ("approved", "published", ADMIN, False, True),
         ("published", "archived", ADMIN, False, True),
         # admin can also archive from other non-archived states
@@ -40,14 +46,6 @@ VIEWER = "viewer"
         ("changes_requested", "in_review", ADMIN, False, True),
         # --- role/ownership rejections ---
         ("draft", "in_review", CURATOR, False, False),  # not owner
-        ("in_review", "approved", CURATOR, True, False),  # curator can't approve
-        (
-            "in_review",
-            "changes_requested",
-            CURATOR,
-            True,
-            False,
-        ),  # curator can't request_changes
         ("approved", "published", CURATOR, False, False),  # curator can't publish
         ("draft", "in_review", VIEWER, True, False),  # viewer blocked everywhere
         ("in_review", "draft", CURATOR, False, False),  # withdraw requires ownership
@@ -89,7 +87,7 @@ def test_transition_error_has_code_attribute():
     assert exc_info.value.code == "invalid_transition"
 
     with pytest.raises(TransitionError) as exc_info:
-        check_transition("in_review", "approved", role=CURATOR, is_owner=True)
+        check_transition("approved", "published", role=CURATOR, is_owner=True)
     assert exc_info.value.code == "forbidden_role"
 
     with pytest.raises(TransitionError) as exc_info:
@@ -107,6 +105,25 @@ def test_allowed_transitions_admin_on_in_review():
     """Admin on in_review: can approve, request_changes, withdraw, or archive."""
     legal = allowed_transitions("in_review", role=ADMIN, is_owner=False)
     assert legal == {"draft", "changes_requested", "approved", "archived"}
+
+
+def test_allowed_review_transitions_for_nonowner_curator():
+    """The pure matrix leaves independence decisions to the locked service."""
+    assert allowed_transitions("in_review", role=CURATOR, is_owner=False) == {
+        "changes_requested",
+        "approved",
+    }
+    assert allowed_transitions("approved", role=CURATOR, is_owner=False) == {
+        "changes_requested"
+    }
+
+
+def test_pure_matrix_does_not_claim_reviewer_independence():
+    """Owner status is deliberately ignored for structurally valid decisions."""
+    rule = check_transition("in_review", "approved", role=CURATOR, is_owner=True)
+
+    assert rule.requires_admin is False
+    assert rule.requires_ownership_or_admin is False
 
 
 def test_allowed_transitions_nonowner_curator_on_draft():

--- a/mcp/contract/openapi.snapshot.json
+++ b/mcp/contract/openapi.snapshot.json
@@ -54,6 +54,27 @@
         "title": "AggregationResult",
         "type": "object"
       },
+      "ApprovalAttestation": {
+        "description": "Affirmative statements required for an independent approval decision.",
+        "properties": {
+          "independent_review": {
+            "const": true,
+            "title": "Independent Review",
+            "type": "boolean"
+          },
+          "no_unmanaged_conflict": {
+            "const": true,
+            "title": "No Unmanaged Conflict",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "independent_review",
+          "no_unmanaged_conflict"
+        ],
+        "title": "ApprovalAttestation",
+        "type": "object"
+      },
       "AssessmentStatus": {
         "description": "Explicit clinical assessment states for a source phenotype question.",
         "enum": [
@@ -4574,6 +4595,64 @@
       "TransitionRequest": {
         "description": "Request body for POST /phenopackets/{id}/transitions.\n\nSee .planning/specs/2026-04-12-wave-7-d1-state-machine-design.md \u00a77.3.",
         "properties": {
+          "approved_content_sha256": {
+            "anyOf": [
+              {
+                "pattern": "^sha256:[0-9a-f]{64}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Content Sha256"
+          },
+          "approved_revision_id": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Revision Id"
+          },
+          "attestation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ApprovalAttestation"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "candidate_content_sha256": {
+            "anyOf": [
+              {
+                "pattern": "^sha256:[0-9a-f]{64}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Candidate Content Sha256"
+          },
+          "candidate_revision_id": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Candidate Revision Id"
+          },
           "reason": {
             "maxLength": 500,
             "minLength": 1,


### PR DESCRIPTION
## Status

Draft and intentionally incomplete. This PR publishes the reviewed backend integrity foundation through implementation Task 5 so work can continue from a visible branch. The review queue/context API and frontend workflow are not complete yet.

## What changed

- Added the reviewed design, implementation plan, and one-pass independent specification review for a four-eyes Phenopacket curation workflow.
- Added nullable review/audit expansion `d0f422b00005` and invariant activation `e0f422b00006`.
- Added full-content canonical SHA-256 evidence and versioned revision-ledger v2 writes without rewriting legacy history.
- Enforced independent curator/admin review: owners, candidate submitters, and active-cycle content contributors cannot decide; admins do not bypass independence.
- Bound approval and publication to exact immutable revision IDs and full-content digests; publication copies approved content without canonicalization or other mutation.
- Added revision-bound blocking review issues, append-only resolution/reopen evidence, phenopacket-first application locking, database actor validation, guarded rollback, and direct-SQL invariant triggers.
- Preserved old immutable public heads throughout re-review and kept unpublished candidates private.

## Why

The existing workflow lacked an open reviewer surface and allowed admin-only review paths that could collapse author and reviewer into one actor. It also did not bind sign-off to a complete immutable content digest. This foundation applies common biomedical curation controls: independent review, explicit issue reconciliation, immutable provenance, exact-snapshot approval, and fail-closed ambiguity handling.

## Validation completed for the published scope

- Task 1 schema expansion: focused migration/ORM/immutability checks, real upgrade/downgrade, Ruff, and mypy.
- Task 2 ledger hashing: canonical literal digest, extension tamper coverage, projection regressions, Ruff, and mypy.
- Task 3 policy: 82 focused plus 23 adjacent tests after review fixes; Ruff and mypy.
- Task 4 exact snapshots: 112 focused/reconciled tests plus broader state/public-head checks; Ruff and mypy.
- Task 5 issue/invariant activation: 110 impacted tests, 56 Task 4 regressions, all four two-connection raw-SQL lock races, real Alembic `e0 -> c0 -> e0` roundtrip, Ruff, formatting, full `mypy app`, and diff hygiene.
- Every completed task received a separate task-scoped spec/code review; accepted findings were fixed with regression tests and scoped re-review.

Repository-baseline warnings remain documented in the planning reports; no new warning class was intentionally introduced.

## Remaining before this can leave draft

- Finish and review Task 6: typed server-driven review queue/context API, coherent semantic comparison, comment review DTOs, and effective-state CRUD projection.
- Task 7: frontend transport, curator-only routes, guards, and navigation.
- Task 8: URL-backed `AppDataTable` review queue with server pagination/filtering/sorting.
- Tasks 9-10: responsive review workspace, semantic diff, blocking issues, exact decision dialogs/actions, accessibility, and mobile behavior.
- Task 11: remove duplicated frontend transition policy and legacy direct-publish bypasses.
- Task 12: seed distinct curator actors, finalize OpenAPI, and prove the two-curator lifecycle with Playwright.
- Task 13: full backend/frontend verification, runtime smoke tests, durable workflow documentation, one-pass adversarial PR review, finding resolution, and required GitHub Actions green.

## Local-only work not in this push

Task 6 was paused mid-TDD at the user's request to publish this draft. Its unstaged/untracked files remain only in the local worktree and are not included in this PR.
